### PR TITLE
applicators: run supplied ApplyOptions for creations, too

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -139,7 +139,11 @@ func (a *APIPatchingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, o)
 	if kerrors.IsNotFound(err) {
-		// TODO(negz): Apply ApplyOptions here too?
+		for _, fn := range ao {
+			if err := fn(ctx, o, desired); err != nil {
+				return err
+			}
+		}
 		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
 	}
 	if err != nil {
@@ -190,7 +194,11 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
 	if kerrors.IsNotFound(err) {
-		// TODO(negz): Apply ApplyOptions here too?
+		for _, fn := range ao {
+			if err := fn(ctx, current, o); err != nil {
+				return err
+			}
+		}
 		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
 	}
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

While I was working on Crossplane Agent, I needed to copy a resource from another cluster. Since it has its own UID, resource version etc. I wanted to use an `ApplyOption` to get rid of those but realized they are not run on creation case.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml