### PR TITLE
Skip no-op CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,7 @@ on:
     branches:
       - master
       - release-*
-    paths-ignore:
-      - '**.md'
-      - '**.png'
-      - '**.jpg'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.png'
-      - '**.jpg'
+  pull_request: {}
 
 env:
   # Common versions
@@ -28,9 +20,24 @@ env:
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
+  detect-noop:
+    runs-on: ubuntu-18.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+
 
   lint:
     runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -59,6 +66,8 @@ jobs:
 
   check-diff:
     runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -86,6 +95,8 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -122,6 +133,8 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Setup QEMU
@@ -171,6 +184,8 @@ jobs:
 
   publish-artifacts:
     runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Setup QEMU


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This change will skip CI runs that are deemed to be no-ops. A run is a no-op if it only contains ignored files (i.e. markdown or images). A run is also a no-op if it would test identical content to a run that previously succeeded, and is not a merge or push to a branch (i.e. mostly likely is a PR).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
