### PR TITLE
Implement a LateInitializer struct for use by providers

### DIFF
--- a/pkg/resource/late_initializer.go
+++ b/pkg/resource/late_initializer.go
@@ -41,12 +41,18 @@ func (li *LateInitializer) IsChanged() bool {
 	return li.changed
 }
 
+// SetChanged marks the LateInitializer such that users can tell whether any
+// of the late initialization calls returned the non-original argument.
+func (li *LateInitializer) SetChanged() {
+	li.changed = true
+}
+
 // LateInitializeStringPtr implements late initialization for *string.
 func (li *LateInitializer) LateInitializeStringPtr(org *string, from *string) *string {
 	if org != nil || from == nil {
 		return org
 	}
-	li.changed = true
+	li.SetChanged()
 	return from
 }
 
@@ -55,7 +61,7 @@ func (li *LateInitializer) LateInitializeInt64Ptr(org *int64, from *int64) *int6
 	if org != nil || from == nil {
 		return org
 	}
-	li.changed = true
+	li.SetChanged()
 	return from
 }
 
@@ -64,7 +70,7 @@ func (li *LateInitializer) LateInitializeBoolPtr(org *bool, from *bool) *bool {
 	if org != nil || from == nil {
 		return org
 	}
-	li.changed = true
+	li.SetChanged()
 	return from
 }
 
@@ -74,7 +80,7 @@ func (li *LateInitializer) LateInitializeTimePtr(org *metav1.Time, from *time.Ti
 	if org != nil || from == nil {
 		return org
 	}
-	li.changed = true
+	li.SetChanged()
 	t := metav1.NewTime(*from)
 	return &t
 }

--- a/pkg/resource/late_initializer.go
+++ b/pkg/resource/late_initializer.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewLateInitializer returns a new instance of *LateInitializer.
+func NewLateInitializer() *LateInitializer {
+	return &LateInitializer{}
+}
+
+// LateInitializer contains functions to late initialize two fields with varying
+// types. The main purpose of LateInitializer is to be able to report whether
+// anything different from the original value has been returned after all late
+// initialization calls.
+type LateInitializer struct {
+	changed bool
+}
+
+// IsChanged reports whether the second argument is ever used in late initialization
+// function calls.
+func (li *LateInitializer) IsChanged() bool {
+	return li.changed
+}
+
+// LateInitializeStringPtr implements late initialization for *string.
+func (li *LateInitializer) LateInitializeStringPtr(org *string, from *string) *string {
+	if org != nil || from == nil {
+		return org
+	}
+	li.changed = true
+	return from
+}
+
+// LateInitializeInt64Ptr implements late initialization for *int64.
+func (li *LateInitializer) LateInitializeInt64Ptr(org *int64, from *int64) *int64 {
+	if org != nil || from == nil {
+		return org
+	}
+	li.changed = true
+	return from
+}
+
+// LateInitializeBoolPtr implements late initialization for *bool.
+func (li *LateInitializer) LateInitializeBoolPtr(org *bool, from *bool) *bool {
+	if org != nil || from == nil {
+		return org
+	}
+	li.changed = true
+	return from
+}
+
+// LateInitializeTimePtr implements late initialization for *metav1.Time from
+// *time.Time.
+func (li *LateInitializer) LateInitializeTimePtr(org *metav1.Time, from *time.Time) *metav1.Time {
+	if org != nil || from == nil {
+		return org
+	}
+	li.changed = true
+	t := metav1.NewTime(*from)
+	return &t
+}

--- a/pkg/resource/late_initializer_test.go
+++ b/pkg/resource/late_initializer_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLateInitializeStringPtr(t *testing.T) {
+	s1 := "desired"
+	s2 := "observed"
+	type args struct {
+		org  *string
+		from *string
+	}
+	type want struct {
+		result  *string
+		changed bool
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Original": {
+			args: args{
+				org:  &s1,
+				from: &s2,
+			},
+			want: want{
+				result:  &s1,
+				changed: false,
+			},
+		},
+		"LateInitialized": {
+			args: args{
+				org:  nil,
+				from: &s2,
+			},
+			want: want{
+				result:  &s2,
+				changed: true,
+			},
+		},
+		"Neither": {
+			args: args{
+				org:  nil,
+				from: nil,
+			},
+			want: want{
+				result:  nil,
+				changed: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			li := NewLateInitializer()
+			got := li.LateInitializeStringPtr(tc.org, tc.from)
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("LateInitializeStringPtr(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLateInitializeInt64Ptr(t *testing.T) {
+	i1 := int64(10)
+	i2 := int64(20)
+	type args struct {
+		org  *int64
+		from *int64
+	}
+	type want struct {
+		result  *int64
+		changed bool
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Original": {
+			args: args{
+				org:  &i1,
+				from: &i2,
+			},
+			want: want{
+				result:  &i1,
+				changed: false,
+			},
+		},
+		"LateInitialized": {
+			args: args{
+				org:  nil,
+				from: &i2,
+			},
+			want: want{
+				result:  &i2,
+				changed: true,
+			},
+		},
+		"Neither": {
+			args: args{
+				org:  nil,
+				from: nil,
+			},
+			want: want{
+				result:  nil,
+				changed: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			li := NewLateInitializer()
+			got := li.LateInitializeInt64Ptr(tc.org, tc.from)
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("LateInitializeBoolPtr(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLateInitializeBoolPtr(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	type args struct {
+		org  *bool
+		from *bool
+	}
+	type want struct {
+		result  *bool
+		changed bool
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Original": {
+			args: args{
+				org:  &trueVal,
+				from: &falseVal,
+			},
+			want: want{
+				result:  &trueVal,
+				changed: false,
+			},
+		},
+		"LateInitialized": {
+			args: args{
+				org:  nil,
+				from: &trueVal,
+			},
+			want: want{
+				result:  &trueVal,
+				changed: true,
+			},
+		},
+		"Neither": {
+			args: args{
+				org:  nil,
+				from: nil,
+			},
+			want: want{
+				result:  nil,
+				changed: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			li := NewLateInitializer()
+			got := li.LateInitializeBoolPtr(tc.org, tc.from)
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("LateInitializeBoolPtr(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLateInitializeTimePtr(t *testing.T) {
+	t1 := metav1.Now()
+	t2 := time.Now().Add(time.Minute)
+	t2m := metav1.NewTime(t2)
+	type args struct {
+		org  *metav1.Time
+		from *time.Time
+	}
+	type want struct {
+		result  *metav1.Time
+		changed bool
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Original": {
+			args: args{
+				org:  &t1,
+				from: &t2,
+			},
+			want: want{
+				result:  &t1,
+				changed: false,
+			},
+		},
+		"LateInitialized": {
+			args: args{
+				org:  nil,
+				from: &t2,
+			},
+			want: want{
+				result:  &t2m,
+				changed: true,
+			},
+		},
+		"Neither": {
+			args: args{
+				org:  nil,
+				from: nil,
+			},
+			want: want{
+				result:  nil,
+				changed: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			li := NewLateInitializer()
+			got := li.LateInitializeTimePtr(tc.org, tc.from)
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("LateInitializeTimePtr(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`LateInitializer` will help providers figure out whether a change has been made and spec update is needed after the late initialization without using `DeepCopy` of the original and changed objects.

I wanted to include only the bare minimum I need for generated ACK resources where the source and target field types are the same to be conservative about what we expose. We can add more as needed.

Example usage:
```go
func lateInitialize(cr *svcapitypes.Table, resp *svcsdk.DescribeTableOutput) bool {
  li := awsclients.NewLateInitializer()
  cr.Spec.ForProvider.Property = li.LateInitializeStringPtr(cr.Spec.ForProvider.Property, resp.Table.Property)
  // .. many calls using the same li object ...
  return li.IsChanged()
}
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
