### PR TITLE
Support ApplicationConfiguration controller

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -195,6 +195,19 @@ func (p *Paved) GetNumber(path string) (float64, error) {
 }
 
 func (p *Paved) setValue(s Segments, value interface{}) error {
+	// We expect p.object to look like JSON data that was unmarshalled into an
+	// interface{} per https://golang.org/pkg/encoding/json/#Unmarshal. We
+	// marshal our value to JSON and unmarshal it into an interface{} to ensure
+	// it meets these criteria before setting it within p.object.
+	var v interface{}
+	j, err := json.Marshal(value)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal value to JSON")
+	}
+	if err := json.Unmarshal(j, &v); err != nil {
+		return errors.Wrap(err, "cannot unmarshal value from JSON")
+	}
+
 	var in interface{} = p.object
 	for i, current := range s {
 		final := i == len(s)-1
@@ -207,7 +220,7 @@ func (p *Paved) setValue(s Segments, value interface{}) error {
 			}
 
 			if final {
-				array[current.Index] = value
+				array[current.Index] = v
 				return nil
 			}
 
@@ -221,7 +234,7 @@ func (p *Paved) setValue(s Segments, value interface{}) error {
 			}
 
 			if final {
-				object[current.Field] = value
+				object[current.Field] = v
 				return nil
 			}
 

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -42,6 +42,19 @@ func (p *Paved) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &p.object)
 }
 
+// UnstructuredContent returns the JSON serialisable content of this Paved.
+func (p *Paved) UnstructuredContent() map[string]interface{} {
+	if p.object == nil {
+		return make(map[string]interface{})
+	}
+	return p.object
+}
+
+// SetUnstructuredContent sets the JSON serialisable content of this Paved.
+func (p *Paved) SetUnstructuredContent(content map[string]interface{}) {
+	p.object = content
+}
+
 func (p *Paved) getValue(s Segments) (interface{}, error) {
 	var it interface{} = p.object
 	for i, current := range s {

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -561,6 +563,48 @@ func TestSetValue(t *testing.T) {
 			want: want{
 				object: map[string]interface{}{
 					"data": []interface{}{"a", nil, "c"},
+				},
+			},
+		},
+		"MapStringString": {
+			reason: "A map of string to string should be converted to a map of string to interface{}",
+			data:   []byte(`{"metadata":{}}`),
+			args: args{
+				path:  "metadata.labels",
+				value: map[string]string{"cool": "very"},
+			},
+			want: want{
+				object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{"cool": "very"},
+					},
+				},
+			},
+		},
+		"OwnerReference": {
+			reason: "An ObjectReference (i.e. struct) should be converted to a map of string to interface{}",
+			data:   []byte(`{"metadata":{}}`),
+			args: args{
+				path: "metadata.ownerRefs[0]",
+				value: metav1.OwnerReference{
+					APIVersion: "v",
+					Kind:       "k",
+					Name:       "n",
+					UID:        types.UID("u"),
+				},
+			},
+			want: want{
+				object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"ownerRefs": []interface{}{
+							map[string]interface{}{
+								"apiVersion": "v",
+								"kind":       "k",
+								"name":       "n",
+								"uid":        "u",
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This PR adds two relatively unrelated pieces of functionality:

* Getters and setters for the unstructured content of a `fieldpath.Paved` This helps convert a `*fieldpath.Paved` to and from an `*unstructured.Unstructured`. The API matches that of `*unstructured.Unstructured`
* An `Apply` function that either creates or patches a resource. We've implemented this in at least two controllers, and I've found myself doing it again.

The only theme linking these commits is "stuff I need to implement the OAM ApplicationConfiguration controller". :)

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml