### PR TITLE
Fix controller mismatch detection in resource.Apply

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -274,7 +274,7 @@ func Apply(ctx context.Context, c client.Client, o runtime.Object, ao ...ApplyOp
 		return errors.Wrap(err, "cannot get object")
 	}
 
-	if opts.ControllersMustMatch && !meta.HaveSameController(o.(metav1.Object), m) {
+	if opts.ControllersMustMatch && !meta.HaveSameController(m, desired.(metav1.Object)) {
 		return errors.New("existing object has a different (or no) controller")
 	}
 

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -468,7 +468,8 @@ func TestApply(t *testing.T) {
 	named.SetName("barry")
 
 	controlled := &object{}
-	meta.AddControllerReference(controlled, metav1.OwnerReference{UID: types.UID("wat")})
+	ref := metav1.NewControllerRef(named, schema.GroupVersionKind{})
+	meta.AddControllerReference(controlled, *ref)
 
 	type args struct {
 		ctx context.Context


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
I noticed this was broken immediately after merging https://github.com/crossplane/crossplane-runtime/pull/122. 😬It was not caught by the unit test because the test was also broken in that both the object being applied and the object returned from `Get` had a nil controller reference and would thus always be considered to have a controller mismatch.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml