### PR TITLE
Introduce a distinct secret type for connection secrets

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -88,9 +88,9 @@ type APISecretPublisher struct {
 
 // NewAPISecretPublisher returns a new APISecretPublisher.
 func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPublisher {
-	// NOTE(negz): We transparently inject an APIApplicator in order to maintain
+	// NOTE(negz): We transparently inject an APIPatchingApplicator in order to maintain
 	// backward compatibility with the original API of this function.
-	return &APISecretPublisher{secret: resource.NewAPIApplicator(c), typer: ot}
+	return &APISecretPublisher{secret: resource.NewAPIPatchingApplicator(c), typer: ot}
 }
 
 // PublishConnection publishes the supplied ConnectionDetails to a Secret in the

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -20,10 +20,8 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -31,7 +29,6 @@ import (
 
 // Error strings.
 const (
-	errSecretConflict       = "cannot establish control of existing connection secret"
 	errCreateOrUpdateSecret = "cannot create or update connection secret"
 	errUpdateManaged        = "cannot update managed resource"
 	errUpdateManagedStatus  = "cannot update managed resource status"
@@ -85,13 +82,15 @@ func (a *NameAsExternalName) Initialize(ctx context.Context, mg resource.Managed
 // An APISecretPublisher publishes ConnectionDetails by submitting a Secret to a
 // Kubernetes API server.
 type APISecretPublisher struct {
-	client client.Client
+	secret resource.Applicator
 	typer  runtime.ObjectTyper
 }
 
 // NewAPISecretPublisher returns a new APISecretPublisher.
 func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPublisher {
-	return &APISecretPublisher{client: c, typer: ot}
+	// NOTE(negz): We transparently inject an APIApplicator in order to maintain
+	// backward compatibility with the original API of this function.
+	return &APISecretPublisher{secret: resource.NewAPIApplicator(c), typer: ot}
 }
 
 // PublishConnection publishes the supplied ConnectionDetails to a Secret in the
@@ -104,30 +103,8 @@ func (a *APISecretPublisher) PublishConnection(ctx context.Context, mg resource.
 	}
 
 	s := resource.ConnectionSecretFor(mg, resource.MustGetKind(mg, a.typer))
-
-	_, err := util.CreateOrUpdate(ctx, a.client, s, func() error {
-		// Inside this anonymous function s could either be unchanged (if it
-		// does not exist in the API server) or updated to reflect its current
-		// state according to the API server.
-		if c := metav1.GetControllerOf(s); c == nil || c.UID != mg.GetUID() {
-			return errors.New(errSecretConflict)
-		}
-
-		// NOTE(negz): We want to support additive publishing, i.e. support
-		// setting one subset of secret values then later setting another subset
-		// without effecting the original subset.
-		if s.Data == nil {
-			s.Data = make(map[string][]byte, len(c))
-		}
-
-		for k, v := range c {
-			s.Data[k] = v
-		}
-
-		return nil
-	})
-
-	return errors.Wrap(err, errCreateOrUpdateSecret)
+	s.Data = c
+	return errors.Wrap(a.secret.Apply(ctx, s, resource.ConnectionSecretMustBeControllableBy(mg.GetUID())), errCreateOrUpdateSecret)
 }
 
 // UnpublishConnection is no-op since PublishConnection only creates resources

--- a/pkg/reconciler/oam/trait/reconciler.go
+++ b/pkg/reconciler/oam/trait/reconciler.go
@@ -120,7 +120,7 @@ func NewReconciler(m ctrl.Manager, trait resource.TraitKind, trans resource.Obje
 		newTrait:       nt,
 		newTranslation: nr,
 		trait:          ModifyFn(NoopModifier),
-		applicator:     resource.NewAPIApplicator(m.GetClient()),
+		applicator:     resource.NewAPIPatchingApplicator(m.GetClient()),
 
 		log:    logging.NewNopLogger(),
 		record: event.NewNopRecorder(),

--- a/pkg/reconciler/oam/trait/reconciler.go
+++ b/pkg/reconciler/oam/trait/reconciler.go
@@ -120,7 +120,7 @@ func NewReconciler(m ctrl.Manager, trait resource.TraitKind, trans resource.Obje
 		newTrait:       nt,
 		newTranslation: nr,
 		trait:          ModifyFn(NoopModifier),
-		applicator:     resource.ApplyFn(resource.Apply),
+		applicator:     resource.NewAPIApplicator(m.GetClient()),
 
 		log:    logging.NewNopLogger(),
 		record: event.NewNopRecorder(),
@@ -181,7 +181,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	// object(s) that is controlled by the workload. In the case where an
 	// object(s) already exists in the same namespace and with the same name
 	// before it is created, this wll guard against modifying it.
-	if err := r.applicator.Apply(ctx, r.client, translation, resource.ControllersMustMatch()); err != nil {
+	if err := r.applicator.Apply(ctx, translation, resource.ControllersMustMatch()); err != nil {
 		log.Debug("Cannot apply workload translation", "error", err, "requeue-after", time.Now().Add(shortWait))
 		r.record.Event(trait, event.Warning(reasonCannotApplyModification, err))
 		trait.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errApplyTraitModification)))

--- a/pkg/reconciler/oam/trait/reconciler.go
+++ b/pkg/reconciler/oam/trait/reconciler.go
@@ -181,7 +181,9 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	// object(s) that is controlled by the workload. In the case where an
 	// object(s) already exists in the same namespace and with the same name
 	// before it is created, this wll guard against modifying it.
-	if err := r.applicator.Apply(ctx, translation, resource.ControllersMustMatch()); err != nil {
+
+	// TODO(negz): Migrate to resource.ControlledBy
+	if err := r.applicator.Apply(ctx, translation, resource.ControllersMustMatch()); err != nil { // nolint:staticcheck
 		log.Debug("Cannot apply workload translation", "error", err, "requeue-after", time.Now().Add(shortWait))
 		r.record.Event(trait, event.Warning(reasonCannotApplyModification, err))
 		trait.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errApplyTraitModification)))

--- a/pkg/reconciler/oam/trait/reconciler_test.go
+++ b/pkg/reconciler/oam/trait/reconciler_test.go
@@ -235,7 +235,7 @@ func TestReconciler(t *testing.T) {
 				},
 				t: resource.TraitKind(fake.GVK(&fake.Trait{})),
 				p: resource.ObjectKind(fake.GVK(&fake.Object{})),
-				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 					return errBoom
 				}))},
 			},
@@ -278,7 +278,7 @@ func TestReconciler(t *testing.T) {
 				},
 				t: resource.TraitKind(fake.GVK(&fake.Trait{})),
 				p: resource.ObjectKind(fake.GVK(&fake.Object{})),
-				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 					return nil
 				}))},
 			},
@@ -309,7 +309,7 @@ func TestReconciler(t *testing.T) {
 				},
 				t: resource.TraitKind(fake.GVK(&fake.Trait{})),
 				p: resource.ObjectKind(fake.GVK(&fake.Object{})),
-				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 					return nil
 				}))},
 			},

--- a/pkg/reconciler/oam/workload/reconciler.go
+++ b/pkg/reconciler/oam/workload/reconciler.go
@@ -120,7 +120,7 @@ func NewReconciler(m ctrl.Manager, workload resource.WorkloadKind, o ...Reconcil
 		client:      m.GetClient(),
 		newWorkload: nw,
 		workload:    TranslateFn(NoopTranslate),
-		applicator:  resource.NewAPIApplicator(m.GetClient()),
+		applicator:  resource.NewAPIPatchingApplicator(m.GetClient()),
 		// TODO(negz): Migrate to resource.ControlledBy
 		applyOpts: []resource.ApplyOption{resource.ControllersMustMatch()}, // nolint:staticcheck
 		log:       logging.NewNopLogger(),

--- a/pkg/reconciler/oam/workload/reconciler.go
+++ b/pkg/reconciler/oam/workload/reconciler.go
@@ -121,9 +121,10 @@ func NewReconciler(m ctrl.Manager, workload resource.WorkloadKind, o ...Reconcil
 		newWorkload: nw,
 		workload:    TranslateFn(NoopTranslate),
 		applicator:  resource.NewAPIApplicator(m.GetClient()),
-		applyOpts:   []resource.ApplyOption{resource.ControllersMustMatch()},
-		log:         logging.NewNopLogger(),
-		record:      event.NewNopRecorder(),
+		// TODO(negz): Migrate to resource.ControlledBy
+		applyOpts: []resource.ApplyOption{resource.ControllersMustMatch()}, // nolint:staticcheck
+		log:       logging.NewNopLogger(),
+		record:    event.NewNopRecorder(),
 	}
 
 	for _, ro := range o {

--- a/pkg/reconciler/oam/workload/reconciler.go
+++ b/pkg/reconciler/oam/workload/reconciler.go
@@ -120,7 +120,7 @@ func NewReconciler(m ctrl.Manager, workload resource.WorkloadKind, o ...Reconcil
 		client:      m.GetClient(),
 		newWorkload: nw,
 		workload:    TranslateFn(NoopTranslate),
-		applicator:  resource.ApplyFn(resource.Apply),
+		applicator:  resource.NewAPIApplicator(m.GetClient()),
 		applyOpts:   []resource.ApplyOption{resource.ControllersMustMatch()},
 		log:         logging.NewNopLogger(),
 		record:      event.NewNopRecorder(),
@@ -179,7 +179,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		// so this label is not being used.
 		meta.AddLabels(o, map[string]string{lowerGroupKind(workload.GetObjectKind()): string(workload.GetUID())})
 
-		if err := r.applicator.Apply(ctx, r.client, o, r.applyOpts...); err != nil {
+		if err := r.applicator.Apply(ctx, o, r.applyOpts...); err != nil {
 			log.Debug("Cannot apply workload translation", "error", err, "requeue-after", time.Now().Add(shortWait))
 			r.record.Event(workload, event.Warning(reasonCannotApplyWorkloadTranslation, err))
 			workload.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errApplyWorkloadTranslation)))

--- a/pkg/reconciler/oam/workload/reconciler_test.go
+++ b/pkg/reconciler/oam/workload/reconciler_test.go
@@ -171,7 +171,7 @@ func TestReconciler(t *testing.T) {
 							&appsv1.Deployment{},
 						}, nil
 					})),
-					WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+					WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 						return errBoom
 					}))},
 			},
@@ -188,7 +188,7 @@ func TestReconciler(t *testing.T) {
 					Scheme: fake.SchemeWith(&fake.Workload{}),
 				},
 				w: resource.WorkloadKind(fake.GVK(&fake.Workload{})),
-				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 					return nil
 				}))},
 			},
@@ -205,7 +205,7 @@ func TestReconciler(t *testing.T) {
 					Scheme: fake.SchemeWith(&fake.Workload{}),
 				},
 				w: resource.WorkloadKind(fake.GVK(&fake.Workload{})),
-				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ client.Client, _ runtime.Object, _ ...resource.ApplyOption) error {
+				o: []ReconcilerOption{WithApplicator(resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error {
 					return nil
 				}))},
 			},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -239,7 +239,7 @@ func TestPropagateConnection(t *testing.T) {
 	}
 }
 
-func TestApply(t *testing.T) {
+func TestAPIPatchingApplicator(t *testing.T) {
 	errBoom := errors.New("boom")
 	named := &object{}
 	named.SetName("barry")
@@ -359,7 +359,139 @@ func TestApply(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			a := NewAPIApplicator(tc.c)
+			a := NewAPIPatchingApplicator(tc.c)
+			err := a.Apply(tc.args.ctx, tc.args.o, tc.args.ao...)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nApply(...): -want error, +got error\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, tc.args.o); diff != "" {
+				t.Errorf("\n%s\nApply(...): -want, +got\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPIUpdatingApplicator(t *testing.T) {
+	errBoom := errors.New("boom")
+	named := &object{}
+	named.SetName("barry")
+
+	type args struct {
+		ctx context.Context
+		o   runtime.Object
+		ao  []ApplyOption
+	}
+
+	type want struct {
+		o   runtime.Object
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		c      client.Client
+		args   args
+		want   want
+	}{
+		"NotAMetadataObject": {
+			reason: "An error should be returned if we can't access the object's metadata",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			args: args{
+				o: &nopeject{},
+			},
+			want: want{
+				o:   &nopeject{},
+				err: errors.New("cannot access object metadata"),
+			},
+		},
+		"GetError": {
+			reason: "An error should be returned if we can't get the object",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot get object"),
+			},
+		},
+		"CreateError": {
+			reason: "No error should be returned if we successfully create a new object",
+			c: &test.MockClient{
+				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(errBoom),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot create object"),
+			},
+		},
+		"ApplyOptionError": {
+			reason: "Any errors from an apply option should be returned",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			args: args{
+				o:  &object{},
+				ao: []ApplyOption{func(_ context.Context, _, _ runtime.Object) error { return errBoom }},
+			},
+			want: want{
+				o:   &object{},
+				err: errBoom,
+			},
+		},
+		"UpdateError": {
+			reason: "An error should be returned if we can't update the object",
+			c: &test.MockClient{
+				MockGet:    test.NewMockGetFn(nil),
+				MockUpdate: test.NewMockUpdateFn(errBoom),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot update object"),
+			},
+		},
+		"Created": {
+			reason: "No error should be returned if we successfully create a new object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(nil, func(o runtime.Object) error {
+					*o.(*object) = *named
+					return nil
+				}),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o: named,
+			},
+		},
+		"Updated": {
+			reason: "No error should be returned if we successfully update an existing object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+				MockUpdate: test.NewMockUpdateFn(nil, func(o runtime.Object) error {
+					*o.(*object) = *named
+					return nil
+				}),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o: named,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := NewAPIUpdatingApplicator(tc.c)
 			err := a.Apply(tc.args.ctx, tc.args.o, tc.args.ao...)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nApply(...): -want error, +got error\n%s\n", tc.reason, diff)

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -42,370 +41,199 @@ var (
 )
 
 func TestPropagateConnection(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	mgcsns := "coolnamespace"
+	mgcsname := "coolmanagedsecret"
+	mgcsuid := types.UID("managed-uid")
+	mgcsdata := map[string][]byte{"cool": {1}}
+
+	cmcsns := "coolnamespace"
+	cmcsname := "coolclaimsecret"
+	cmcsuid := types.UID("claim-uid")
+
+	mg := &fake.Managed{
+		ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
+			Ref: &v1alpha1.SecretReference{Namespace: mgcsns, Name: mgcsname},
+		},
+	}
+
+	cm := &fake.Claim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: cmcsns},
+		LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
+			Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
+		},
+	}
+
 	type fields struct {
-		client client.Client
+		client ClientApplicator
 		typer  runtime.ObjectTyper
 	}
 
 	type args struct {
 		ctx context.Context
-		cm  Claim
+		o   LocalConnectionSecretOwner
 		mg  Managed
 	}
 
