### PR TITLE
Make WorkloadReferencer use non-pointer types

### DIFF
--- a/pkg/reconciler/oam/trait/reconciler_test.go
+++ b/pkg/reconciler/oam/trait/reconciler_test.go
@@ -92,7 +92,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,
@@ -125,7 +125,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,
@@ -162,7 +162,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,
@@ -205,7 +205,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,
@@ -248,7 +248,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,
@@ -291,7 +291,7 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 							if t, ok := obj.(resource.Trait); ok {
-								t.SetWorkloadReference(&v1alpha1.TypedReference{
+								t.SetWorkloadReference(v1alpha1.TypedReference{
 									APIVersion: workloadAPIVersion,
 									Kind:       workloadKind,
 									Name:       workloadName,

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -156,15 +156,15 @@ func (m *CredentialsSecretReferencer) GetCredentialsSecretReference() v1alpha1.S
 }
 
 // A WorkloadReferencer references an OAM Workload type.
-type WorkloadReferencer struct{ Ref *v1alpha1.TypedReference }
+type WorkloadReferencer struct{ Ref v1alpha1.TypedReference }
 
 // GetWorkloadReference gets the WorkloadReference.
-func (w *WorkloadReferencer) GetWorkloadReference() *v1alpha1.TypedReference {
+func (w *WorkloadReferencer) GetWorkloadReference() v1alpha1.TypedReference {
 	return w.Ref
 }
 
 // SetWorkloadReference sets the WorkloadReference.
-func (w *WorkloadReferencer) SetWorkloadReference(r *v1alpha1.TypedReference) {
+func (w *WorkloadReferencer) SetWorkloadReference(r v1alpha1.TypedReference) {
 	w.Ref = r
 }
 

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -97,8 +97,8 @@ type ProviderReferencer interface {
 
 // A WorkloadReferencer may reference an OAM workload.
 type WorkloadReferencer interface {
-	GetWorkloadReference() *v1alpha1.TypedReference
-	SetWorkloadReference(*v1alpha1.TypedReference)
+	GetWorkloadReference() v1alpha1.TypedReference
+	SetWorkloadReference(v1alpha1.TypedReference)
 }
 
 // An Object is a Kubernetes object.


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

The `WorkloadReferencer` interface introduced in #130 was incorrectly implemented using a pointer type. `Trait`, the only interface that currently embeds `WorkloadReferencer`, does not use a pointer type when implemented.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml