### PR TITLE
Update with desired object in APIUpdatingApplicator

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -176,7 +176,7 @@ func NewAPIUpdatingApplicator(c client.Client) *APIUpdatingApplicator {
 // Apply changes to the supplied object. The object will be created if it does
 // not exist, or updated if it does.
 func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao ...ApplyOption) error {
-	m, ok := o.(metav1.Object)
+	m, ok := o.(Object)
 	if !ok {
 		return errors.New("cannot access object metadata")
 	}
@@ -190,22 +190,22 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o runtime.Object, ao 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
 	if kerrors.IsNotFound(err) {
 		// TODO(negz): Apply ApplyOptions here too?
-		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
+		return errors.Wrap(a.client.Create(ctx, m), "cannot create object")
 	}
 	if err != nil {
 		return errors.Wrap(err, "cannot get object")
 	}
 
 	for _, fn := range ao {
-		if err := fn(ctx, current, o); err != nil {
+		if err := fn(ctx, current, m); err != nil {
 			return err
 		}
 	}
 
 	// NOTE(hasheddan): we must set the resource version of the desired object
 	// to that of the current or the update will always fail.
-	o.(metav1.Object).SetResourceVersion(current.(metav1.Object).GetResourceVersion())
-	return errors.Wrap(a.client.Update(ctx, o), "cannot update object")
+	m.SetResourceVersion(current.(metav1.Object).GetResourceVersion())
+	return errors.Wrap(a.client.Update(ctx, m), "cannot update object")
 }
 
 // An APIFinalizer adds and removes finalizers to and from a resource.

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -468,13 +467,10 @@ func TestAPIUpdatingApplicator(t *testing.T) {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
 					*o.(*object) = *current
-					fmt.Println(current.Name)
 					return nil
 				}),
 				MockUpdate: test.NewMockUpdateFn(nil, func(o runtime.Object) error {
-					fmt.Println(current.Name)
-					fmt.Println(o.(*object).Name)
-					if diff := cmp.Diff(*current, *o.(*object)); diff != "" {
+					if diff := cmp.Diff(*desired, *o.(*object)); diff != "" {
 						t.Errorf("r: -want, +got:\n%s", diff)
 					}
 					return nil


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->


This modifies the behavior of the APIUpdatingApplicator to update with
the desired object by setting its resource version to that of the
current. This ensures that a successful update will result in the object
being modified to match the desired by default. Consumers of this
Applicator no longer are required to pass in an UpdateFn to avoid no-op
updates.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #191 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml