### PR TITLE
Support AnnotatedReaders in package parser

### DIFF
--- a/pkg/parser/fsreader.go
+++ b/pkg/parser/fsreader.go
@@ -24,6 +24,14 @@ import (
 	"github.com/spf13/afero"
 )
 
+var _ AnnotatedReadCloser = &FsReadCloser{}
+
+// FsReadCloserAnnotation annotates data for an FsReadCloser.
+type FsReadCloserAnnotation struct {
+	path     string
+	position int
+}
+
 // FsReadCloser implements io.ReadCloser for an Afero filesystem.
 type FsReadCloser struct {
 	fs         afero.Fs
@@ -32,6 +40,7 @@ type FsReadCloser struct {
 	index      int
 	position   int
 	writeBreak bool
+	wroteBreak bool
 }
 
 // A FilterFn filters files when the FsReadCloser walks the filesystem.
@@ -94,24 +103,29 @@ func NewFsReadCloser(fs afero.Fs, dir string, fns ...FilterFn) (*FsReadCloser, e
 		index:      0,
 		position:   0,
 		writeBreak: false,
+		wroteBreak: false,
 	}, err
 }
 
 func (r *FsReadCloser) Read(p []byte) (n int, err error) {
+	if r.wroteBreak {
+		r.index++
+		r.position = 0
+		r.wroteBreak = false
+	}
 	if r.index == len(r.paths) {
 		return 0, io.EOF
 	}
 	if r.writeBreak {
 		n = copy(p, "\n---\n")
 		r.writeBreak = false
+		r.wroteBreak = true
 		return n, nil
 	}
 	b, err := afero.ReadFile(r.fs, r.paths[r.index])
 	n = copy(p, b[r.position:])
 	r.position += n
 	if err == io.EOF || n == 0 {
-		r.position = 0
-		r.index++
 		r.writeBreak = true
 		err = nil
 	}
@@ -121,4 +135,18 @@ func (r *FsReadCloser) Read(p []byte) (n int, err error) {
 // Close is a no op for an FsReadCloser.
 func (r *FsReadCloser) Close() error {
 	return nil
+}
+
+// Annotate returns additional about the data currently being read.
+func (r *FsReadCloser) Annotate() interface{} {
+	// Index will be out of bounds if we error after the final file has been
+	// read.
+	index := r.index
+	if index == len(r.paths) {
+		index--
+	}
+	return FsReadCloserAnnotation{
+		path:     r.paths[index],
+		position: r.position,
+	}
 }

--- a/pkg/parser/fsreader.go
+++ b/pkg/parser/fsreader.go
@@ -65,6 +65,13 @@ func SkipDirs() FilterFn {
 	}
 }
 
+// SkipEmpty skips empty files.
+func SkipEmpty() FilterFn {
+	return func(path string, info os.FileInfo) (bool, error) {
+		return info.Size() == 0, nil
+	}
+}
+
 // SkipNotYAML skips files that do not have YAML extension.
 func SkipNotYAML() FilterFn {
 	return func(path string, info os.FileInfo) (bool, error) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -131,7 +131,7 @@ func TestParser(t *testing.T) {
 		"FsBackendSkip": {
 			reason:  "should skip empty files and files without yaml extension",
 			parser:  New(metaScheme, objScheme),
-			backend: NewFsBackend(emptyFs, FsDir("."), FsFilters(SkipDirs(), SkipNotYAML())),
+			backend: NewFsBackend(emptyFs, FsDir("."), FsFilters(SkipDirs(), SkipEmpty(), SkipNotYAML())),
 			pkg:     NewPackage(),
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds the `AnnotatedReader` interface and an implementation in `FsReadCloser`. This allows a parser backend to provide additional context about the data being read if an error is encountered.

xref #229 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://github.com/crossplane/crossplane/pull/2014 for usage.

[contribution process]: https://git.io/fj2m9
