### PR TITLE
fieldpath: add GetInteger to retrieve int64 number

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -17,10 +17,9 @@ limitations under the License.
 package fieldpath
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 type errNotFound struct {

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -220,7 +220,15 @@ func (p *Paved) GetBool(path string) (bool, error) {
 	return b, nil
 }
 
+// NOTE(muvaf): If there is no CRD, unstructured.Unstructured reads numbers as
+// float64. However, in practice, use of float64 is discouraged and when you fetch
+// an instance of a CRD whose number fields are int64, you'll get int64. So,
+// it's not really possible to test this without an api-server but that's the
+// actual behavior.
+
 // GetNumber value of the supplied field path.
+// Deprecated: Use of float64 is discouraged. Please use GetInteger.
+// See https://github.com/kubernetes/community/blob/c9ae475/contributors/devel/sig-architecture/api-conventions.md#primitive-types
 func (p *Paved) GetNumber(path string) (float64, error) {
 	v, err := p.GetValue(path)
 	if err != nil {
@@ -230,6 +238,20 @@ func (p *Paved) GetNumber(path string) (float64, error) {
 	f, ok := v.(float64)
 	if !ok {
 		return 0, errors.Errorf("%s: not a (float64) number", path)
+	}
+	return f, nil
+}
+
+// GetInteger value of the supplied field path.
+func (p *Paved) GetInteger(path string) (int64, error) {
+	v, err := p.GetValue(path)
+	if err != nil {
+		return 0, err
+	}
+
+	f, ok := v.(int64)
+	if !ok {
+		return 0, errors.Errorf("%s: not a (int64) number", path)
 	}
 	return f, nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

In practice, it's `int64` most of the time as I have discovered during https://github.com/crossplane/crossplane/pull/1713 . Details are left as comment in the code.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml