### PR TITLE
applicators: Run ApplyOptions against empty instance in case of creation

### DIFF
--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -329,6 +329,18 @@ func TestAPIPatchingApplicator(t *testing.T) {
 				o: desired,
 			},
 		},
+		"CreatedWithGenerateName": {
+			reason: "No error should be returned if we successfully create a new object with only generate name",
+			c: &test.MockClient{
+				MockCreate: test.NewMockCreateFn(nil),
+			},
+			args: args{
+				o: &object{ObjectMeta: metav1.ObjectMeta{GenerateName: "olala"}},
+			},
+			want: want{
+				o: &object{ObjectMeta: metav1.ObjectMeta{GenerateName: "olala"}},
+			},
+		},
 		"Patched": {
 			reason: "No error should be returned if we successfully patch an existing object",
 			c: &test.MockClient{
@@ -461,6 +473,18 @@ func TestAPIUpdatingApplicator(t *testing.T) {
 			},
 			want: want{
 				o: desired,
+			},
+		},
+		"CreatedWithGenerateName": {
+			reason: "No error should be returned if we successfully create a new object with only generate name",
+			c: &test.MockClient{
+				MockCreate: test.NewMockCreateFn(nil),
+			},
+			args: args{
+				o: &object{ObjectMeta: metav1.ObjectMeta{GenerateName: "olala"}},
+			},
+			want: want{
+				o: &object{ObjectMeta: metav1.ObjectMeta{GenerateName: "olala"}},
 			},
 		},
 		"Updated": {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -340,6 +341,18 @@ func ControllersMustMatch() ApplyOption {
 		}
 		return nil
 	}
+}
+
+// NewEmptyInstance returns a runtime.Object whose fields are filled with zero
+// values.
+func NewEmptyInstance(o runtime.Object) runtime.Object {
+	if u, ok := o.(runtime.Unstructured); ok {
+		return u.NewEmptyInstance()
+	}
+	// We know that the input is runtime.Object so it is not possible for output
+	// to not satisfy runtime.Object interface, hence we skip returning error.
+	v, _ := reflect.New(reflect.TypeOf(o).Elem()).Interface().(runtime.Object)
+	return v
 }
 
 // Apply changes to the supplied object. The object will be created if it does


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

While I was working on Crossplane Agent, I needed to copy a resource from another cluster. Since it has its own UID, resource version etc. I wanted to use an `ApplyOption` to get rid of those but realized they are not run on creation case.

This PR makes sure options are called in all cases; in case the object doesn't exist, then `current` is the empty form of that object.

Unit tests are working and I tested it manually with the agent code.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml