### PR TITLE
Unpublish connection details and remove finalizer without attempting to connect to external client when deletion policy is Orphan

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -629,7 +629,9 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
 		managed.SetConditions(xpv1.Deleting())
 
-		if observation.ResourceExists && managed.GetDeletionPolicy() != xpv1.DeletionOrphan {
+		// We'll only reach this point if deletion policy is not orphan, so we
+		// are safe to call external deletion if external resource exists.
+		if observation.ResourceExists {
 			if err := external.Delete(externalCtx, managed); err != nil {
 				// We'll hit this condition if we can't delete our external
 				// resource, for example if our provider credentials don't have

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -525,6 +525,46 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		"external-name", meta.GetExternalName(managed),
 	)
 
+	// If managed resource has a deletion timestamp and and a deletion policy of
+	// Orphan, we do not need to observe the external resource before attempting
+	// to unpublish connection details and remove finalizer.
+	if meta.WasDeleted(managed) && managed.GetDeletionPolicy() == xpv1.DeletionOrphan {
+		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
+		managed.SetConditions(xpv1.Deleting())
+
+		// Empty ConnectionDetails are passed to UnpublishConnection because we
+		// have not retrieved them from the external resource. In practice we
+		// currently only write connection details to a Secret, and we rely on
+		// garbage collection to delete the entire secret, regardless of the
+		// supplied connection details.
+		if err := r.managed.UnpublishConnection(ctx, managed, ConnectionDetails{}); err != nil {
+			// If this is the first time we encounter this issue we'll be
+			// requeued implicitly when we update our status with the new error
+			// condition. If not, we requeue explicitly, which will trigger
+			// backoff.
+			log.Debug("Cannot unpublish connection details", "error", err)
+			record.Event(managed, event.Warning(reasonCannotUnpublish, err))
+			managed.SetConditions(xpv1.ReconcileError(err))
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		}
+		if err := r.managed.RemoveFinalizer(ctx, managed); err != nil {
+			// If this is the first time we encounter this issue we'll be
+			// requeued implicitly when we update our status with the new error
+			// condition. If not, we requeue explicitly, which will trigger
+			// backoff.
+			log.Debug("Cannot remove managed resource finalizer", "error", err)
+			managed.SetConditions(xpv1.ReconcileError(err))
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		}
+
+		// We've successfully unpublished our managed resource's connection
+		// details and removed our finalizer. If we assume we were the only
+		// controller that added a finalizer to this resource then it should no
+		// longer exist and thus there is no point trying to update its status.
+		log.Debug("Successfully deleted managed resource")
+		return reconcile.Result{Requeue: false}, nil
+	}
+
 	if err := r.managed.Initialize(ctx, managed); err != nil {
 		// If this is the first time we encounter this issue we'll be requeued
 		// implicitly when we update our status with the new error condition. If

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -627,9 +627,9 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 
 	if meta.WasDeleted(managed) {
 		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
+		managed.SetConditions(xpv1.Deleting())
 
 		if observation.ResourceExists && managed.GetDeletionPolicy() != xpv1.DeletionOrphan {
-			managed.SetConditions(xpv1.Deleting())
 			if err := external.Delete(externalCtx, managed); err != nil {
 				// We'll hit this condition if we can't delete our external
 				// resource, for example if our provider credentials don't have


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR adds the following functionality to the managed reconciler (see individual commits for more detail):
- Modifies managed reconciler to skip attempting to connect to external
client as well as initialize and resolve references when managed
resource has deletion timestamp and deletion policy is orphan.
- Updates the status of managed resource to be set to deleting in the case
where an external resource does not exist, but we fail to unpublish
connection or remove finalizer.
- Now that the managed reconciler will handle deletion with policy Orphan
early, there is no need to check that deletion policy is not orphan when
handling a managed resource with deletion timestamp set and external
resource exists.

Fixes #256 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
