### PR TITLE
Set namespace when looking up resource with externalName

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -687,7 +687,7 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 			// of the loop. In that case, we warn the user that the external resource
 			// might be leaked.
 			err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
-				nn := types.NamespacedName{Name: managed.GetName()}
+				nn := types.NamespacedName{Name: managed.GetName(), Namespace: managed.GetNamespace()}
 				if err := r.client.Get(ctx, nn, managed); err != nil {
 					return err
 				}


### PR DESCRIPTION
### Description of your changes

Set namespace when looking up resource with externalName.

Fixes #245 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.