### PR TITLE
Introduce IgnoreAny to be able to ignore more than one type of error

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -180,10 +180,22 @@ func MustGetKind(obj runtime.Object, ot runtime.ObjectTyper) schema.GroupVersion
 type ErrorIs func(err error) bool
 
 // Ignore any errors that satisfy the supplied ErrorIs function by returning
-// nil. Errors that do not satisfy the suppled function are returned unmodified.
+// nil. Errors that do not satisfy the supplied function are returned unmodified.
 func Ignore(is ErrorIs, err error) error {
 	if is(err) {
 		return nil
+	}
+	return err
+}
+
+// IgnoreAny ignores errors that satisfy any of the supplied ErrorIs functions
+// by returning nil. Errors that do not satisfy any of the supplied functions
+// are returned unmodified.
+func IgnoreAny(err error, is ...ErrorIs) error {
+	for _, f := range is {
+		if f(err) {
+			return nil
+		}
 	}
 	return err
 }

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -302,6 +302,53 @@ func TestIgnore(t *testing.T) {
 	}
 }
 
+func TestIgnoreAny(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		is  []ErrorIs
+		err error
+	}
+	cases := map[string]struct {
+		args args
+		want error
+	}{
+		"IgnoreError": {
+			args: args{
+				is:  []ErrorIs{func(err error) bool { return true }},
+				err: errBoom,
+			},
+			want: nil,
+		},
+		"IgnoreErrorArr": {
+			args: args{
+				is: []ErrorIs{
+					func(err error) bool { return true },
+					func(err error) bool { return false },
+				},
+				err: errBoom,
+			},
+			want: nil,
+		},
+		"PropagateError": {
+			args: args{
+				is:  []ErrorIs{func(err error) bool { return false }},
+				err: errBoom,
+			},
+			want: errBoom,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IgnoreAny(tc.args.err, tc.args.is...)
+			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
+				t.Errorf("Ignore(...): -want error, +got error:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestIsConditionTrue(t *testing.T) {
 	cases := map[string]struct {
 		c    xpv1.Condition


### PR DESCRIPTION
Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

I needed this to be able to append more `ErrorIs` functions to generated call from another file. I think even the original `Ignore` could be deprecated since this one covers it as well but I know it's used in many places so I kept it. Let me know of your thoughts about whether we should deprecate it and use this everywhere instead.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
