### PR TITLE
Bind and unbind managed resources conservatively

### DIFF
--- a/pkg/reconciler/claimbinding/api.go
+++ b/pkg/reconciler/claimbinding/api.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,6 +39,7 @@ const (
 	errDeleteManaged       = "cannot delete managed resource"
 	errBindMismatch        = "refusing to bind to managed resource that does not reference resource claim"
 	errUnbindMismatch      = "refusing to 'unbind' from managed resource that does not reference resource claim"
+	errBindControlled      = "refusing to bind to managed resource that is controlled by another resource"
 )
 
 // An APIManagedCreator creates resources by submitting them to a Kubernetes
@@ -86,6 +88,14 @@ func NewAPIBinder(c client.Client, t runtime.ObjectTyper) *APIBinder {
 
 // Bind the supplied resource to the supplied claim.
 func (a *APIBinder) Bind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	// A managed resource that was statically provisioned by an infrastructure
+	// operator should not have a controller reference. We assume a managed
+	// resource with a controller reference is part of a composite resource or a
+	// stack, and therefore not available to be claimed.
+	if metav1.GetControllerOf(mg) != nil {
+		return errors.New(errBindControlled)
+	}
+
 	// Note that we allow a claim to bind to a managed resource with a nil claim
 	// reference in order to enable the static provisioning case in which a
 	// managed resource is provisioned ahead of time and is not associated with
@@ -156,6 +166,14 @@ func NewAPIStatusBinder(c client.Client, t runtime.ObjectTyper) *APIStatusBinder
 
 // Bind the supplied resource to the supplied claim.
 func (a *APIStatusBinder) Bind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	// A managed resource that was statically provisioned by an infrastructure
+	// operator should not have a controller reference. We assume a managed
+	// resource with a controller reference is part of a composite resource or a
+	// stack, and therefore not available to be claimed.
+	if metav1.GetControllerOf(mg) != nil {
+		return errors.New(errBindControlled)
+	}
+
 	// Note that we allow a claim to bind to a managed resource with a nil claim
 	// reference in order to enable the static provisioning case in which a
 	// managed resource is provisioned ahead of time and is not associated with

--- a/pkg/reconciler/claimbinding/api.go
+++ b/pkg/reconciler/claimbinding/api.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,6 +36,8 @@ const (
 	errUpdateManaged       = "cannot update managed resource"
 	errUpdateManagedStatus = "cannot update managed resource status"
 	errDeleteManaged       = "cannot delete managed resource"
+	errBindMismatch        = "refusing to bind to managed resource that does not reference resource claim"
+	errUnbindMismatch      = "refusing to 'unbind' from managed resource that does not reference resource claim"
 )
 
 // An APIManagedCreator creates resources by submitting them to a Kubernetes
@@ -83,6 +86,14 @@ func NewAPIBinder(c client.Client, t runtime.ObjectTyper) *APIBinder {
 
 // Bind the supplied resource to the supplied claim.
 func (a *APIBinder) Bind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	// Note that we allow a claim to bind to a managed resource with a nil claim
+	// reference in order to enable the static provisioning case in which a
+	// managed resource is provisioned ahead of time and is not associated with
+	// any claim.
+	if r := mg.GetClaimReference(); r != nil && !equal(meta.ReferenceTo(cm, resource.MustGetKind(cm, a.typer)), r) {
+		return errors.New(errBindMismatch)
+	}
+
 	cm.SetBindingPhase(v1alpha1.BindingPhaseBound)
 
 	// This claim reference will already be set for dynamically provisioned
@@ -108,7 +119,11 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.Claim, mg resource.Man
 // managed resource's claim reference, transitioning it to binding phase
 // "Released", and if the managed resource's reclaim policy is "Delete",
 // deleting it.
-func (a *APIBinder) Unbind(ctx context.Context, _ resource.Claim, mg resource.Managed) error {
+func (a *APIBinder) Unbind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	if !equal(meta.ReferenceTo(cm, resource.MustGetKind(cm, a.typer)), mg.GetClaimReference()) {
+		return errors.New(errUnbindMismatch)
+	}
+
 	mg.SetBindingPhase(v1alpha1.BindingPhaseReleased)
 	mg.SetClaimReference(nil)
 	if err := a.client.Update(ctx, mg); err != nil {
@@ -141,6 +156,14 @@ func NewAPIStatusBinder(c client.Client, t runtime.ObjectTyper) *APIStatusBinder
 
 // Bind the supplied resource to the supplied claim.
 func (a *APIStatusBinder) Bind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	// Note that we allow a claim to bind to a managed resource with a nil claim
+	// reference in order to enable the static provisioning case in which a
+	// managed resource is provisioned ahead of time and is not associated with
+	// any claim.
+	if r := mg.GetClaimReference(); r != nil && !equal(meta.ReferenceTo(cm, resource.MustGetKind(cm, a.typer)), r) {
+		return errors.New(errBindMismatch)
+	}
+
 	cm.SetBindingPhase(v1alpha1.BindingPhaseBound)
 
 	// This claim reference will already be set for dynamically provisioned
@@ -170,7 +193,11 @@ func (a *APIStatusBinder) Bind(ctx context.Context, cm resource.Claim, mg resour
 // managed resource's claim reference, transitioning it to binding phase
 // "Released", and if the managed resource's reclaim policy is "Delete",
 // deleting it.
-func (a *APIStatusBinder) Unbind(ctx context.Context, _ resource.Claim, mg resource.Managed) error {
+func (a *APIStatusBinder) Unbind(ctx context.Context, cm resource.Claim, mg resource.Managed) error {
+	if !equal(meta.ReferenceTo(cm, resource.MustGetKind(cm, a.typer)), mg.GetClaimReference()) {
+		return errors.New(errUnbindMismatch)
+	}
+
 	mg.SetClaimReference(nil)
 	if err := a.client.Update(ctx, mg); err != nil {
 		return errors.Wrap(resource.IgnoreNotFound(err), errUpdateManaged)
@@ -189,4 +216,26 @@ func (a *APIStatusBinder) Unbind(ctx context.Context, _ resource.Claim, mg resou
 	}
 
 	return errors.Wrap(resource.IgnoreNotFound(a.client.Delete(ctx, mg)), errDeleteManaged)
+}
+
+// equal returns true if the supplied object references are considered equal. We
+// consider two otherwise matching references with different UIDs to be equal,
+// presuming that they are both references to a particular object that has been
+// deleted and recreated, e.g. due to being restored from a backup.
+//
+// TODO(negz): If we switch to a reference that only has the fields we care
+// about (GVK, namespace, and name) we can just use struct equality.
+// https://github.com/crossplane/crossplane-runtime/issues/49
+func equal(a, b *corev1.ObjectReference) bool {
+	switch {
+	case a == nil || b == nil:
+		return a == b
+	case a.APIVersion != b.APIVersion:
+		return false
+	case a.Kind != b.Kind:
+		return false
+	case a.Namespace != b.Namespace:
+		return false
+	}
+	return a.Name == b.Name
 }

--- a/pkg/reconciler/claimbinding/api_test.go
+++ b/pkg/reconciler/claimbinding/api_test.go
@@ -167,6 +167,7 @@ func TestBind(t *testing.T) {
 
 	errBoom := errors.New("boom")
 	externalName := "very-cool-external-resource"
+	controller := true
 
 	cases := map[string]struct {
 		client client.Client
@@ -174,6 +175,23 @@ func TestBind(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"ControlledError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{},
+				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Controller: &controller}},
+				}},
+			},
+			want: want{
+				err: errors.New(errBindControlled),
+				cm:  &fake.Claim{},
+				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Controller: &controller}},
+				}},
+			},
+		},
 		"RefMismatchError": {
 			typer: fake.SchemeWith(&fake.Claim{}),
 			args: args{
@@ -320,6 +338,7 @@ func TestStatusBind(t *testing.T) {
 
 	errBoom := errors.New("boom")
 	externalName := "very-cool-external-resource"
+	controller := true
 
 	cases := map[string]struct {
 		client client.Client
@@ -327,6 +346,23 @@ func TestStatusBind(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"ControlledError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{},
+				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Controller: &controller}},
+				}},
+			},
+			want: want{
+				err: errors.New(errBindControlled),
+				cm:  &fake.Claim{},
+				mg: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{Controller: &controller}},
+				}},
+			},
+		},
 		"RefMismatchError": {
 			typer: fake.SchemeWith(&fake.Claim{}),
 			args: args{

--- a/pkg/reconciler/claimbinding/api_test.go
+++ b/pkg/reconciler/claimbinding/api_test.go
@@ -174,6 +174,23 @@ func TestBind(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"RefMismatchError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg: &fake.Managed{
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+				},
+			},
+			want: want{
+				err: errors.New(errBindMismatch),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg: &fake.Managed{
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+				},
+			},
+		},
 		"UpdateManagedError": {
 			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil, func(obj runtime.Object) error {
 				switch obj.(type) {
@@ -310,6 +327,23 @@ func TestStatusBind(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"RefMismatchError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg: &fake.Managed{
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+				},
+			},
+			want: want{
+				err: errors.New(errBindMismatch),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg: &fake.Managed{
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+				},
+			},
+		},
 		"UpdateManagedError": {
 			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil, func(obj runtime.Object) error {
 				switch obj.(type) {
@@ -467,22 +501,39 @@ func TestUnbind(t *testing.T) {
 
 	errBoom := errors.New("boom")
 
+	typer := fake.SchemeWith(&fake.Claim{})
+	ref := meta.ReferenceTo(&fake.Claim{}, resource.MustGetKind(&fake.Claim{}, typer))
+
 	cases := map[string]struct {
 		client client.Client
 		typer  runtime.ObjectTyper
 		args   args
 		want   want
 	}{
+		"RefMismatchError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg:  &fake.Managed{ClaimReferencer: fake.ClaimReferencer{Ref: ref}},
+			},
+			want: want{
+				err: errors.New(errUnbindMismatch),
+				mg:  &fake.Managed{ClaimReferencer: fake.ClaimReferencer{Ref: ref}},
+			},
+		},
 		"SuccessfulRetain": {
 			client: &test.MockClient{
 				MockUpdate: test.NewMockUpdateFn(nil),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimRetain},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -499,12 +550,14 @@ func TestUnbind(t *testing.T) {
 				MockUpdate: test.NewMockUpdateFn(nil),
 				MockDelete: test.NewMockDeleteFn(nil),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimDelete},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -520,12 +573,14 @@ func TestUnbind(t *testing.T) {
 			client: &test.MockClient{
 				MockUpdate: test.NewMockUpdateFn(errBoom),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimRetain},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -542,12 +597,14 @@ func TestUnbind(t *testing.T) {
 				MockUpdate: test.NewMockUpdateFn(nil),
 				MockDelete: test.NewMockDeleteFn(errBoom),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimDelete},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -588,6 +645,8 @@ func TestStatusUnbind(t *testing.T) {
 	}
 
 	errBoom := errors.New("boom")
+	typer := fake.SchemeWith(&fake.Claim{})
+	ref := meta.ReferenceTo(&fake.Claim{}, resource.MustGetKind(&fake.Claim{}, typer))
 
 	cases := map[string]struct {
 		client client.Client
@@ -595,16 +654,30 @@ func TestStatusUnbind(t *testing.T) {
 		args   args
 		want   want
 	}{
+		"RefMismatchError": {
+			typer: fake.SchemeWith(&fake.Claim{}),
+			args: args{
+				ctx: context.Background(),
+				cm:  &fake.Claim{ObjectMeta: metav1.ObjectMeta{Name: "I'm different!"}},
+				mg:  &fake.Managed{ClaimReferencer: fake.ClaimReferencer{Ref: ref}},
+			},
+			want: want{
+				err: errors.New(errUnbindMismatch),
+				mg:  &fake.Managed{ClaimReferencer: fake.ClaimReferencer{Ref: ref}},
+			},
+		},
 		"SuccessfulRetain": {
 			client: &test.MockClient{
 				MockUpdate:       test.NewMockUpdateFn(nil),
 				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -621,12 +694,14 @@ func TestStatusUnbind(t *testing.T) {
 				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 				MockDelete:       test.NewMockDeleteFn(nil),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimDelete},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -642,11 +717,13 @@ func TestStatusUnbind(t *testing.T) {
 			client: &test.MockClient{
 				MockUpdate: test.NewMockUpdateFn(errBoom),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -662,12 +739,14 @@ func TestStatusUnbind(t *testing.T) {
 				MockUpdate:       test.NewMockUpdateFn(nil),
 				MockStatusUpdate: test.NewMockStatusUpdateFn(errBoom),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimRetain},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -685,12 +764,14 @@ func TestStatusUnbind(t *testing.T) {
 				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 				MockDelete:       test.NewMockDeleteFn(errBoom),
 			},
+			typer: typer,
 			args: args{
 				ctx: context.Background(),
+				cm:  &fake.Claim{},
 				mg: &fake.Managed{
 					Reclaimer:       fake.Reclaimer{Policy: v1alpha1.ReclaimDelete},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
-					ClaimReferencer: fake.ClaimReferencer{Ref: &corev1.ObjectReference{}},
+					ClaimReferencer: fake.ClaimReferencer{Ref: ref},
 				},
 			},
 			want: want{
@@ -713,6 +794,89 @@ func TestStatusUnbind(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mg, tc.args.mg, test.EquateConditions()); diff != "" {
 				t.Errorf("api.Unbind(...) Managed: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectReferenceEqual(t *testing.T) {
+	cases := map[string]struct {
+		a    *corev1.ObjectReference
+		b    *corev1.ObjectReference
+		want bool
+	}{
+		"BothNil": {
+			want: true,
+		},
+		"OneIsNil": {
+			a:    &corev1.ObjectReference{},
+			want: false,
+		},
+		"MismatchedAPIVersion": {
+			a: &corev1.ObjectReference{
+				APIVersion: "v",
+			},
+			b:    &corev1.ObjectReference{},
+			want: false,
+		},
+		"MismatchedKind": {
+			a: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+			},
+			b: &corev1.ObjectReference{
+				APIVersion: "v",
+			},
+			want: false,
+		},
+		"MismatchedNamespace": {
+			a: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+				Namespace:  "ns",
+			},
+			b: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+			},
+			want: false,
+		},
+		"MismatchedName": {
+			a: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+				Namespace:  "ns",
+				Name:       "cool",
+			},
+			b: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+				Namespace:  "ns",
+			},
+			want: false,
+		},
+		"Match": {
+			a: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+				Namespace:  "ns",
+				Name:       "cool",
+			},
+			b: &corev1.ObjectReference{
+				APIVersion: "v",
+				Kind:       "k",
+				Namespace:  "ns",
+				Name:       "cool",
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := equal(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("equal(...): want %t, got %t", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #177

The two commits in this PR gate against a handful of possible issues:

1. Composite resource C composes managed resource M. Claim A explicitly sets its resource reference to managed resource M, thereby making M doubly owned by a claim and a composition.
1. Claim A dynamically provisions managed resource M. Claim B runs and wins a race against Claim A to bind to the newly provisioned and bindable M.
1. Claim A dynamically provisions managed resource M. Claim B explicitly sets its resource reference to M, and is then deleted, thereby deleting M which it was never bound to and did not dynamically provision.

We noticed both of these issues during review of https://github.com/crossplane/crossplane-runtime/pull/174 (which did not introduce them). I'd like to wait until that PR is merged before I manually test this.

Note (cc @prasek) that one implication of this change is that a resource claim may not claim a managed resource that was statically provisioned by an infrastructure stack. i.e. You could not author an infra stack that created a `CloudSQLInstance`, then later author a `MySQLInstance` that claimed that `CloudSQLInstance`. To my knowledge we don't do this today - infra stacks only provision "unclaimable" supporting infrastructure like VPC networks.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml