### PR TITLE
Add Retry Logic for APISecretPublisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ external-dns-*.tgz
 gitlab-*.tgz
 gitlab-gcp.yaml
 gitlab/
+
+# ignore IDE folders
+.vscode/
+.idea/

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -87,7 +87,11 @@ type APISecretPublisher struct {
 func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPublisher {
 	// NOTE(negz): We transparently inject an APIPatchingApplicator in order to maintain
 	// backward compatibility with the original API of this function.
-	return &APISecretPublisher{secret: resource.NewAPIPatchingApplicator(c), typer: ot}
+	return &APISecretPublisher{
+		secret: resource.NewApplicatorWithRetry(resource.NewAPIPatchingApplicator(c),
+			resource.IsAPIErrorWrapped, nil),
+		typer: ot,
+	}
 }
 
 // PublishConnection publishes the supplied ConnectionDetails to a Secret in the

--- a/pkg/resource/reference_test.go
+++ b/pkg/resource/reference_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReferenceStatusType_String(t *testing.T) {
+	tests := map[string]struct {
+		t    ReferenceStatusType
+		want string
+	}{
+		"ReferenceStatusUnknown": {
+			t:    ReferenceStatusUnknown,
+			want: "Unknown",
+		},
+		"ReferenceNotFound": {
+			t:    ReferenceNotFound,
+			want: "NotFound",
+		},
+		"ReferenceNotReady": {
+			t:    ReferenceNotReady,
+			want: "NotReady",
+		},
+		"ReferenceReady": {
+			t:    ReferenceReady,
+			want: "Ready",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.t.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReferenceStatus_String(t *testing.T) {
+	tests := map[string]struct {
+		rs   ReferenceStatus
+		want string
+	}{
+		"test-name-ready": {
+			rs: ReferenceStatus{
+				Name:   "test-name",
+				Status: ReferenceReady,
+			},
+			want: fmt.Sprintf("{reference:test-name status:%s}", ReferenceReady.String()),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.rs.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds `resource.ApplicatorWithRetry` that can retry application of a nested `resource.Applicator` on designated errors with the designated schedule. And it further uses a `resource.ApplicatorWithRetry` to introduce retries during connection secret publication.

Fixes #263 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- I have manually tested this change in crossplane-runtime together with a custom build of provider-gcp & `v1alpha1.ServiceAccountKey`, which published a connection secret.
- Unit tests are also introduced with this PR.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
