### PR TITLE
Implement GetExternalTags 

### DIFF
--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -810,15 +810,13 @@ func TestWasCreated(t *testing.T) {
 }
 
 func TestGetExternalName(t *testing.T) {
-	testName := "my-external-name"
-
 	cases := map[string]struct {
 		o    metav1.Object
 		want string
 	}{
 		"ExternalNameExists": {
-			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: testName}}},
-			want: testName,
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: name}}},
+			want: name,
 		},
 		"NoExternalName": {
 			o:    &corev1.Pod{},
@@ -830,15 +828,13 @@ func TestGetExternalName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := GetExternalName(tc.o)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("WasCreated(...): -want, +got:\n%s", diff)
+				t.Errorf("GetExternalName(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
 }
 
 func TestSetExternalName(t *testing.T) {
-	testName := "my-external-name"
-
 	cases := map[string]struct {
 		o    metav1.Object
 		name string
@@ -846,8 +842,8 @@ func TestSetExternalName(t *testing.T) {
 	}{
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
-			name: testName,
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: testName}}},
+			name: name,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: name}}},
 		},
 	}
 
@@ -855,7 +851,7 @@ func TestSetExternalName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			SetExternalName(tc.o, tc.name)
 			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
-				t.Errorf("WasCreated(...): -want, +got:\n%s", diff)
+				t.Errorf("SetExternalName(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -95,6 +95,15 @@ func (m *ManagedResourceReferencer) SetResourceReference(r *corev1.ObjectReferen
 // GetResourceReference gets the ResourceReference.
 func (m *ManagedResourceReferencer) GetResourceReference() *corev1.ObjectReference { return m.Ref }
 
+// ProviderReferencer is a mock that implements ProviderReferencer interface.
+type ProviderReferencer struct{ Ref *corev1.ObjectReference }
+
+// SetProviderReference sets the ProviderReference.
+func (m *ProviderReferencer) SetProviderReference(p *corev1.ObjectReference) { m.Ref = p }
+
+// GetProviderReference gets the ProviderReference.
+func (m *ProviderReferencer) GetProviderReference() *corev1.ObjectReference { return m.Ref }
+
 // LocalConnectionSecretWriterTo is a mock that implements LocalConnectionSecretWriterTo interface.
 type LocalConnectionSecretWriterTo struct {
 	Ref *v1alpha1.LocalSecretReference
@@ -200,6 +209,7 @@ type Managed struct {
 	metav1.ObjectMeta
 	ClassReferencer
 	ClaimReferencer
+	ProviderReferencer
 	ConnectionSecretWriterTo
 	Reclaimer
 	v1alpha1.ConditionedStatus

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -89,6 +89,12 @@ type CredentialsSecretReferencer interface {
 	SetCredentialsSecretReference(r v1alpha1.SecretKeySelector)
 }
 
+// A ProviderReferencer may reference a provider resource.
+type ProviderReferencer interface {
+	GetProviderReference() *corev1.ObjectReference
+	SetProviderReference(p *corev1.ObjectReference)
+}
+
 // A Claim is a Kubernetes object representing an abstract resource claim (e.g.
 // an SQL database) that may be bound to a concrete managed resource (e.g. a
 // CloudSQL instance).
@@ -122,6 +128,7 @@ type Managed interface {
 
 	ClassReferencer
 	ClaimReferencer
+	ProviderReferencer
 	ConnectionSecretWriterTo
 	Reclaimer
 


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Implement GetExternalTags to return Crossplane tags for managed resource controllers to tag their external resources.

Makes it easier to implement https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#external-resource-labeling

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml