### PR TITLE
Add IsNamed predicate

### DIFF
--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -135,3 +135,14 @@ func IsPropagated() PredicateFn {
 		return nn.Namespace != "" && nn.Name != ""
 	}
 }
+
+// IsNamed accepts objects that is named as the given name.
+func IsNamed(name string) PredicateFn {
+	return func(obj runtime.Object) bool {
+		mo, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		return mo.GetName() == name
+	}
+}

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -265,3 +265,35 @@ func TestIsPropagated(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNamed(t *testing.T) {
+	cases := map[string]struct {
+		name string
+		obj  runtime.Object
+		want bool
+	}{
+		"NoObjectMeta": {
+			name: "test",
+			want: false,
+		},
+		"NameDoesNotMatch": {
+			name: "test",
+			obj:  &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: "not-test"}},
+			want: false,
+		},
+		"NameMatches": {
+			name: "test",
+			obj:  &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: "test"}},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IsNamed(tc.name)(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("IsNamed(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example


-->
Adds `IsNamed` predicate to filter resources with name.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
