### PR TITLE
Mark Claim and KubeApp reconcilers deprecated.

### DIFF
--- a/pkg/reconciler/claimbinding/doc.go
+++ b/pkg/reconciler/claimbinding/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // Package claimbinding provides a resource claim binding reconciler.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1670
 package claimbinding

--- a/pkg/reconciler/claimdefaulting/doc.go
+++ b/pkg/reconciler/claimdefaulting/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // Package claimdefaulting provides a reconciler that sets the default resource
 // class for a resource claim.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1670
 package claimdefaulting

--- a/pkg/reconciler/claimscheduling/doc.go
+++ b/pkg/reconciler/claimscheduling/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // Package claimscheduling provides a reconciler that selects a resource class
 // for a resource claim.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1670
 package claimscheduling

--- a/pkg/reconciler/target/doc.go
+++ b/pkg/reconciler/target/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // Package target provides a reconciler that propagates a Kubernetes cluster
 // managed resource's connection secret to a Kubernetes target.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1595
 package target


### PR DESCRIPTION
Signed-off-by: Nic Cope <negz@rk0n.org>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Kubernetes Applications and resource claims are deprecated per https://github.com/crossplane/crossplane/issues/1595 and https://github.com/crossplane/crossplane/issues/1670. This PR marks the reconcilers that providers use to implement these features as such.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml