### PR TITLE
Make connection secret propagation UID-agnostic

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -33,9 +33,9 @@ import (
 */
 
 const (
-	// ExternalNameAnnotationKey is the key in the annotations map of a resource
+	// AnnotationKeyExternalName is the key in the annotations map of a resource
 	// for the name of the resource as it appears on provider's systems.
-	ExternalNameAnnotationKey = "crossplane.io/external-name"
+	AnnotationKeyExternalName = "crossplane.io/external-name"
 )
 
 // ReferenceTo returns an object reference to the supplied object, presumed to
@@ -213,10 +213,10 @@ func WasCreated(o metav1.Object) bool {
 
 // GetExternalName returns the external name annotation value on the resource.
 func GetExternalName(o metav1.Object) string {
-	return o.GetAnnotations()[ExternalNameAnnotationKey]
+	return o.GetAnnotations()[AnnotationKeyExternalName]
 }
 
 // SetExternalName sets the external name annotation of the resource.
 func SetExternalName(o metav1.Object, name string) {
-	AddAnnotations(o, map[string]string{ExternalNameAnnotationKey: name})
+	AddAnnotations(o, map[string]string{AnnotationKeyExternalName: name})
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -815,7 +815,7 @@ func TestGetExternalName(t *testing.T) {
 		want string
 	}{
 		"ExternalNameExists": {
-			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: name}}},
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalName: name}}},
 			want: name,
 		},
 		"NoExternalName": {
@@ -843,7 +843,7 @@ func TestSetExternalName(t *testing.T) {
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
 			name: name,
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: name}}},
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalName: name}}},
 		},
 	}
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package meta
 
 import (
+	"fmt"
+	"hash/fnv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -852,6 +854,147 @@ func TestSetExternalName(t *testing.T) {
 			SetExternalName(tc.o, tc.name)
 			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
 				t.Errorf("SetExternalName(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAllowPropagation(t *testing.T) {
+	fromns := "from-namespace"
+	from := "from-name"
+	tons := "to-namespace"
+	to := "to-name"
+
+	tohash := func() string {
+		h := fnv.New32a()
+		h.Write([]byte(tons))
+		h.Write([]byte(to))
+		return fmt.Sprintf("%x", h.Sum32())
+	}()
+
+	type args struct {
+		from metav1.Object
+		to   metav1.Object
+	}
+	type want struct {
+		from metav1.Object
+		to   metav1.Object
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"Successful": {
+			args: args{
+				from: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Namespace: fromns,
+					Name:      from,
+					Annotations: map[string]string{
+						"existing": "annotation",
+					},
+				}},
+				to: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Namespace: tons,
+					Name:      to,
+					Annotations: map[string]string{
+						"existing": "annotation",
+					},
+				}},
+			},
+			want: want{
+				from: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Namespace: fromns,
+					Name:      from,
+					Annotations: map[string]string{
+						"existing":                              "annotation",
+						AnnotationKeyPropagateToPrefix + tohash: tons + "/" + to,
+					},
+				}},
+				to: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Namespace: tons,
+					Name:      to,
+					Annotations: map[string]string{
+						"existing":                          "annotation",
+						AnnotationKeyPropagateFromNamespace: fromns,
+						AnnotationKeyPropagateFromName:      from,
+					},
+				}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			AllowPropagation(tc.args.from, tc.args.to)
+			if diff := cmp.Diff(tc.want.from, tc.args.from); diff != "" {
+				t.Errorf("AllowPropagation(...): -want from, +got from\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.to, tc.args.to); diff != "" {
+				t.Errorf("AllowPropagation(...): -want to, +got to\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAllowsPropagationFrom(t *testing.T) {
+	ns := "coolns"
+	name := "coolname"
+
+	cases := map[string]struct {
+		to   metav1.Object
+		want types.NamespacedName
+	}{
+		"Successful": {
+			to: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyPropagateFromNamespace: ns,
+				AnnotationKeyPropagateFromName:      name,
+			}}},
+			want: types.NamespacedName{Namespace: ns, Name: name},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := AllowsPropagationFrom(tc.to)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("AllowsPropagationFrom(...): -want, +got\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAllowsPropagationTo(t *testing.T) {
+	nsA := "coolns"
+	nameA := "coolname"
+	nsB := "coolerns"
+	nameB := "coolername"
+
+	cases := map[string]struct {
+		from metav1.Object
+		want map[types.NamespacedName]bool
+	}{
+		"Successful": {
+			from: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"existing": "annotation",
+				AnnotationKeyPropagateToPrefix + "missingslash":     "wat",
+				AnnotationKeyPropagateToPrefix + "missingname":      "wat/",
+				AnnotationKeyPropagateToPrefix + "missingnamespace": "/wat",
+				AnnotationKeyPropagateToPrefix + "a":                nsA + "/" + nameA,
+				AnnotationKeyPropagateToPrefix + "b":                nsB + "/" + nameB,
+			}}},
+			want: map[types.NamespacedName]bool{
+				{Namespace: nsA, Name: nameA}: true,
+				{Namespace: nsB, Name: nameB}: true,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := AllowsPropagationTo(tc.from)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("AllowsPropagationTo(...): -want, +got\n%s", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/claimbinding/api_test.go
+++ b/pkg/reconciler/claimbinding/api_test.go
@@ -215,17 +215,17 @@ func TestBind(t *testing.T) {
 				ctx: context.Background(),
 				cm:  &fake.Claim{},
 				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 				},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateClaim),
 				cm: &fake.Claim{
-					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &fake.Managed{
-					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
@@ -255,16 +255,16 @@ func TestBind(t *testing.T) {
 				ctx: context.Background(),
 				cm:  &fake.Claim{},
 				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 				},
 			},
 			want: want{
 				err: nil,
 				cm: &fake.Claim{
-					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
@@ -373,17 +373,17 @@ func TestStatusBind(t *testing.T) {
 				ctx: context.Background(),
 				cm:  &fake.Claim{},
 				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 				},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateClaim),
 				cm: &fake.Claim{
-					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &fake.Managed{
-					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
@@ -419,17 +419,17 @@ func TestStatusBind(t *testing.T) {
 				ctx: context.Background(),
 				cm:  &fake.Claim{},
 				mg: &fake.Managed{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 				},
 			},
 			want: want{
 				err: nil,
 				cm: &fake.Claim{
-					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &fake.Managed{
-					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName}},
 					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},

--- a/pkg/reconciler/claimbinding/configurator_test.go
+++ b/pkg/reconciler/claimbinding/configurator_test.go
@@ -130,7 +130,7 @@ func TestNameConfigurators(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   claimNS,
 						Name:        claimName,
-						Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName},
+						Annotations: map[string]string{meta.AnnotationKeyExternalName: externalName},
 					}},
 				mg: &fake.Managed{},
 			},
@@ -138,7 +138,7 @@ func TestNameConfigurators(t *testing.T) {
 				mg: &fake.Managed{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: claimNS + "-" + claimName + "-",
-						Annotations:  map[string]string{meta.ExternalNameAnnotationKey: externalName},
+						Annotations:  map[string]string{meta.AnnotationKeyExternalName: externalName},
 					},
 				},
 			},

--- a/pkg/reconciler/managed/api_test.go
+++ b/pkg/reconciler/managed/api_test.go
@@ -183,7 +183,7 @@ func TestNameAsExternalName(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: testExternalName},
+					Annotations: map[string]string{meta.AnnotationKeyExternalName: testExternalName},
 				}},
 			},
 		},
@@ -197,7 +197,7 @@ func TestNameAsExternalName(t *testing.T) {
 				err: nil,
 				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: testExternalName},
+					Annotations: map[string]string{meta.AnnotationKeyExternalName: testExternalName},
 				}},
 			},
 		},
@@ -206,14 +206,14 @@ func TestNameAsExternalName(t *testing.T) {
 				ctx: context.Background(),
 				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: "some-name"},
+					Annotations: map[string]string{meta.AnnotationKeyExternalName: "some-name"},
 				}},
 			},
 			want: want{
 				err: nil,
 				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: "some-name"},
+					Annotations: map[string]string{meta.AnnotationKeyExternalName: "some-name"},
 				}},
 			},
 		},

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -36,19 +36,6 @@ import (
 // SecretTypeConnection is the type of Crossplane connection secrets.
 const SecretTypeConnection corev1.SecretType = "connection.crossplane.io/v1alpha1"
 
-// Supported resources with all of these annotations will be fully or partially
-// propagated to the named resource of the same kind, assuming it exists and
-// consents to propagation.
-const (
-	AnnotationKeyPropagateToPrefix = "to.propagate.crossplane.io"
-
-	AnnotationKeyPropagateFromNamespace = "from.propagate.crossplane.io/namespace"
-	AnnotationKeyPropagateFromName      = "from.propagate.crossplane.io/name"
-	AnnotationKeyPropagateFromUID       = "from.propagate.crossplane.io/uid"
-
-	AnnotationDelimiter = "/"
-)
-
 // External resources are tagged/labelled with the following keys in the cloud
 // provider API if the type supports.
 const (


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/crossplane/crossplane-runtime/issues/140

This allows propagation to function even when the propagating and/or propagated secrets have been deleted and recreated, and thus allocated new UIDs.


### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml