### PR TITLE
Connection secret publishers are made consumable by all resources with secret

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -72,21 +72,21 @@ func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPu
 // PublishConnection publishes the supplied ConnectionDetails to a Secret in the
 // same namespace as the supplied Managed resource. It is a no-op if the secret
 // already exists with the supplied ConnectionDetails.
-func (a *APISecretPublisher) PublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+func (a *APISecretPublisher) PublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error {
 	// This resource does not want to expose a connection secret.
-	if mg.GetWriteConnectionSecretToReference() == nil {
+	if owner.GetWriteConnectionSecretToReference() == nil {
 		return nil
 	}
 
-	s := resource.ConnectionSecretFor(mg, resource.MustGetKind(mg, a.typer))
+	s := resource.ConnectionSecretFor(owner, resource.MustGetKind(owner, a.typer))
 	s.Data = c
-	return errors.Wrap(a.secret.Apply(ctx, s, resource.ConnectionSecretMustBeControllableBy(mg.GetUID())), errCreateOrUpdateSecret)
+	return errors.Wrap(a.secret.Apply(ctx, s, resource.ConnectionSecretMustBeControllableBy(owner.GetUID())), errCreateOrUpdateSecret)
 }
 
 // UnpublishConnection is no-op since PublishConnection only creates resources
 // that will be garbage collected by Kubernetes when the managed resource is
 // deleted.
-func (a *APISecretPublisher) UnpublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+func (a *APISecretPublisher) UnpublishConnection(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 	return nil
 }
 

--- a/pkg/reconciler/managed/publisher.go
+++ b/pkg/reconciler/managed/publisher.go
@@ -27,9 +27,9 @@ type PublisherChain []ConnectionPublisher
 
 // PublishConnection calls each ConnectionPublisher.PublishConnection serially. It returns the first error it
 // encounters, if any.
-func (pc PublisherChain) PublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+func (pc PublisherChain) PublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error {
 	for _, p := range pc {
-		if err := p.PublishConnection(ctx, mg, c); err != nil {
+		if err := p.PublishConnection(ctx, owner, c); err != nil {
 			return err
 		}
 	}
@@ -38,9 +38,9 @@ func (pc PublisherChain) PublishConnection(ctx context.Context, mg resource.Mana
 
 // UnpublishConnection calls each ConnectionPublisher.UnpublishConnection serially. It returns the first error it
 // encounters, if any.
-func (pc PublisherChain) UnpublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+func (pc PublisherChain) UnpublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error {
 	for _, p := range pc {
-		if err := p.UnpublishConnection(ctx, mg, c); err != nil {
+		if err := p.UnpublishConnection(ctx, owner, c); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/managed/publisher_test.go
+++ b/pkg/reconciler/managed/publisher_test.go
@@ -59,10 +59,10 @@ func TestPublisherChain(t *testing.T) {
 		"SuccessfulPublisher": {
 			p: PublisherChain{
 				ConnectionPublisherFns{
-					PublishConnectionFn: func(_ context.Context, mg resource.Managed, c ConnectionDetails) error {
+					PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return nil
 					},
-					UnpublishConnectionFn: func(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+					UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return nil
 					},
 				},
@@ -77,10 +77,10 @@ func TestPublisherChain(t *testing.T) {
 		"PublisherReturnsError": {
 			p: PublisherChain{
 				ConnectionPublisherFns{
-					PublishConnectionFn: func(_ context.Context, mg resource.Managed, c ConnectionDetails) error {
+					PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return errBoom
 					},
-					UnpublishConnectionFn: func(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
+					UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return nil
 					},
 				},

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -81,32 +81,32 @@ func ControllerName(kind string) string {
 type ConnectionDetails map[string][]byte
 
 // A ConnectionPublisher manages the supplied ConnectionDetails for the
-// supplied Managed resource. ManagedPublishers must handle the case in which
+// supplied resource. ManagedPublishers must handle the case in which
 // the supplied ConnectionDetails are empty.
 type ConnectionPublisher interface {
-	// PublishConnection details for the supplied Managed resource. Publishing
+	// PublishConnection details for the supplied resource. Publishing
 	// must be additive; i.e. if details (a, b, c) are published, subsequently
 	// publicing details (b, c, d) should update (b, c) but not remove a.
-	PublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error
+	PublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error
 
-	// UnpublishConnection details for the supplied Managed resource.
-	UnpublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error
+	// UnpublishConnection details for the supplied resource.
+	UnpublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error
 }
 
 // ConnectionPublisherFns is the pluggable struct to produce objects with ConnectionPublisher interface.
 type ConnectionPublisherFns struct {
-	PublishConnectionFn   func(ctx context.Context, mg resource.Managed, c ConnectionDetails) error
-	UnpublishConnectionFn func(ctx context.Context, mg resource.Managed, c ConnectionDetails) error
+	PublishConnectionFn   func(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error
+	UnpublishConnectionFn func(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error
 }
 
-// PublishConnection details for the supplied Managed resource.
-func (fn ConnectionPublisherFns) PublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
-	return fn.PublishConnectionFn(ctx, mg, c)
+// PublishConnection details for the supplied resource.
+func (fn ConnectionPublisherFns) PublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error {
+	return fn.PublishConnectionFn(ctx, owner, c)
 }
 
-// UnpublishConnection details for the supplied Managed resource.
-func (fn ConnectionPublisherFns) UnpublishConnection(ctx context.Context, mg resource.Managed, c ConnectionDetails) error {
-	return fn.UnpublishConnectionFn(ctx, mg, c)
+// UnpublishConnection details for the supplied resource.
+func (fn ConnectionPublisherFns) UnpublishConnection(ctx context.Context, owner resource.ConnectionSecretOwner, c ConnectionDetails) error {
+	return fn.UnpublishConnectionFn(ctx, owner, c)
 }
 
 // A Initializer establishes ownership of the supplied Managed resource.

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -323,7 +323,7 @@ func TestReconciler(t *testing.T) {
 						return c, nil
 					})),
 					WithConnectionPublishers(ConnectionPublisherFns{
-						UnpublishConnectionFn: func(_ context.Context, _ resource.Managed, _ ConnectionDetails) error { return errBoom },
+						UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error { return errBoom },
 					}),
 				},
 			},
@@ -425,7 +425,7 @@ func TestReconciler(t *testing.T) {
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnecter(&NopConnecter{}),
 					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ resource.Managed, _ ConnectionDetails) error { return errBoom },
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error { return errBoom },
 					}),
 				},
 			},
@@ -534,7 +534,7 @@ func TestReconciler(t *testing.T) {
 						return c, nil
 					})),
 					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ resource.Managed, cd ConnectionDetails) error {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, cd ConnectionDetails) error {
 							// We're called after observe, create, and update
 							// but we only want to fail when publishing details
 							// after a creation.
@@ -688,7 +688,7 @@ func TestReconciler(t *testing.T) {
 						return c, nil
 					})),
 					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ resource.Managed, cd ConnectionDetails) error {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, cd ConnectionDetails) error {
 							// We're called after observe, create, and update
 							// but we only want to fail when publishing details
 							// after an update.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

This is a non-breaking change that simplifies the interface that the connection publishers require. It's necessary for composition instances to be able to use the existing connection publishers.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml