### PR TITLE
Add TypedReferenceTo meta utility

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -27,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
 /*
@@ -58,6 +60,18 @@ func ReferenceTo(o metav1.Object, of schema.GroupVersionKind) *corev1.ObjectRefe
 		APIVersion: v,
 		Kind:       k,
 		Namespace:  o.GetNamespace(),
+		Name:       o.GetName(),
+		UID:        o.GetUID(),
+	}
+}
+
+// TypedReferenceTo returns a typed object reference to the supplied object,
+// presumed to be of the supplied group, version, and kind.
+func TypedReferenceTo(o metav1.Object, of schema.GroupVersionKind) *v1alpha1.TypedReference {
+	v, k := of.ToAPIVersionAndKind()
+	return &v1alpha1.TypedReference{
+		APIVersion: v,
+		Kind:       k,
 		Name:       o.GetName(),
 		UID:        o.GetUID(),
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -81,7 +81,7 @@ func TypedReferenceTo(o metav1.Object, of schema.GroupVersionKind) *v1alpha1.Typ
 }
 
 // AsOwner converts the supplied object reference to an owner reference.
-func AsOwner(r *corev1.ObjectReference) metav1.OwnerReference {
+func AsOwner(r *v1alpha1.TypedReference) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: r.APIVersion,
 		Kind:       r.Kind,
@@ -92,7 +92,7 @@ func AsOwner(r *corev1.ObjectReference) metav1.OwnerReference {
 
 // AsController converts the supplied object reference to a controller
 // reference. You may also consider using metav1.NewControllerRef.
-func AsController(r *corev1.ObjectReference) metav1.OwnerReference {
+func AsController(r *v1alpha1.TypedReference) metav1.OwnerReference {
 	c := true
 	ref := AsOwner(r)
 	ref.Controller = &c

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -31,13 +31,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
-/*
-	Prefer taking *corev1.ObjectReference as an argument where possible when
-	adding new functions to this package. It's easier to convert an object to
-	an ObjectReference using ReferenceTo() than it is to make an ObjectReference
-	satisfy metav1.Object.
-*/
-
 // AnnotationKeyExternalName is the key in the annotations map of a resource for
 // the name of the resource as it appears on provider's systems.
 const AnnotationKeyExternalName = "crossplane.io/external-name"

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -54,6 +54,9 @@ const (
 
 // ReferenceTo returns an object reference to the supplied object, presumed to
 // be of the supplied group, version, and kind.
+// Deprecated: use a more specific reference type, such as TypedReference or
+// Reference instead of the overly verbose ObjectReference.
+// See https://github.com/crossplane/crossplane-runtime/issues/49
 func ReferenceTo(o metav1.Object, of schema.GroupVersionKind) *corev1.ObjectReference {
 	v, k := of.ToAPIVersionAndKind()
 	return &corev1.ObjectReference{

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -131,14 +131,13 @@ func TestTypedReferenceTo(t *testing.T) {
 
 func TestAsOwner(t *testing.T) {
 	tests := map[string]struct {
-		r    *corev1.ObjectReference
+		r    *v1alpha1.TypedReference
 		want metav1.OwnerReference
 	}{
 		"Successful": {
-			r: &corev1.ObjectReference{
+			r: &v1alpha1.TypedReference{
 				APIVersion: groupVersion,
 				Kind:       kind,
-				Namespace:  name,
 				Name:       name,
 				UID:        uid,
 			},
@@ -165,14 +164,13 @@ func TestAsController(t *testing.T) {
 	controller := true
 
 	tests := map[string]struct {
-		r    *corev1.ObjectReference
+		r    *v1alpha1.TypedReference
 		want metav1.OwnerReference
 	}{
 		"Successful": {
-			r: &corev1.ObjectReference{
+			r: &v1alpha1.TypedReference{
 				APIVersion: groupVersion,
 				Kind:       kind,
-				Namespace:  name,
 				Name:       name,
 				UID:        uid,
 			},

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
@@ -80,6 +81,49 @@ func TestReferenceTo(t *testing.T) {
 			got := ReferenceTo(tc.args.o, tc.args.of)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("ReferenceTo(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTypedReferenceTo(t *testing.T) {
+	type args struct {
+		o  metav1.Object
+		of schema.GroupVersionKind
+	}
+	tests := map[string]struct {
+		args
+		want *v1alpha1.TypedReference
+	}{
+		"WithTypeMeta": {
+			args: args{
+				o: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+						UID:       uid,
+					},
+				},
+				of: schema.GroupVersionKind{
+					Group:   group,
+					Version: version,
+					Kind:    kind,
+				},
+			},
+			want: &v1alpha1.TypedReference{
+				APIVersion: groupVersion,
+				Kind:       kind,
+				Name:       name,
+				UID:        uid,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := TypedReferenceTo(tc.args.o, tc.args.of)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("TypedReferenceTo(): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,7 +76,7 @@ func TestResolve(t *testing.T) {
 	controlled := &fake.Managed{}
 	controlled.SetName(value)
 	meta.SetExternalName(controlled, value)
-	meta.AddControllerReference(controlled, meta.AsController(&corev1.ObjectReference{UID: types.UID("very-unique")}))
+	meta.AddControllerReference(controlled, meta.AsController(&v1alpha1.TypedReference{UID: types.UID("very-unique")}))
 
 	type args struct {
 		ctx context.Context
@@ -268,7 +267,7 @@ func TestResolveMultiple(t *testing.T) {
 	controlled := &fake.Managed{}
 	controlled.SetName(value)
 	meta.SetExternalName(controlled, value)
-	meta.AddControllerReference(controlled, meta.AsController(&corev1.ObjectReference{UID: types.UID("very-unique")}))
+	meta.AddControllerReference(controlled, meta.AsController(&v1alpha1.TypedReference{UID: types.UID("very-unique")}))
 
 	type args struct {
 		ctx context.Context

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -116,7 +116,7 @@ func LocalConnectionSecretFor(o LocalConnectionSecretOwner, kind schema.GroupVer
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       o.GetNamespace(),
 			Name:            o.GetWriteConnectionSecretToReference().Name,
-			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.ReferenceTo(o, kind))},
+			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(o, kind))},
 		},
 		Type: SecretTypeConnection,
 		Data: make(map[string][]byte),
@@ -141,7 +141,7 @@ func ConnectionSecretFor(o ConnectionSecretOwner, kind schema.GroupVersionKind) 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       o.GetWriteConnectionSecretToReference().Namespace,
 			Name:            o.GetWriteConnectionSecretToReference().Name,
-			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.ReferenceTo(o, kind))},
+			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(o, kind))},
 		},
 		Type: SecretTypeConnection,
 		Data: make(map[string][]byte),


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Adds a TypedReferenceTo utility function that matches the ReferenceTo
implementation for ObjectReference, but returns a TypedReference
instead.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml