### PR TITLE
Make use of rate limiting in managed reconciler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.2.2
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	k8s.io/api v0.20.1
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.1

--- a/pkg/ratelimiter/default.go
+++ b/pkg/ratelimiter/default.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+)
+
+// DefaultProviderRPS is the recommended default average requeues per second
+// tolerated by a provider's controller manager.
+const DefaultProviderRPS = 1
+
+// NewDefaultProviderRateLimiter returns a token bucket rate limiter meant for
+// limiting the number of average total requeues per second for all controllers
+// registered with a controller manager. The bucket size is a linear function of
+// the requeues per second.
+func NewDefaultProviderRateLimiter(rps int) *workqueue.BucketRateLimiter {
+	return &workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(rps), rps*10)}
+}
+
+// NewDefaultManagedRateLimiter returns a rate limiter that takes the maximum
+// delay between the passed providerRateLimiter and a per-item exponential
+// backoff limiter. The exponential backoff limiter has a base delay of 1s and a
+// maximum of 60s.
+func NewDefaultManagedRateLimiter(providerRateLimiter ratelimiter.RateLimiter) ratelimiter.RateLimiter {
+	return workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second),
+		providerRateLimiter,
+	)
+}

--- a/pkg/ratelimiter/default.go
+++ b/pkg/ratelimiter/default.go
@@ -37,12 +37,11 @@ func NewDefaultProviderRateLimiter(rps int) *workqueue.BucketRateLimiter {
 }
 
 // NewDefaultManagedRateLimiter returns a rate limiter that takes the maximum
-// delay between the passed providerRateLimiter and a per-item exponential
-// backoff limiter. The exponential backoff limiter has a base delay of 1s and a
-// maximum of 60s.
-func NewDefaultManagedRateLimiter(providerRateLimiter ratelimiter.RateLimiter) ratelimiter.RateLimiter {
+// delay between the passed provider and a per-item exponential backoff limiter.
+// The exponential backoff limiter has a base delay of 1s and a maximum of 60s.
+func NewDefaultManagedRateLimiter(provider ratelimiter.RateLimiter) ratelimiter.RateLimiter {
 	return workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second),
-		providerRateLimiter,
+		provider,
 	)
 }

--- a/pkg/ratelimiter/default_test.go
+++ b/pkg/ratelimiter/default_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultMangedRateLimiter(t *testing.T) {
+	limiter := NewDefaultManagedRateLimiter(NewDefaultProviderRateLimiter(DefaultProviderRPS))
+	backoffSchedule := []int{1, 2, 4, 8, 16, 32, 60}
+	for _, d := range backoffSchedule {
+		if e, a := time.Duration(d)*time.Second, limiter.When("one"); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+	limiter.Forget("one")
+	if e, a := time.Duration(backoffSchedule[0])*time.Second, limiter.When("one"); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -42,8 +42,7 @@ const (
 	reconcileGracePeriod = 30 * time.Second
 	reconcileTimeout     = 1 * time.Minute
 
-	defaultManagedShortWait = 30 * time.Second
-	defaultManagedLongWait  = 1 * time.Minute
+	defaultpollInterval = 1 * time.Minute
 )
 
 // Error strings.
@@ -343,9 +342,8 @@ type Reconciler struct {
 	client     client.Client
 	newManaged func() resource.Managed
 
-	shortWait time.Duration
-	longWait  time.Duration
-	timeout   time.Duration
+	pollInterval time.Duration
+	timeout      time.Duration
 
 	// The below structs embed the set of interfaces used to implement the
 	// managed resource reconciler. We do this primarily for readability, so
@@ -400,24 +398,14 @@ func WithTimeout(duration time.Duration) ReconcilerOption {
 	}
 }
 
-// WithShortWait specifies how long the Reconciler should wait before queueing a
-// new reconciliation in 'short wait' scenarios. The Reconciler requeues after a
-// short wait when it knows it is waiting for an external operation to complete,
-// or when it encounters a potentially temporary error.
-func WithShortWait(after time.Duration) ReconcilerOption {
+// WithPollInterval specifies how long the Reconciler should wait before queueing
+// a new reconciliation after a successful reconcile. The Reconciler requeues
+// after a specified duration when it is not actively waiting for an external
+// operation, but wishes to check whether an existing external resource needs to
+// be synced to its Crossplane Managed resource.
+func WithPollInterval(after time.Duration) ReconcilerOption {
 	return func(r *Reconciler) {
-		r.shortWait = after
-	}
-}
-
-// WithLongWait specifies how long the Reconciler should wait before queueing a
-// new reconciliation in 'long wait' scenarios. The Reconciler requeues after a
-// long wait when it is not actively waiting for an external operation, but
-// wishes to check whether an existing external resource needs to be synced to
-// its Crossplane Managed resource.
-func WithLongWait(after time.Duration) ReconcilerOption {
-	return func(r *Reconciler) {
-		r.longWait = after
+		r.pollInterval = after
 	}
 }
 
@@ -492,15 +480,14 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOp
 	_ = nm()
 
 	r := &Reconciler{
-		client:     m.GetClient(),
-		newManaged: nm,
-		shortWait:  defaultManagedShortWait,
-		longWait:   defaultManagedLongWait,
-		timeout:    reconcileTimeout,
-		managed:    defaultMRManaged(m),
-		external:   defaultMRExternal(),
-		log:        logging.NewNopLogger(),
-		record:     event.NewNopRecorder(),
+		client:       m.GetClient(),
+		newManaged:   nm,
+		pollInterval: defaultpollInterval,
+		timeout:      reconcileTimeout,
+		managed:      defaultMRManaged(m),
+		external:     defaultMRExternal(),
+		log:          logging.NewNopLogger(),
+		record:       event.NewNopRecorder(),
 	}
 
 	for _, ro := range o {
@@ -545,10 +532,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// If this is the first time we encounter this issue we'll be requeued
 		// implicitly when we update our status with the new error condition.
 		// If not, we want to try again after a short wait.
-		log.Debug("Cannot initialize managed resource", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot initialize managed resource", "error", err)
 		record.Event(managed, event.Warning(reasonCannotInitialize, err))
 		managed.SetConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	// We resolve any references before observing our external resource because
@@ -566,10 +553,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 			// encountered an error resolving them) we want to try again after a
 			// short wait. If this is the first time we encounter this situation
 			// we'll be requeued implicitly due to the status update.
-			log.Debug("Cannot resolve managed resource references", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Cannot resolve managed resource references", "error", err)
 			record.Event(managed, event.Warning(reasonCannotResolveRefs, err))
 			managed.SetConditions(xpv1.ReconcileError(err))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 	}
 
@@ -579,10 +566,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// or invalid. If this is first time we encounter this issue we'll be
 		// requeued implicitly when we update our status with the new error
 		// condition. If not, we want to try again after a short wait.
-		log.Debug("Cannot connect to provider", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot connect to provider", "error", err)
 		record.Event(managed, event.Warning(reasonCannotConnect, err))
 		managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileConnect)))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	observation, err := external.Observe(externalCtx, managed)
@@ -592,10 +579,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// concerned with. If this is the first time we encounter this issue
 		// we'll be requeued implicitly when we update our status with the new
 		// error condition. If not, we want to try again after a short wait.
-		log.Debug("Cannot observe external resource", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot observe external resource", "error", err)
 		record.Event(managed, event.Warning(reasonCannotObserve, err))
 		managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileObserve)))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	if meta.WasDeleted(managed) {
@@ -609,10 +596,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 				// issue we'll be requeued implicitly when we update our status with
 				// the new error condition. If not, we want to try again after a
 				// short wait.
-				log.Debug("Cannot delete external resource", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+				log.Debug("Cannot delete external resource", "error", err, "requeue-after")
 				record.Event(managed, event.Warning(reasonCannotDelete, err))
 				managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileDelete)))
-				return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+				return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 			}
 
 			// We've successfully requested deletion of our external resource.
@@ -622,27 +609,27 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 			// we'll skip this block on the next reconcile and proceed to
 			// unpublish and finalize. If it still exists we'll re-enter this
 			// block and try again.
-			log.Debug("Successfully requested deletion of external resource", "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Successfully requested deletion of external resource")
 			record.Event(managed, event.Normal(reasonDeleted, "Successfully requested deletion of external resource"))
 			managed.SetConditions(xpv1.ReconcileSuccess())
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 		if err := r.managed.UnpublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {
 			// If this is the first time we encounter this issue we'll be
 			// requeued implicitly when we update our status with the new error
 			// condition. If not, we want to try again after a short wait.
-			log.Debug("Cannot unpublish connection details", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Cannot unpublish connection details", "error", err)
 			record.Event(managed, event.Warning(reasonCannotUnpublish, err))
 			managed.SetConditions(xpv1.ReconcileError(err))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(resource.IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 		if err := r.managed.RemoveFinalizer(ctx, managed); err != nil {
 			// If this is the first time we encounter this issue we'll be
 			// requeued implicitly when we update our status with the new error
 			// condition. If not, we want to try again after a short wait.
-			log.Debug("Cannot remove managed resource finalizer", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Cannot remove managed resource finalizer", "error", err)
 			managed.SetConditions(xpv1.ReconcileError(err))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(resource.IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 
 		// We've successfully deleted our external resource (if necessary) and
@@ -657,19 +644,19 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// If this is the first time we encounter this issue we'll be requeued
 		// implicitly when we update our status with the new error condition. If
 		// not, we want to try again after a short wait.
-		log.Debug("Cannot publish connection details", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot publish connection details", "error", err)
 		record.Event(managed, event.Warning(reasonCannotPublish, err))
 		managed.SetConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	if err := r.managed.AddFinalizer(ctx, managed); err != nil {
 		// If this is the first time we encounter this issue we'll be
 		// requeued implicitly when we update our status with the new error
 		// condition. If not, we want to try again after a short wait.
-		log.Debug("Cannot add finalizer", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot add finalizer", "error", err)
 		managed.SetConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(resource.IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	if !observation.ResourceExists {
@@ -681,10 +668,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 			// issue we'll be requeued implicitly when we update our status with
 			// the new error condition. If not, we want to try again after a
 			// short wait.
-			log.Debug("Cannot create external resource", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Cannot create external resource", "error", err)
 			record.Event(managed, event.Warning(reasonCannotCreate, err))
 			managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileCreate)))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 
 		if creation.ExternalNameAssigned {
@@ -702,10 +689,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 				return r.client.Update(ctx, managed)
 			})
 			if err != nil {
-				log.Debug("Cannot update managed resource", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+				log.Debug("Cannot update managed resource", "error", err)
 				record.Event(managed, event.Warning(reasonCannotUpdateManaged, errors.Wrap(err, errUpdateManagedAfterCreate)))
 				managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errUpdateManagedAfterCreate)))
-				return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+				return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 			}
 		}
 
@@ -713,20 +700,20 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 			// If this is the first time we encounter this issue we'll be
 			// requeued implicitly when we update our status with the new error
 			// condition. If not, we want to try again after a short wait.
-			log.Debug("Cannot publish connection details", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug("Cannot publish connection details", "error", err)
 			record.Event(managed, event.Warning(reasonCannotPublish, err))
 			managed.SetConditions(xpv1.ReconcileError(err))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 
 		// We've successfully created our external resource. In many cases the
 		// creation process takes a little time to finish. We requeue a short
 		// wait in order to observe the external resource to determine whether
 		// it's ready for use.
-		log.Debug("Successfully requested creation of external resource", "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Successfully requested creation of external resource")
 		record.Event(managed, event.Normal(reasonCreated, "Successfully requested creation of external resource"))
 		managed.SetConditions(xpv1.ReconcileSuccess())
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	if observation.ResourceLateInitialized {
@@ -738,10 +725,10 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// an immediate reconcile which should re-observe the external resource
 		// and persist its status.
 		if err := r.client.Update(ctx, managed); err != nil {
-			log.Debug(errUpdateManaged, "error", err, "requeue-after", time.Now().Add(r.shortWait))
+			log.Debug(errUpdateManaged, "error", err)
 			record.Event(managed, event.Warning(reasonCannotUpdateManaged, err))
 			managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errUpdateManaged)))
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 	}
 
@@ -751,9 +738,9 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// resource we manage changes, so we requeue a speculative reconcile
 		// after a long wait in order to observe it and react accordingly.
 		// https://github.com/crossplane/crossplane/issues/289
-		log.Debug("External resource is up to date", "requeue-after", time.Now().Add(r.longWait))
+		log.Debug("External resource is up to date", "requeue-after", time.Now().Add(r.pollInterval))
 		managed.SetConditions(xpv1.ReconcileSuccess())
-		return reconcile.Result{RequeueAfter: r.longWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	update, err := external.Update(externalCtx, managed)
@@ -763,20 +750,20 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// it. If this is the first time we encounter this issue we'll be
 		// requeued implicitly when we update our status with the new error
 		// condition. If not, we want to try again after a short wait.
-		log.Debug("Cannot update external resource", "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot update external resource")
 		record.Event(managed, event.Warning(reasonCannotUpdate, err))
 		managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileUpdate)))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	if err := r.managed.PublishConnection(ctx, managed, update.ConnectionDetails); err != nil {
 		// If this is the first time we encounter this issue we'll be requeued
 		// implicitly when we update our status with the new error condition. If
 		// not, we want to try again after a short wait.
-		log.Debug("Cannot publish connection details", "error", err, "requeue-after", time.Now().Add(r.shortWait))
+		log.Debug("Cannot publish connection details", "error", err)
 		record.Event(managed, event.Warning(reasonCannotPublish, err))
 		managed.SetConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	// We've successfully updated our external resource. Per the below issue
@@ -784,8 +771,8 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 	// changes, so we requeue a speculative reconcile after a long wait in order
 	// to observe it and react accordingly.
 	// https://github.com/crossplane/crossplane/issues/289
-	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(r.longWait))
+	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(r.pollInterval))
 	record.Event(managed, event.Normal(reasonUpdated, "Successfully requested update of external resource"))
 	managed.SetConditions(xpv1.ReconcileSuccess())
-	return reconcile.Result{RequeueAfter: r.longWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+	return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 }

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -106,7 +106,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ResolveReferencesError": {
 			reason: "Errors during reference resolution references should trigger a requeue after a short wait.",
@@ -134,7 +134,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalConnectError": {
 			reason: "Errors connecting to the provider should trigger a requeue after a short wait.",
@@ -162,7 +162,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalObserveError": {
 			reason: "Errors observing the external resource should trigger a requeue after a short wait.",
@@ -195,7 +195,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalDeleteError": {
 			reason: "Errors deleting the external resource should trigger a requeue after a short wait.",
@@ -239,7 +239,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalDeleteSuccessful": {
 			reason: "A deleted managed resource with the 'delete' reclaim policy should delete its external resource then requeue after a short wait.",
@@ -283,7 +283,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"UnpublishConnectionDetailsError": {
 			reason: "Errors unpublishing connection details should trigger a requeue after a short wait.",
@@ -325,7 +325,7 @@ func TestReconciler(t *testing.T) {
 					}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"RemoveFinalizerError": {
 			reason: "Errors removing the managed resource finalizer should trigger a requeue after a short wait.",
@@ -366,7 +366,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"DeleteSuccessful": {
 			reason: "Successful managed resource deletion should not trigger a requeue or status update.",
@@ -427,7 +427,7 @@ func TestReconciler(t *testing.T) {
 					}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"AddFinalizerError": {
 			reason: "Errors adding a finalizer should trigger a requeue after a short wait.",
@@ -456,7 +456,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateExternalError": {
 			reason: "Errors while creating an external resource should trigger a requeue after a short wait.",
@@ -495,7 +495,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"PublishCreationConnectionDetailsError": {
 			reason: "Errors publishing connection details after creation should trigger a requeue after a short wait.",
@@ -545,7 +545,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateSuccessful": {
 			reason: "Successful managed resource creation should trigger a requeue after a short wait.",
@@ -574,7 +574,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateWithExternalNameAssignmentSuccessful": {
 			reason: "Successful managed resource creation with external name assignment should trigger an update.",
@@ -616,7 +616,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateWithExternalNameAssignmentGetError": {
 			reason: "If the Get call during the update after Create does not go through, we need to inform the user and requeue shortly.",
@@ -662,7 +662,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateWithExternalNameAssignmentUpdateError": {
 			reason: "If the update after Create does not go through, we need to inform the user and requeue shortly.",
@@ -704,7 +704,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"LateInitializeUpdateError": {
 			reason: "Errors updating a managed resource to persist late initialized fields should trigger a requeue after a short wait.",
@@ -741,7 +741,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalResourceUpToDate": {
 			reason: "When the external resource exists and is up to date a requeue should be triggered after a long wait.",
@@ -777,7 +777,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedLongWait}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
 		},
 		"UpdateExternalError": {
 			reason: "Errors while updating an external resource should trigger a requeue after a short wait.",
@@ -816,7 +816,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"PublishUpdateConnectionDetailsError": {
 			reason: "Errors publishing connection details after an update should trigger a requeue after a short wait.",
@@ -866,7 +866,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"UpdateSuccessful": {
 			reason: "A successful managed resource update should trigger a requeue after a long wait.",
@@ -905,7 +905,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedLongWait}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates managed reconciler to return Requeue: true instead of
RequeueAfter when encountering non-status update errors. This allows the
reconciler to make use of the controller rate limiter rather use a
constant value for requeuing after errors.

This also renames longWait to pollInterval to more accurately reflect
its behavior, and adds default rate limiters to be used at both the provider and
controller level. The provider rate limiter is a configurable token
bucket and the controller limiter is a max of limiter that uses the
provider limiter and a per-item exponential backoff.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref #40 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
