### PR TITLE
Have managed resource DeletionPolicy default to 'Delete'

### DIFF
--- a/apis/common/v1/policies.go
+++ b/apis/common/v1/policies.go
@@ -18,6 +18,7 @@ package v1
 
 // A DeletionPolicy determines what should happen to the underlying external
 // resource when a managed resource is deleted.
+// +kubebuilder:validation:Enum=Orphan;Delete
 type DeletionPolicy string
 
 const (

--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -149,11 +149,9 @@ type ResourceSpec struct {
 
 	// DeletionPolicy specifies what will happen to the underlying external
 	// when this managed resource is deleted - either "Delete" or "Orphan" the
-	// external resource. The "Delete" policy is the default when no policy is
-	// specified.
-	//
+	// external resource.
 	// +optional
-	// +kubebuilder:validation:Enum=Orphan;Delete
+	// +kubebuilder:default=Delete
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Nic Cope <negz@rk0n.org>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane-runtime/issues/205

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I added a `replace` to my my `provider-gcp` `go.mod` and ran `make generate`:

```diff
--- a/package/crds/cache.gcp.crossplane.io_cloudmemorystoreinstances.yaml
+++ b/package/crds/cache.gcp.crossplane.io_cloudmemorystoreinstances.yaml
@@ -51,7 +51,8 @@ spec:
             description: A CloudMemorystoreInstanceSpec defines the desired state of a CloudMemorystoreInstance.
             properties:
               deletionPolicy:
-                description: DeletionPolicy specifies what will happen to the underlying external when this managed resource is deleted - either "Delete" or "Orphan" the external resource. The "Delete" policy is the default when no policy is specified.
+                default: Delete
+                description: DeletionPolicy specifies what will happen to the underlying external when this managed resource is deleted - either "Delete" or "Orphan" the external resource.
                 enum:
                 - Orphan
                 - Delete
@@ -106,6 +107,8 @@ spec:
                 - tier
                 type: object
               providerConfigRef:
+                default:
+                  name: default
                 description: ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed resource should be configured.
                 properties:
                   name:
```

Note the providerConfigRed change is because provider-gcp `master` hasn't been bumped to include https://github.com/crossplane/crossplane-runtime/pull/252 yet. 

[contribution process]: https://git.io/fj2m9