-	namespace := "coolns"
-	cmname := "coolclaim"
-	mgname := "coolmanaged"
-	uid := types.UID("definitely-a-uuid")
-	cmcsname := "coolclaimsecret"
-	mgcsname := "coolmanagedsecret"
-	mgcsnamespace := "coolns"
-	mgcsdata := map[string][]byte{"cool": []byte("data")}
-	controller := true
-	errBoom := errors.New("boom")
-
 	cases := map[string]struct {
+		reason string
 		fields fields
 		args   args
 		want   error
 	}{
 		"ClaimDoesNotWantConnectionSecret": {
+			reason: "The managed resource's secret should not be propagated if the claim does not want to write one",
 			args: args{
-				ctx: context.Background(),
-				cm:  &fake.Claim{},
-				mg: &fake.Managed{
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  &fake.Claim{},
+				mg: mg,
 			},
 			want: nil,
 		},
 		"ManagedDoesNotExposeConnectionSecret": {
+			reason: "The managed resource's secret should not be propagated if it does not have one",
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: mgcsname},
-					},
-				},
+				o:  cm,
 				mg: &fake.Managed{},
 			},
 			want: nil,
 		},
 		"GetManagedSecretError": {
+			reason: "Errors getting the managed resource's connection secret should be returned",
 			fields: fields{
-				client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+				client: ClientApplicator{
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+				},
 			},
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  cm,
+				mg: mg,
 			},
 			want: errors.Wrap(errBoom, errGetSecret),
 		},
-		"ClaimSecretConflictError": {
+		"ManagedResourceDoesNotControlSecret": {
+			reason: "The managed resource must control its connection secret before it can be propagated",
 			fields: fields{
-				client: &test.MockClient{
-					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
-						switch n.Name {
-						case cmcsname:
-							s := &corev1.Secret{}
-							s.SetOwnerReferences([]metav1.OwnerReference{{
-								UID:        types.UID("some-other-uuid"),
-								Controller: &controller,
-							}})
-							*o.(*corev1.Secret) = *s
-						case mgcsname:
-							s := &corev1.Secret{}
-							s.SetOwnerReferences([]metav1.OwnerReference{{
-								UID:        uid,
-								Controller: &controller,
-							}})
-							*o.(*corev1.Secret) = *s
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
-					},
-					MockUpdate: test.NewMockUpdateFn(nil),
+				client: ClientApplicator{
+					// Simulate getting a secret that is not controlled by the
+					// managed resource by not modifying the secret passed to
+					// the client, and not returning an error. We thus proceed
+					// with our original empty secret, which has no controller
+					// reference.
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(nil)},
 				},
-				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
 			},
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					ObjectMeta: metav1.ObjectMeta{Name: cmname},
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  cm,
+				mg: mg,
 			},
-			want: errors.Wrap(errors.New(errSecretConflict), errCreateOrUpdateSecret),
+			want: errors.New(errSecretConflict),
 		},
-		"ClaimSecretUncontrolledError": {
+		"ApplyClaimSecretError": {
+			reason: "Errors applying the claim connection secret should be returned",
 			fields: fields{
-				client: &test.MockClient{
-					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
-						switch n.Name {
-						case mgcsname:
-							s := &corev1.Secret{}
-							s.SetOwnerReferences([]metav1.OwnerReference{{
-								UID:        uid,
-								Controller: &controller,
-							}})
-							*o.(*corev1.Secret) = *s
-						case cmcsname:
-							// A secret without any owner references.
-							*o.(*corev1.Secret) = corev1.Secret{}
-						default:
-							return errors.New("unexpected secret name")
-						}
+				client: ClientApplicator{
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+						s := ConnectionSecretFor(mg, fake.GVK(mg))
+						*o.(*corev1.Secret) = *s
 						return nil
-					},
-					MockUpdate: test.NewMockUpdateFn(nil),
+					})},
+					Applicator: ApplyFn(func(_ context.Context, _ runtime.Object, _ ...ApplyOption) error { return errBoom }),
 				},
-				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
+				typer: fake.SchemeWith(mg, cm),
 			},
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					ObjectMeta: metav1.ObjectMeta{Name: cmname},
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  cm,
+				mg: mg,
 			},
-			want: errors.Wrap(errors.New(errSecretConflict), errCreateOrUpdateSecret),
+			want: errors.Wrap(errBoom, errCreateOrUpdateSecret),
 		},
-		"ManagedSecretUpdateError": {
+		"UpdateManagedSecretError": {
+			reason: "Errors updating the managed resource connection secret should be returned",
 			fields: fields{
-				client: &test.MockClient{
-					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
-
-						switch n.Name {
-						case mgcsname:
-							s := corev1.Secret{}
-							s.SetNamespace(namespace)
-							s.SetUID(uid)
-							s.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
-							s.SetName(mgcsname)
-							s.Data = mgcsdata
-							*o.(*corev1.Secret) = s
-						case cmcsname:
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
+				client: ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							s := ConnectionSecretFor(mg, fake.GVK(mg))
+							*o.(*corev1.Secret) = *s
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(errBoom),
 					},
-					MockUpdate: test.NewMockUpdateFn(nil, func(got runtime.Object) error {
-						switch got.(metav1.Object).GetName() {
-						case cmcsname:
-						case mgcsname:
-							return errBoom
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
-					}),
+					Applicator: ApplyFn(func(_ context.Context, _ runtime.Object, _ ...ApplyOption) error { return nil }),
 				},
-				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
+				typer: fake.SchemeWith(mg, cm),
 			},
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					ObjectMeta: metav1.ObjectMeta{Name: cmname},
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  cm,
+				mg: mg,
 			},
 			want: errors.Wrap(errBoom, errUpdateSecret),
 		},
 		"Successful": {
+			reason: "Successful propagation should update the claim and managed resource secrets with the appropriate values",
 			fields: fields{
-				client: &test.MockClient{
-					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
-						s := corev1.Secret{}
-						s.SetNamespace(namespace)
-						s.SetUID(uid)
-						s.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
-
-						switch n.Name {
-						case mgcsname:
-							s.SetName(mgcsname)
+				client: ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							// The managed secret has some data when we get it.
+							s := ConnectionSecretFor(mg, fake.GVK(mg))
+							s.SetUID(mgcsuid)
 							s.Data = mgcsdata
-							*o.(*corev1.Secret) = s
-						case cmcsname:
-							s.SetName(cmcsname)
-							*o.(*corev1.Secret) = s
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
-					},
-					MockUpdate: test.NewMockUpdateFn(nil, func(got runtime.Object) error {
-						want := &corev1.Secret{}
-						want.SetNamespace(namespace)
-						want.SetUID(uid)
-						want.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
-						want.Data = mgcsdata
 
-						switch got.(metav1.Object).GetName() {
-						case cmcsname:
-							want.SetName(cmcsname)
-							want.SetAnnotations(map[string]string{
-								AnnotationKeyPropagateFromNamespace: namespace,
-								AnnotationKeyPropagateFromName:      mgcsname,
-								AnnotationKeyPropagateFromUID:       string(uid),
-							})
-							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("-want, +got:\n%s", diff)
+							*o.(*corev1.Secret) = *s
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil, func(o runtime.Object) error {
+							// Ensure the managed secret is annotated to allow
+							// constant propagation to the claim secret.
+							want := ConnectionSecretFor(mg, fake.GVK(mg))
+							want.SetUID(mgcsuid)
+							k := strings.Join([]string{AnnotationKeyPropagateToPrefix, string(cmcsuid)}, AnnotationDelimiter)
+							v := strings.Join([]string{cmcsns, cmcsname}, AnnotationDelimiter)
+							want.SetAnnotations(map[string]string{k: v})
+							want.Data = mgcsdata
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got: %s", diff)
 							}
-						case mgcsname:
-							want.SetName(mgcsname)
-							want.SetAnnotations(map[string]string{
-								strings.Join([]string{AnnotationKeyPropagateToPrefix, string(uid)}, AnnotationDelimiter): strings.Join([]string{namespace, cmcsname}, AnnotationDelimiter),
-							})
-							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("-want, +got:\n%s", diff)
-							}
-						default:
-							return errors.New("unexpected secret name")
+							return nil
+						}),
+					},
+					Applicator: ApplyFn(func(_ context.Context, o runtime.Object, _ ...ApplyOption) error {
+						// Ensure the managed secret's data is copied to the
+						// claim secret, and that the claim secret is annotated
+						// to allow constant propagation from the managed
+						// secret.
+						want := LocalConnectionSecretFor(cm, fake.GVK(cm))
+						want.SetAnnotations(map[string]string{
+							AnnotationKeyPropagateFromNamespace: mgcsns,
+							AnnotationKeyPropagateFromName:      mgcsname,
+							AnnotationKeyPropagateFromUID:       string(mgcsuid),
+						})
+						want.Data = mgcsdata
+						if diff := cmp.Diff(want, o); diff != "" {
+							t.Errorf("-want, +got: %s", diff)
 						}
+
+						o.(*corev1.Secret).SetUID(cmcsuid)
 						return nil
 					}),
 				},
-				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
+				typer: fake.SchemeWith(mg, cm),
 			},
 			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: cmname, UID: uid},
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
+				o:  cm,
+				mg: mg,
 			},
-			want: nil,
-		},
-		"SuccessfulWithExisting": {
-			fields: fields{
-				client: &test.MockClient{
-					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
-						s := corev1.Secret{}
-						s.SetNamespace(namespace)
-						s.SetUID(uid)
-						s.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
-
-						switch n.Name {
-						case mgcsname:
-							s.SetName(mgcsname)
-							meta.AddAnnotations(&s, map[string]string{
-								strings.Join([]string{AnnotationKeyPropagateToPrefix, "existing-uid"}, AnnotationDelimiter): "existing-namespace/existing-name",
-							})
-							s.Data = mgcsdata
-							*o.(*corev1.Secret) = s
-						case cmcsname:
-							s.SetName(cmcsname)
-							*o.(*corev1.Secret) = s
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
-					},
-					MockUpdate: test.NewMockUpdateFn(nil, func(got runtime.Object) error {
-						want := &corev1.Secret{}
-						want.SetNamespace(namespace)
-						want.SetUID(uid)
-						want.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
-						want.Data = mgcsdata
-
-						switch got.(metav1.Object).GetName() {
-						case cmcsname:
-							want.SetName(cmcsname)
-							want.SetAnnotations(map[string]string{
-								AnnotationKeyPropagateFromNamespace: namespace,
-								AnnotationKeyPropagateFromName:      mgcsname,
-								AnnotationKeyPropagateFromUID:       string(uid),
-							})
-							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("-want, +got:\n%s", diff)
-							}
-						case mgcsname:
-							want.SetName(mgcsname)
-							want.SetAnnotations(map[string]string{
-								strings.Join([]string{AnnotationKeyPropagateToPrefix, "existing-uid"}, AnnotationDelimiter): "existing-namespace/existing-name",
-								strings.Join([]string{AnnotationKeyPropagateToPrefix, string(uid)}, AnnotationDelimiter):    strings.Join([]string{namespace, cmcsname}, AnnotationDelimiter),
-							})
-							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("-want, +got:\n%s", diff)
-							}
-						default:
-							return errors.New("unexpected secret name")
-						}
-						return nil
-					}),
-				},
-				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
-			},
-			args: args{
-				ctx: context.Background(),
-				cm: &fake.Claim{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: cmname, UID: uid},
-					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
-						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
-					},
-				},
-				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
-					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
-						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
-					},
-				},
-			},
-			want: nil,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			api := NewAPIManagedConnectionPropagator(tc.fields.client, tc.fields.typer)
-			err := api.PropagateConnection(tc.args.ctx, tc.args.cm, tc.args.mg)
+			api := &APIManagedConnectionPropagator{client: tc.fields.client, typer: tc.fields.typer}
+			err := api.PropagateConnection(tc.args.ctx, tc.args.o, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
-				t.Errorf("api.PropagateConnection(...): -want error, +got error:\n%s", diff)
+				t.Errorf("\n%s\napi.PropagateConnection(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
 	}
@@ -500,7 +328,7 @@ func TestApply(t *testing.T) {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				MockCreate: test.NewMockCreateFn(nil, func(o runtime.Object) error {
-					*(o.(*object)) = *named
+					*o.(*object) = *named
 					return nil
 				}),
 			},
@@ -516,7 +344,7 @@ func TestApply(t *testing.T) {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil),
 				MockPatch: test.NewMockPatchFn(nil, func(o runtime.Object) error {
-					*(o.(*object)) = *named
+					*o.(*object) = *named
 					return nil
 				}),
 			},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -24,8 +24,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -404,6 +406,138 @@ func TestPropagateConnection(t *testing.T) {
 			err := api.PropagateConnection(tc.args.ctx, tc.args.cm, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("api.PropagateConnection(...): -want error, +got error:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	errBoom := errors.New("boom")
+	named := &object{}
+	named.SetName("barry")
+
+	type args struct {
+		ctx context.Context
+		o   runtime.Object
+		ao  []ApplyOption
+	}
+
+	type want struct {
+		o   runtime.Object
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		c      client.Client
+		args   args
+		want   want
+	}{
+		"NotAMetadataObject": {
+			reason: "An error should be returned if we can't access the object's metadata",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			args: args{
+				o: &nopeject{},
+			},
+			want: want{
+				o:   &nopeject{},
+				err: errors.New("cannot access object metadata"),
+			},
+		},
+		"GetError": {
+			reason: "An error should be returned if we can't get the object",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot get object"),
+			},
+		},
+		"CreateError": {
+			reason: "No error should be returned if we successfully create a new object",
+			c: &test.MockClient{
+				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(errBoom),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot create object"),
+			},
+		},
+		"ApplyOptionError": {
+			reason: "Any errors from an apply option should be returned",
+			c:      &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			args: args{
+				o:  &object{},
+				ao: []ApplyOption{func(_ context.Context, _, _ runtime.Object) error { return errBoom }},
+			},
+			want: want{
+				o:   &object{},
+				err: errBoom,
+			},
+		},
+		"PatchError": {
+			reason: "An error should be returned if we can't patch the object",
+			c: &test.MockClient{
+				MockGet:   test.NewMockGetFn(nil),
+				MockPatch: test.NewMockPatchFn(errBoom),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o:   &object{},
+				err: errors.Wrap(errBoom, "cannot patch object"),
+			},
+		},
+		"Created": {
+			reason: "No error should be returned if we successfully create a new object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(nil, func(o runtime.Object) error {
+					*(o.(*object)) = *named
+					return nil
+				}),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o: named,
+			},
+		},
+		"Patched": {
+			reason: "No error should be returned if we successfully patch an existing object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+				MockPatch: test.NewMockPatchFn(nil, func(o runtime.Object) error {
+					*(o.(*object)) = *named
+					return nil
+				}),
+			},
+			args: args{
+				o: &object{},
+			},
+			want: want{
+				o: named,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := NewAPIApplicator(tc.c)
+			err := a.Apply(tc.args.ctx, tc.args.o, tc.args.ao...)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nApply(...): -want error, +got error\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, tc.args.o); diff != "" {
+				t.Errorf("\n%s\nApply(...): -want, +got\n%s\n", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -341,9 +341,9 @@ func ControllersMustMatch() ApplyOption {
 // Apply changes to the supplied object. The object will be created if it does
 // not exist, or patched if it does.
 //
-// Deprecated: use APIApplicator instead.
+// Deprecated: use APIPatchingApplicator instead.
 func Apply(ctx context.Context, c client.Client, o runtime.Object, ao ...ApplyOption) error {
-	return NewAPIApplicator(c).Apply(ctx, o, ao...)
+	return NewAPIPatchingApplicator(c).Apply(ctx, o, ao...)
 }
 
 // GetExternalTags returns the identifying tags to be used to tag the external

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -24,15 +24,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -463,141 +460,57 @@ func (o *nopeject) DeepCopyObject() runtime.Object {
 	return &nopeject{}
 }
 
-var _ Applicator = ApplyFn(Apply)
-
-func TestApply(t *testing.T) {
-	errBoom := errors.New("boom")
-	named := &object{}
-	named.SetName("barry")
-
-	controlled := &object{}
-	ref := metav1.NewControllerRef(named, schema.GroupVersionKind{})
-	meta.AddControllerReference(controlled, *ref)
+func TestControllersMustMatch(t *testing.T) {
+	uid := types.UID("very-unique-string")
+	controller := true
 
 	type args struct {
-		ctx context.Context
-		c   client.Client
-		o   runtime.Object
-		ao  []ApplyOption
-	}
-
-	type want struct {
-		o   runtime.Object
-		err error
+		ctx     context.Context
+		current runtime.Object
+		desired runtime.Object
 	}
 
 	cases := map[string]struct {
 		reason string
 		args   args
-		want   want
+		want   error
 	}{
-		"NotAMetadataObject": {
-			reason: "An error should be returned if we can't access the object's metadata",
+		"ControllersMatch": {
+			reason: "The current and desired objects have matching controller references",
 			args: args{
-				c: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
-				o: &nopeject{},
-			},
-			want: want{
-				o:   &nopeject{},
-				err: errors.New("cannot access object metadata"),
+				current: &object{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					UID:        uid,
+					Controller: &controller,
+				}}}},
+				desired: &object{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					UID:        uid,
+					Controller: &controller,
+				}}}},
 			},
 		},
-		"GetError": {
-			reason: "An error should be returned if we can't get the object",
+		"ControllersDoNotMatch": {
+			reason: "The current and desired objects do not have matching controller references",
 			args: args{
-				c: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
-				o: &object{},
+				current: &object{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					UID:        uid,
+					Controller: &controller,
+				}}}},
+				desired: &object{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+					UID:        types.UID("some-other-uid"),
+					Controller: &controller,
+				}}}},
 			},
-			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot get object"),
-			},
-		},
-		"CreateError": {
-			reason: "No error should be returned if we successfully create a new object",
-			args: args{
-				c: &test.MockClient{
-					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-					MockCreate: test.NewMockCreateFn(errBoom),
-				},
-				o: &object{},
-			},
-			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot create object"),
-			},
-		},
-		"ControllerMismatch": {
-			reason: "An error should be returned if controllers must match, but don't",
-			args: args{
-				c: &test.MockClient{MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
-					*(o.(*object)) = *controlled
-					return nil
-				})},
-				o:  &object{},
-				ao: []ApplyOption{ControllersMustMatch()},
-			},
-			want: want{
-				o:   controlled,
-				err: errors.New("existing object has a different (or no) controller"),
-			},
-		},
-		"PatchError": {
-			reason: "An error should be returned if we can't patch the object",
-			args: args{
-				c: &test.MockClient{
-					MockGet:   test.NewMockGetFn(nil),
-					MockPatch: test.NewMockPatchFn(errBoom),
-				},
-				o: &object{},
-			},
-			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot patch object"),
-			},
-		},
-		"Created": {
-			reason: "No error should be returned if we successfully create a new object",
-			args: args{
-				c: &test.MockClient{
-					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-					MockCreate: test.NewMockCreateFn(nil, func(o runtime.Object) error {
-						*(o.(*object)) = *named
-						return nil
-					}),
-				},
-				o: &object{},
-			},
-			want: want{
-				o: named,
-			},
-		},
-		"Patched": {
-			reason: "No error should be returned if we successfully patch an existing object",
-			args: args{
-				c: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil),
-					MockPatch: test.NewMockPatchFn(nil, func(o runtime.Object) error {
-						*(o.(*object)) = *named
-						return nil
-					}),
-				},
-				o: &object{},
-			},
-			want: want{
-				o: named,
-			},
+			want: errors.New("existing object has a different (or no) controller"),
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := Apply(tc.args.ctx, tc.args.c, tc.args.o, tc.args.ao...)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nApply(...): -want error, +got error\n%s\n", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.o, tc.args.o); diff != "" {
-				t.Errorf("\n%s\nApply(...): -want, +got\n%s\n", tc.reason, diff)
+			ao := ControllersMustMatch()
+			err := ao(tc.args.ctx, tc.args.current, tc.args.desired)
+
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nControllersMustMatch(...)(...): -want error, +got error\n%s\n", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane-runtime/issues/138

This PR introduces a new type of secret: `connection.crossplane.io/v1alpha`. Using a distinct type for connection secrets allows Crossplane to adopt orphaned connection secrets (i.e. those without controller references) without needing to be concerned about adopting an existing secret that has nothing to do with Crossplane. Refer to https://github.com/crossplane/crossplane-runtime/issues/138#issuecomment-607009508 for more context.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml