### PR TITLE
Introduce memory profiling server

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// Server represents a HTTP server to serve Memory Profiling.
+type Server interface {
+	// Start memory profiling server
+	Start()
+
+	// Stop memory profiling server
+	Stop()
+}
+
+const (
+	port = 9090
+)
+
+type profilingServer struct {
+	log    logging.Logger
+	server *http.Server
+}
+
+// NewServer creates a new HTTP server on port 9090 for Memory Profiling.
+func NewServer(log logging.Logger) Server {
+	mux := http.NewServeMux()
+
+	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+
+	server := &http.Server{
+		Addr:           fmt.Sprintf(":%d", port),
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   5 * time.Second,
+		MaxHeaderBytes: http.DefaultMaxHeaderBytes,
+		Handler:        mux,
+	}
+
+	return &profilingServer{log: log, server: server}
+}
+
+func (p *profilingServer) Start() {
+	go func() {
+		p.log.Debug("starting memory profiling server")
+		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			p.log.Debug("error starting memory profiling server", err)
+		}
+	}()
+}
+
+func (p *profilingServer) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	p.log.Debug("shutting down memory profiling server")
+	if err := p.server.Shutdown(ctx); err != nil {
+		p.log.Debug("error shutting down memory profiling server", err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Start standalone HTTP server on port 9090 dedicated for Memory
Profiling. This is mostly useful to be used in conjunction with
--debug flag from consuemers of crossplane-runtime. It exposes
the following endpoints:

- /debug/pprof/
- /debug/pprof/cmdline
- /debug/pprof/profile
- /debug/pprof/symbol
- /debug/pprof/trace
- /debug/pprof/goroutine
- /debug/pprof/heap
- /debug/pprof/threadcreate
- /debug/pprof/block

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partial fix for crossplane/crossplane#1846

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Locally build and deploy Crossplane by using this code and make sure I can access `http://localhost:9090/debug/pprof/` endpoints locally in browser.

[contribution process]: https://git.io/fj2m9
