### PR TITLE
Have the managed reconciler update late initialized resources

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -267,18 +267,46 @@ func (c *NopClient) Delete(ctx context.Context, mg resource.Managed) error { ret
 // An ExternalObservation is the result of an observation of an external
 // resource.
 type ExternalObservation struct {
-	ResourceExists    bool
-	ResourceUpToDate  bool
+	// ResourceExists must be true if a corresponding external resource exists
+	// for the managed resource. Typically this is proven by the presence of an
+	// external resource of the expected kind whose unique identifier matches
+	// the managed resource's external name. Crossplane uses this information to
+	// determine whether it needs to create or delete the external resource.
+	ResourceExists bool
+
+	// ResourceUpToDate should be true if the corresponding external resource
+	// appears to be up-to-date - i.e. updating the external resource to match
+	// the desired state of the managed resource would be a no-op. Keep in mind
+	// that often only a subset of external resource fields can be updated.
+	// Crossplane uses this information to determine whether it needs to update
+	// the external resource.
+	ResourceUpToDate bool
+
+	// ConnectionDetails required to connect to this resource. These details
+	// are a set that is collated throughout the managed resource's lifecycle -
+	// i.e. returning new connection details will have no affect on old details
+	// unless an existing key is overwritten. Crossplane may publish these
+	// credentials to a store (e.g. a Secret).
 	ConnectionDetails ConnectionDetails
 }
 
 // An ExternalCreation is the result of the creation of an external resource.
 type ExternalCreation struct {
+	// ConnectionDetails required to connect to this resource. These details
+	// are a set that is collated throughout the managed resource's lifecycle -
+	// i.e. returning new connection details will have no affect on old details
+	// unless an existing key is overwritten. Crossplane may publish these
+	// credentials to a store (e.g. a Secret).
 	ConnectionDetails ConnectionDetails
 }
 
 // An ExternalUpdate is the result of an update to an external resource.
 type ExternalUpdate struct {
+	// ConnectionDetails required to connect to this resource. These details
+	// are a set that is collated throughout the managed resource's lifecycle -
+	// i.e. returning new connection details will have no affect on old details
+	// unless an existing key is overwritten. Crossplane may publish these
+	// credentials to a store (e.g. a Secret).
 	ConnectionDetails ConnectionDetails
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A design goal of the managed.Reconciler implementation was to insulate folks who are authoring an ExternalClient implementation from needing to interact with the Kubernetes API directly. The separation of concerns was intended to be:

* ExternalClient accepts a managed resource struct and reconciles it with the provider. It may update the struct it is passed, but otherwise does not interact with the Kubernetes API.
* ExternalConnector interacts with the Kubernetes API in order to produce an ExternalClient.
* Reconciler orchestrates the ExternalConnector and ExternalClient, propagating updates from the ExternalClient back to the Kubernetes API as necessary.

The desire to late initialize managed resources sullied this separation of concern (or single responsibility) by plumbing a Kubernetes client down into the ExternalClient implementations. I believe this was done because:

* We must update the resource spec before we update its status, or changes made to the status will be overwritten.
* We don't want to update the resource spec on every reconcile if it's possible to avoid doing so.

This small change to the managed resource reconciler allows an ExternalClient to signal that it has late initialized a managed resource, and thus defer updating that managed resource to the Reconciler. I believe this change is backward compatible (ExternalClient implementations could continue to 'manually' late initialize the resource and not return ResourceLateInitialized).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I updated the GCP CloudSQLInstance managed resource in https://github.com/crossplane/provider-gcp/pull/269 and confirmed it works as expected.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
