### PR TITLE
AddOwnerRef should update

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -109,6 +109,7 @@ func AddOwnerReference(o metav1.Object, r metav1.OwnerReference) {
 	for i := range refs {
 		if refs[i].UID == r.UID {
 			refs[i] = r
+			o.SetOwnerReferences(refs)
 			return
 		}
 	}


### PR DESCRIPTION


Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

AddOwnerReference should always set the owner ref array to be able to modify the existing reference. Otherwise it never updates the existing owner ref.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml