### PR TITLE
Don't wait for IsBindable before calling AddFinalizer

### DIFF
--- a/pkg/reconciler/claimbinding/reconciler_test.go
+++ b/pkg/reconciler/claimbinding/reconciler_test.go
@@ -309,6 +309,9 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
@@ -344,6 +347,9 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
@@ -379,9 +385,14 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
-				o: []ReconcilerOption{WithManagedConfigurators(ManagedConfiguratorFn(
-					func(_ context.Context, _ resource.Claim, _ resource.Class, _ resource.Managed) error { return errBoom },
-				))},
+				o: []ReconcilerOption{
+					WithManagedConfigurators(ManagedConfiguratorFn(
+						func(_ context.Context, _ resource.Claim, _ resource.Class, _ resource.Managed) error { return errBoom },
+					)),
+					WithClaimFinalizer(resource.FinalizerFns{
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }},
+					),
+				},
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
@@ -470,6 +481,9 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
 		},
@@ -510,6 +524,9 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
 		},
@@ -550,6 +567,7 @@ func TestReconciler(t *testing.T) {
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 					WithManagedConnectionPropagator(resource.ManagedConnectionPropagatorFn(
 						func(_ context.Context, _ resource.LocalConnectionSecretOwner, _ resource.Managed) error {
 							return errBoom
@@ -692,6 +710,9 @@ func TestReconciler(t *testing.T) {
 				of:   resource.ClaimKind(fake.GVK(&fake.Claim{})),
 				use:  resource.ClassKind(fake.GVK(&fake.Class{})),
 				with: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
 		},


### PR DESCRIPTION
Fixes https://github.com/crossplane/crossplane-runtime/issues/173

@muvaf please take a look. @negz intuition was that the issue reported in #173 is caused by the Finalizer never being added before deletion occurs. Walking through the code, that seems to add up, as we only call `AddFinalizer()` after `IsBindable()` evaluates true.

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml