### PR TITLE
Update with object that is gotten in APIUpdatingApplicator

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -123,7 +123,8 @@ func NewAPIPatchingApplicator(c client.Client) *APIPatchingApplicator {
 }
 
 // Apply changes to the supplied object. The object will be created if it does
-// not exist, or patched if it does.
+// not exist, or patched if it does. If the object does it exist it will always
+// be patched, regardless of resource version.
 func (a *APIPatchingApplicator) Apply(ctx context.Context, o runtime.Object, ao ...ApplyOption) error {
 	m, ok := o.(metav1.Object)
 	if !ok {
@@ -173,7 +174,8 @@ func NewAPIUpdatingApplicator(c client.Client) *APIUpdatingApplicator {
 }
 
 // Apply changes to the supplied object. The object will be created if it does
-// not exist, or updated if it does.
+// not exist, or updated if it does. If the object does exist and no
+// ApplyOptions are passed, the update will be a no-op.
 func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao ...ApplyOption) error {
 	m, ok := o.(metav1.Object)
 	if !ok {
@@ -201,7 +203,7 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 		}
 	}
 
-	return errors.Wrap(a.client.Update(ctx, o), "cannot update object")
+	return errors.Wrap(a.client.Update(ctx, current), "cannot update object")
 }
 
 // An APIFinalizer adds and removes finalizers to and from a resource.

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -273,6 +273,15 @@ func (fn ApplyFn) Apply(ctx context.Context, o runtime.Object, ao ...ApplyOption
 // desired object. ApplyOptions are not called if no current object exists.
 type ApplyOption func(ctx context.Context, current, desired runtime.Object) error
 
+// UpdateFn returns an ApplyOption that is used to modify the current object to
+// match fields of the desired.
+func UpdateFn(fn func(current, desired runtime.Object)) ApplyOption {
+	return func(_ context.Context, c, d runtime.Object) error {
+		fn(c, d)
+		return nil
+	}
+}
+
 // MustBeControllableBy requires that the current object is controllable by an
 // object with the supplied UID. An object is controllable if its controller
 // reference matches the supplied UID, or it has no controller reference.


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This changes APIUpdatingApplicator to make its Update call with the object it gets rather than the one passed so that the default behavior is a no-op rather than a guaranteed error on mismatched resource versions.


This adds an apply option that sets the resource version of the desired object to that of the current object such that it will force operations on update and patch calls.

~Keeping in draft until I can do some testing with Crossplane controllers.~

Please see https://github.com/crossplane/crossplane/pull/1492 for testing details.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml