### PR TITLE
Default ProviderConfig is automatically selected

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
@@ -52,6 +53,24 @@ func (a *NameAsExternalName) Initialize(ctx context.Context, mg resource.Managed
 		return nil
 	}
 	meta.SetExternalName(mg, mg.GetName())
+	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
+}
+
+// DefaultProviderConfig fills the ProviderConfigRef with `default` if it's left
+// empty.
+type DefaultProviderConfig struct{ client client.Client }
+
+// NewDefaultProviderConfig returns a new DefaultProviderConfig.
+func NewDefaultProviderConfig(c client.Client) *DefaultProviderConfig {
+	return &DefaultProviderConfig{client: c}
+}
+
+// Initialize the given managed resource.
+func (a *DefaultProviderConfig) Initialize(ctx context.Context, mg resource.Managed) error {
+	if mg.GetProviderConfigReference() != nil {
+		return nil
+	}
+	mg.SetProviderConfigReference(&v1alpha1.Reference{Name: "default"})
 	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
 }
 

--- a/pkg/reconciler/managed/api_test.go
+++ b/pkg/reconciler/managed/api_test.go
@@ -116,6 +116,72 @@ func TestNameAsExternalName(t *testing.T) {
 	}
 }
 
+func TestDefaultProviderConfig(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		err error
+		mg  resource.Managed
+	}
+
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		client client.Client
+		args   args
+		want   want
+	}{
+		"UpdateManagedError": {
+			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
+			args: args{
+				ctx: context.Background(),
+				mg:  &fake.Managed{},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errUpdateManaged),
+				mg:  &fake.Managed{ProviderConfigReferencer: fake.ProviderConfigReferencer{Ref: &v1alpha1.Reference{Name: "default"}}},
+			},
+		},
+		"UpdateSuccessful": {
+			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			args: args{
+				ctx: context.Background(),
+				mg:  &fake.Managed{},
+			},
+			want: want{
+				err: nil,
+				mg:  &fake.Managed{ProviderConfigReferencer: fake.ProviderConfigReferencer{Ref: &v1alpha1.Reference{Name: "default"}}},
+			},
+		},
+		"UpdateNotNeeded": {
+			args: args{
+				ctx: context.Background(),
+				mg:  &fake.Managed{ProviderConfigReferencer: fake.ProviderConfigReferencer{Ref: &v1alpha1.Reference{Name: "some-value"}}},
+			},
+			want: want{
+				err: nil,
+				mg:  &fake.Managed{ProviderConfigReferencer: fake.ProviderConfigReferencer{Ref: &v1alpha1.Reference{Name: "some-value"}}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			api := NewDefaultProviderConfig(tc.client)
+			err := api.Initialize(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("api.Initialize(...): -want error, +got error:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.mg, tc.args.mg, test.EquateConditions()); diff != "" {
+				t.Errorf("api.Initialize(...) Managed: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAPISecretPublisher(t *testing.T) {
 	errBoom := errors.New("boom")
 

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -316,8 +316,11 @@ func defaultMRManaged(m manager.Manager) mrManaged {
 	return mrManaged{
 		ConnectionPublisher: NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
 		Finalizer:           resource.NewAPIFinalizer(m.GetClient(), managedFinalizerName),
-		Initializer:         NewNameAsExternalName(m.GetClient()),
-		ReferenceResolver:   NewAPIReferenceResolver(m.GetClient()),
+		Initializer: InitializerChain{
+			NewDefaultProviderConfig(m.GetClient()),
+			NewNameAsExternalName(m.GetClient()),
+		},
+		ReferenceResolver: NewAPIReferenceResolver(m.GetClient()),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

If `spec.providerConfigRef` is empty, it will be filled with `default`.

Note that this PR adds that new initializer to the default initializer list but there are managed resources who supply their own initializers. So, we'll need to update them manually.

Fixes https://github.com/crossplane/crossplane/issues/1686

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml