### PR TITLE
Use YAML document terminators and skip empty documents in parser

### DIFF
--- a/pkg/parser/fsreader.go
+++ b/pkg/parser/fsreader.go
@@ -119,12 +119,14 @@ func (r *FsReadCloser) Read(p []byte) (n int, err error) {
 		r.index++
 		r.position = 0
 		r.wroteBreak = false
+		n = copy(p, "\n---\n")
+		return n, nil
 	}
 	if r.index == len(r.paths) {
 		return 0, io.EOF
 	}
 	if r.writeBreak {
-		n = copy(p, "\n---\n")
+		n = copy(p, "\n...\n")
 		r.writeBreak = false
 		r.wroteBreak = true
 		return n, nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -114,6 +115,18 @@ func (p *PackageParser) Parse(ctx context.Context, reader io.ReadCloser) (*Packa
 		if err != nil {
 			o, _, err := do.Decode(bytes, nil, nil)
 			if err != nil {
+				empty := true
+				for _, b := range bytes {
+					if !unicode.IsSpace(rune(b)) {
+						empty = false
+						break
+					}
+				}
+				// If the YAML document only contains Unicode White Space we
+				// ignore and do not return an error.
+				if empty {
+					continue
+				}
 				if anno, ok := reader.(AnnotatedReadCloser); ok {
 					return pkg, errors.Wrap(err, fmt.Sprintf("%+v", anno.Annotate()))
 				}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -38,6 +38,21 @@ kind: CustomResourceDefinition
 metadata:
   name: test`)
 
+	whitespaceBytes = []byte(`---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: test
+---
+
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: test`)
+
 	deployBytes = []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,6 +68,7 @@ func TestParser(t *testing.T) {
 	allBytes := bytes.Join([][]byte{crdBytes, deployBytes}, []byte("\n---\n"))
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "crd.yaml", crdBytes, 0o644)
+	_ = afero.WriteFile(fs, "whitespace.yaml", whitespaceBytes, 0o644)
 	_ = afero.WriteFile(fs, "deployment.yaml", deployBytes, 0o644)
 	_ = afero.WriteFile(fs, "some/nested/dir/crd.yaml", crdBytes, 0o644)
 	_ = afero.WriteFile(fs, ".crossplane/bad.yaml", crdBytes, 0o644)
@@ -109,7 +125,7 @@ func TestParser(t *testing.T) {
 			backend: NewFsBackend(fs, FsDir("."), FsFilters(SkipDirs(), SkipNotYAML(), SkipPath(".crossplane/*"))),
 			pkg: &Package{
 				meta:    []runtime.Object{deploy},
-				objects: []runtime.Object{crd, crd},
+				objects: []runtime.Object{crd, crd, crd, crd},
 			},
 		},
 		"FsBackendAll": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

YAML supports a document terminator (...) when reading files in a
stream. This allows for the reader to indicate that the current document
has ended without indicating that the stream is finished. Anything after
the document terminator is ignored by the consumer. Therefore, we write
the terminator at the end of a read file, then immediately follow with a
YAML document separator (---), which is mandatory according to the YAML
spec when using document terminators.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

If a document contains only whitespace and we are not able to decode it
into one of the supported schemas, we ignore it and continue. We want to
avoid skipping a type that does not have a registered schema so that we
do not silently ignore errors when package building, but we consider it
safe to assume that a YAML document with no content is safe to skip.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Reference: https://yaml.org/spec/1.2/spec.html#id2801681

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have updated unit tests to demonstrate this functionality, as well as testing on a variety of existing packages. One important distinction here is that consecutive separators (`---`) or trailing separators in a YAML document can still cause an error as they are interpreted as document begin / end. So multiple consecutive separators can produce a document with literal `---` as content and a trailing separator can produce a document with literal `...` as content.

Overall, this expands the range of valid YAML that the Crossplane CLI and package manager will accept.

[contribution process]: https://git.io/fj2m9
