### PR TITLE
Use OpenAPI to set the default ProviderConfig

### DIFF
--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -139,6 +139,7 @@ type ResourceSpec struct {
 	// ProviderConfigReference specifies how the provider that will be used to
 	// create, observe, update, and delete this managed resource should be
 	// configured.
+	// +kubebuilder:default={"name": "default"}
 	ProviderConfigReference *Reference `json:"providerConfigRef,omitempty"`
 
 	// ProviderReference specifies the provider that will be used to create,

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -58,9 +58,11 @@ func (a *NameAsExternalName) Initialize(ctx context.Context, mg resource.Managed
 
 // DefaultProviderConfig fills the ProviderConfigRef with `default` if it's left
 // empty.
+// Deprecated: Use OpenAPI schema defaulting instead.
 type DefaultProviderConfig struct{ client client.Client }
 
 // NewDefaultProviderConfig returns a new DefaultProviderConfig.
+// Deprecated: Use OpenAPI schema defaulting instead.
 func NewDefaultProviderConfig(c client.Client) *DefaultProviderConfig {
 	return &DefaultProviderConfig{client: c}
 }

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -367,11 +367,8 @@ func defaultMRManaged(m manager.Manager) mrManaged {
 	return mrManaged{
 		ConnectionPublisher: NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
 		Finalizer:           resource.NewAPIFinalizer(m.GetClient(), managedFinalizerName),
-		Initializer: InitializerChain{
-			NewDefaultProviderConfig(m.GetClient()),
-			NewNameAsExternalName(m.GetClient()),
-		},
-		ReferenceResolver: NewAPISimpleReferenceResolver(m.GetClient()),
+		Initializer:         NewNameAsExternalName(m.GetClient()),
+		ReferenceResolver:   NewAPISimpleReferenceResolver(m.GetClient()),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This allows us to avoid an extra update call to the API server when new managed resources are created.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I've tested this by building provider-gcp against this commit, and ensuring that `spec.providerConfigRef.name` is defaulted even when the provider is not running.

[contribution process]: https://git.io/fj2m9
