### PR TITLE
Add getters and setters for resource counts

### DIFF
--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -194,6 +194,24 @@ func (m *ComposedResourcesReferencer) SetResourceReferences(r []corev1.ObjectRef
 // GetResourceReferences gets the composed references.
 func (m *ComposedResourcesReferencer) GetResourceReferences() []corev1.ObjectReference { return m.Refs }
 
+// ComposedResourceCounter is a mock that implements ComposedResourceCounter interface.
+type ComposedResourceCounter struct{ Count int }
+
+// SetComposedResourceCount sets the composed resource count.
+func (m *ComposedResourceCounter) SetComposedResourceCount(i int) { m.Count = i }
+
+// GetComposedResourceCount Gets the composed resource count.
+func (m *ComposedResourceCounter) GetComposedResourceCount() int { return m.Count }
+
+// ReadyResourceCounter is a mock that implements ReadyResourceCounter interface.
+type ReadyResourceCounter struct{ Count int }
+
+// SetReadyResourceCount sets the ready resource count.
+func (m *ReadyResourceCounter) SetReadyResourceCount(i int) { m.Count = i }
+
+// GetReadyResourceCount gets the ready resource count.
+func (m *ReadyResourceCounter) GetReadyResourceCount() int { return m.Count }
+
 // Object is a mock that implements Object interface.
 type Object struct {
 	metav1.ObjectMeta
@@ -342,12 +360,16 @@ func (m *Target) DeepCopyObject() runtime.Object {
 // Composite is a mock that implements Composite interface.
 type Composite struct {
 	metav1.ObjectMeta
+
 	CompositionSelector
 	CompositionReferencer
 	// TODO(negz): ComposedResourcesReferencer.
 	RequirementReferencer
 	Reclaimer
 	ConnectionSecretWriterTo
+
+	ComposedResourceCounter
+	ReadyResourceCounter
 	v1alpha1.ConditionedStatus
 }
 
@@ -393,10 +415,14 @@ func (m *Composed) DeepCopyObject() runtime.Object {
 // Requirement is a mock that implements Requirement interface.
 type Requirement struct {
 	metav1.ObjectMeta
+
 	CompositionSelector
 	CompositionReferencer
 	CompositeResourceReferencer
 	LocalConnectionSecretWriterTo
+
+	ComposedResourceCounter
+	ReadyResourceCounter
 	v1alpha1.ConditionedStatus
 }
 

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -133,6 +133,18 @@ type CompositeResourceReferencer interface {
 	GetResourceReference() *corev1.ObjectReference
 }
 
+// A ComposedResourceCounter can count how many resources are composed.
+type ComposedResourceCounter interface {
+	SetComposedResourceCount(i int)
+	GetComposedResourceCount() int
+}
+
+// A ReadyResourceCounter can count how many resources are ready.
+type ReadyResourceCounter interface {
+	SetReadyResourceCount(i int)
+	GetReadyResourceCount() int
+}
+
 // An Object is a Kubernetes object.
 type Object interface {
 	metav1.Object
@@ -231,6 +243,8 @@ type Composite interface {
 	Reclaimer
 	ConnectionSecretWriterTo
 
+	ComposedResourceCounter
+	ReadyResourceCounter
 	Conditioned
 }
 
@@ -251,5 +265,7 @@ type Requirement interface {
 	CompositeResourceReferencer
 	LocalConnectionSecretWriterTo
 
+	ComposedResourceCounter
+	ReadyResourceCounter
 	Conditioned
 }

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -154,6 +154,28 @@ func (c *Unstructured) SetReclaimPolicy(p v1alpha1.ReclaimPolicy) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.reclaimPolicy", p)
 }
 
+// SetComposedResourceCount of this Composite resource.
+func (c *Unstructured) SetComposedResourceCount(i int) {
+	_ = fieldpath.Pave(c.Object).SetNumber("status.composedResources", float64(i))
+}
+
+// GetComposedResourceCount of this Composite resource.
+func (c *Unstructured) GetComposedResourceCount() int {
+	v, _ := fieldpath.Pave(c.Object).GetNumber("status.composedResources")
+	return int(v)
+}
+
+// SetReadyResourceCount of this Composite resource.
+func (c *Unstructured) SetReadyResourceCount(i int) {
+	_ = fieldpath.Pave(c.Object).SetNumber("status.readyResources", float64(i))
+}
+
+// GetReadyResourceCount of this Composite resource.
+func (c *Unstructured) GetReadyResourceCount() int {
+	v, _ := fieldpath.Pave(c.Object).GetNumber("status.readyResources")
+	return int(v)
+}
+
 // GetCondition of this Composite resource.
 func (c *Unstructured) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Condition {
 	conditioned := v1alpha1.ConditionedStatus{}

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -262,3 +262,51 @@ func TestReclaimPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestComposedResourceCount(t *testing.T) {
+	cases := map[string]struct {
+		u    *Unstructured
+		set  int
+		want int
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  8,
+			want: 8,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetComposedResourceCount(tc.set)
+			got := tc.u.GetComposedResourceCount()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetComposedResourceCount(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReadyResourceCount(t *testing.T) {
+	cases := map[string]struct {
+		u    *Unstructured
+		set  int
+		want int
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  8,
+			want: 8,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetReadyResourceCount(tc.set)
+			got := tc.u.GetReadyResourceCount()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetReadyResourceCount(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resource/unstructured/requirement/requirement.go
+++ b/pkg/resource/unstructured/requirement/requirement.go
@@ -121,6 +121,28 @@ func (c *Unstructured) SetWriteConnectionSecretToReference(ref *v1alpha1.LocalSe
 	_ = fieldpath.Pave(c.Object).SetValue("spec.writeConnectionSecretToRef", ref)
 }
 
+// SetComposedResourceCount of this Requirement.
+func (c *Unstructured) SetComposedResourceCount(i int) {
+	_ = fieldpath.Pave(c.Object).SetNumber("status.composedResources", float64(i))
+}
+
+// GetComposedResourceCount of this Requirement.
+func (c *Unstructured) GetComposedResourceCount() int {
+	v, _ := fieldpath.Pave(c.Object).GetNumber("status.composedResources")
+	return int(v)
+}
+
+// SetReadyResourceCount of this Requirement.
+func (c *Unstructured) SetReadyResourceCount(i int) {
+	_ = fieldpath.Pave(c.Object).SetNumber("status.readyResources", float64(i))
+}
+
+// GetReadyResourceCount of this Requirement.
+func (c *Unstructured) GetReadyResourceCount() int {
+	v, _ := fieldpath.Pave(c.Object).GetNumber("status.readyResources")
+	return int(v)
+}
+
 // GetCondition of this Requirement.
 func (c *Unstructured) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Condition {
 	conditioned := v1alpha1.ConditionedStatus{}

--- a/pkg/resource/unstructured/requirement/requirement_test.go
+++ b/pkg/resource/unstructured/requirement/requirement_test.go
@@ -213,3 +213,51 @@ func TestWriteConnectionSecretToReference(t *testing.T) {
 		})
 	}
 }
+
+func TestComposedResourceCount(t *testing.T) {
+	cases := map[string]struct {
+		u    *Unstructured
+		set  int
+		want int
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  8,
+			want: 8,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetComposedResourceCount(tc.set)
+			got := tc.u.GetComposedResourceCount()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetComposedResourceCount(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReadyResourceCount(t *testing.T) {
+	cases := map[string]struct {
+		u    *Unstructured
+		set  int
+		want int
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  8,
+			want: 8,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetReadyResourceCount(tc.set)
+			got := tc.u.GetReadyResourceCount()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetReadyResourceCount(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Adding status.composedResources and status.readyResources will allow us to determine whether a composite resource (and thus its corresponding resource requirement) is ready by diffing the composed from the ready resources.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml