### PR TITLE
Note that FsReadCloser does not follow symlinks

### DIFF
--- a/pkg/parser/fsreader.go
+++ b/pkg/parser/fsreader.go
@@ -68,7 +68,7 @@ func SkipNotYAML() FilterFn {
 
 // NewFsReadCloser returns an FsReadCloser that implements io.ReadCloser. It
 // walks the filesystem ahead of time, then reads file contents when Read is
-// invoked.
+// invoked. It does not follow symbolic links.
 func NewFsReadCloser(fs afero.Fs, dir string, fns ...FilterFn) (*FsReadCloser, error) {
 	paths := []string{}
 	err := afero.Walk(fs, dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Adds note to NewFsReadCloser to indicate that symbolic links will not be
honored when walking the filesystem.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Partially addresses #217 (going to add to CLI also)


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
