### PR TITLE
Rename 'requirement' to 'claim'

### DIFF
--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -185,15 +185,6 @@ func (m *CompositeResourceReferencer) SetResourceReference(p *corev1.ObjectRefer
 // GetResourceReference gets the composite resource reference.
 func (m *CompositeResourceReferencer) GetResourceReference() *corev1.ObjectReference { return m.Ref }
 
-// RequirementReferencer is a mock that implements RequirementReferencer interface.
-type RequirementReferencer struct{ Ref *corev1.ObjectReference }
-
-// SetRequirementReference sets the requirement reference.
-func (m *RequirementReferencer) SetRequirementReference(p *corev1.ObjectReference) { m.Ref = p }
-
-// GetRequirementReference gets the requirement reference.
-func (m *RequirementReferencer) GetRequirementReference() *corev1.ObjectReference { return m.Ref }
-
 // ComposedResourcesReferencer is a mock that implements ComposedResourcesReferencer interface.
 type ComposedResourcesReferencer struct{ Refs []corev1.ObjectReference }
 
@@ -355,7 +346,7 @@ type Composite struct {
 	CompositionSelector
 	CompositionReferencer
 	ComposedResourcesReferencer
-	RequirementReferencer
+	ClaimReferencer
 	Reclaimer
 	ConnectionSecretWriterTo
 	v1alpha1.ConditionedStatus
@@ -400,8 +391,8 @@ func (m *Composed) DeepCopyObject() runtime.Object {
 	return out
 }
 
-// Requirement is a mock that implements Requirement interface.
-type Requirement struct {
+// CompositeClaim is a mock that implements the CompositeClaim interface.
+type CompositeClaim struct {
 	metav1.ObjectMeta
 	CompositionSelector
 	CompositionReferencer
@@ -411,13 +402,13 @@ type Requirement struct {
 }
 
 // GetObjectKind returns schema.ObjectKind.
-func (m *Requirement) GetObjectKind() schema.ObjectKind {
+func (m *CompositeClaim) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
 // DeepCopyObject returns a copy of the object as runtime.Object
-func (m *Requirement) DeepCopyObject() runtime.Object {
-	out := &Requirement{}
+func (m *CompositeClaim) DeepCopyObject() runtime.Object {
+	out := &CompositeClaim{}
 	j, err := json.Marshal(m)
 	if err != nil {
 		panic(err)

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -127,12 +127,6 @@ type ComposedResourcesReferencer interface {
 	GetResourceReferences() []corev1.ObjectReference
 }
 
-// A RequirementReferencer can reference a requirement resource.
-type RequirementReferencer interface {
-	SetRequirementReference(r *corev1.ObjectReference)
-	GetRequirementReference() *corev1.ObjectReference
-}
-
 // A CompositeResourceReferencer can reference a composite resource.
 type CompositeResourceReferencer interface {
 	SetResourceReference(r *corev1.ObjectReference)
@@ -234,7 +228,7 @@ type Composite interface {
 	CompositionSelector
 	CompositionReferencer
 	ComposedResourcesReferencer
-	RequirementReferencer
+	ClaimReferencer
 	Reclaimer
 	ConnectionSecretWriterTo
 
@@ -249,8 +243,8 @@ type Composed interface {
 	ConnectionSecretWriterTo
 }
 
-// A Requirement for a Composite resource.
-type Requirement interface {
+// A CompositeClaim for a Composite resource.
+type CompositeClaim interface {
 	Object
 
 	CompositionSelector

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -229,7 +229,6 @@ type Composite interface {
 	CompositionReferencer
 	ComposedResourcesReferencer
 	ClaimReferencer
-	Reclaimer
 	ConnectionSecretWriterTo
 
 	Conditioned

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -69,9 +69,9 @@ type TargetKind schema.GroupVersionKind
 // A CompositeKind contains the type metadata for a kind of composite resource.
 type CompositeKind schema.GroupVersionKind
 
-// A RequirementKind contains the type metadata for a kind of requirement
-// resource.
-type RequirementKind schema.GroupVersionKind
+// A CompositeClaimKind contains the type metadata for a kind of composite
+// resource claim.
+type CompositeClaimKind schema.GroupVersionKind
 
 // A LocalConnectionSecretOwner may create and manage a connection secret in its
 // own namespace.

--- a/pkg/resource/unstructured/claim/claim.go
+++ b/pkg/resource/unstructured/claim/claim.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package requirement contains an unstructured resource requirement.
-package requirement
+// Package claim contains an unstructured composite resource claim.
+package claim
 
 import (
 	corev1 "k8s.io/api/core/v1"
@@ -27,11 +27,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 )
 
-// An Option modifies an unstructured resource requirement.
+// An Option modifies an unstructured composite resource claim.
 type Option func(*Unstructured)
 
-// WithGroupVersionKind sets the GroupVersionKind of the unstructured resource
-// requirement.
+// WithGroupVersionKind sets the GroupVersionKind of the unstructured composite
+// resource claim.
 func WithGroupVersionKind(gvk schema.GroupVersionKind) Option {
 	return func(c *Unstructured) {
 		c.SetGroupVersionKind(gvk)
@@ -39,14 +39,14 @@ func WithGroupVersionKind(gvk schema.GroupVersionKind) Option {
 }
 
 // WithConditions returns an Option that sets the supplied conditions on an
-// unstructured resource requirement.
+// unstructured composite resource claim.
 func WithConditions(c ...v1alpha1.Condition) Option {
 	return func(cr *Unstructured) {
 		cr.SetConditions(c...)
 	}
 }
 
-// New returns a new unstructured resource requirement.
+// New returns a new unstructured composite resource claim.
 func New(opts ...Option) *Unstructured {
 	c := &Unstructured{Unstructured: unstructured.Unstructured{Object: make(map[string]interface{})}}
 	for _, f := range opts {
@@ -55,7 +55,7 @@ func New(opts ...Option) *Unstructured {
 	return c
 }
 
-// An Unstructured resource requirement.
+// An Unstructured composite resource claim.
 type Unstructured struct {
 	unstructured.Unstructured
 }
@@ -65,7 +65,7 @@ func (c *Unstructured) GetUnstructured() *unstructured.Unstructured {
 	return &c.Unstructured
 }
 
-// GetCompositionSelector of this resource Requirement.
+// GetCompositionSelector of this composite resource claim.
 func (c *Unstructured) GetCompositionSelector() *metav1.LabelSelector {
 	out := &metav1.LabelSelector{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionSelector", out); err != nil {
@@ -74,12 +74,12 @@ func (c *Unstructured) GetCompositionSelector() *metav1.LabelSelector {
 	return out
 }
 
-// SetCompositionSelector of this resource Requirement.
+// SetCompositionSelector of this composite resource claim.
 func (c *Unstructured) SetCompositionSelector(sel *metav1.LabelSelector) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionSelector", sel)
 }
 
-// GetCompositionReference of this resource Requirement.
+// GetCompositionReference of this composite resource claim.
 func (c *Unstructured) GetCompositionReference() *corev1.ObjectReference {
 	out := &corev1.ObjectReference{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionRef", out); err != nil {
@@ -88,12 +88,12 @@ func (c *Unstructured) GetCompositionReference() *corev1.ObjectReference {
 	return out
 }
 
-// SetCompositionReference of this resource Requirement.
+// SetCompositionReference of this composite resource claim.
 func (c *Unstructured) SetCompositionReference(ref *corev1.ObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRef", ref)
 }
 
-// GetResourceReference of this resource Requirement.
+// GetResourceReference of this composite resource claim.
 func (c *Unstructured) GetResourceReference() *corev1.ObjectReference {
 	out := &corev1.ObjectReference{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.resourceRef", out); err != nil {
@@ -102,12 +102,12 @@ func (c *Unstructured) GetResourceReference() *corev1.ObjectReference {
 	return out
 }
 
-// SetResourceReference of this resource Requirement.
+// SetResourceReference of this composite resource claim.
 func (c *Unstructured) SetResourceReference(ref *corev1.ObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.resourceRef", ref)
 }
 
-// GetWriteConnectionSecretToReference of this resource Requirement.
+// GetWriteConnectionSecretToReference of this composite resource claim.
 func (c *Unstructured) GetWriteConnectionSecretToReference() *v1alpha1.LocalSecretReference {
 	out := &v1alpha1.LocalSecretReference{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.writeConnectionSecretToRef", out); err != nil {
@@ -116,12 +116,12 @@ func (c *Unstructured) GetWriteConnectionSecretToReference() *v1alpha1.LocalSecr
 	return out
 }
 
-// SetWriteConnectionSecretToReference of this resource Requirement.
+// SetWriteConnectionSecretToReference of this composite resource claim.
 func (c *Unstructured) SetWriteConnectionSecretToReference(ref *v1alpha1.LocalSecretReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.writeConnectionSecretToRef", ref)
 }
 
-// GetCondition of this Requirement.
+// GetCondition of this composite resource claim.
 func (c *Unstructured) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Condition {
 	conditioned := v1alpha1.ConditionedStatus{}
 	// The path is directly `status` because conditions are inline.
@@ -131,7 +131,7 @@ func (c *Unstructured) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Conditio
 	return conditioned.GetCondition(ct)
 }
 
-// SetConditions of this Requirement.
+// SetConditions of this composite resource claim.
 func (c *Unstructured) SetConditions(conditions ...v1alpha1.Condition) {
 	conditioned := v1alpha1.ConditionedStatus{}
 	// The path is directly `status` because conditions are inline.

--- a/pkg/resource/unstructured/claim/claim_test.go
+++ b/pkg/resource/unstructured/claim/claim_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package requirement
+package claim
 
 import (
 	"testing"

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -93,18 +93,18 @@ func (c *Unstructured) SetCompositionReference(ref *corev1.ObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRef", ref)
 }
 
-// GetRequirementReference of this Composite resource.
-func (c *Unstructured) GetRequirementReference() *corev1.ObjectReference {
+// GetClaimReference of this Composite resource.
+func (c *Unstructured) GetClaimReference() *corev1.ObjectReference {
 	out := &corev1.ObjectReference{}
-	if err := fieldpath.Pave(c.Object).GetValueInto("spec.requirementRef", out); err != nil {
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.claimRef", out); err != nil {
 		return nil
 	}
 	return out
 }
 
-// SetRequirementReference of this Composite resource.
-func (c *Unstructured) SetRequirementReference(ref *corev1.ObjectReference) {
-	_ = fieldpath.Pave(c.Object).SetValue("spec.requirementRef", ref)
+// SetClaimReference of this Composite resource.
+func (c *Unstructured) SetClaimReference(ref *corev1.ObjectReference) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.claimRef", ref)
 }
 
 // GetResourceReferences of this Composite resource.

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -163,7 +163,7 @@ func TestCompositionReference(t *testing.T) {
 	}
 }
 
-func TestRequirementReference(t *testing.T) {
+func TestClaimReference(t *testing.T) {
 	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
 	cases := map[string]struct {
 		u    *Unstructured
@@ -179,10 +179,10 @@ func TestRequirementReference(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.u.SetRequirementReference(tc.set)
-			got := tc.u.GetRequirementReference()
+			tc.u.SetClaimReference(tc.set)
+			got := tc.u.GetClaimReference()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("\nu.GetRequirementReference(): -want, +got:\n%s", diff)
+				t.Errorf("\nu.GetClaimReference(): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Crossplane composite resources are cluster scoped, but they can be 'published' to create a namespaced proxy resource. We called this resource a 'requirement', despite it being conceptually quite similar to our existing (and deprecated) 'resource claim' concept. We've found that the 'publish a requirement' concept has not resonated with the community and have decided to switch our terminology.

Under this new approach platform builders may choose to enable platform operators to 'offer' (not publish) a composite resource to their platform consumers. The namespaced interface to these composite resources will be known as a 'claim' or 'composite resource claim'. Note that we think platform builders and operators are the key audience for these concepts; platform consumers will simply think of themselves as using the resource as its kind indicates - e.g. 'a Kubernetes cluster' or 'an SQL instance', not 'an SQL instance claim'.

In some cases our existing but deprecated resource claim concept has name conflicts with this new take on the claim concept - i.e. the resource.Claim interface. In those cases I've named the new type CompositeClaim to distinguish it.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml