### PR TITLE
apply should work for objects with only generateName

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -111,6 +111,10 @@ func (a *APIPatchingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 		return errors.New("cannot access object metadata")
 	}
 
+	if m.GetName() == "" && m.GetGenerateName() != "" {
+		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
+	}
+
 	desired := o.DeepCopyObject()
 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, o)
@@ -155,6 +159,10 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 	m, ok := o.(metav1.Object)
 	if !ok {
 		return errors.New("cannot access object metadata")
+	}
+
+	if m.GetName() == "" && m.GetGenerateName() != "" {
+		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
 	}
 
 	current := o.DeepCopyObject()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

It's a valid creation call but `Apply` doesn't currently support it. The `Get` call returns error when there is no name.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml