### PR TITLE
Added verbose logging option when resource is updated

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -307,11 +307,11 @@ type ExternalObservation struct {
 	// credentials to a store (e.g. a Secret).
 	ConnectionDetails ConnectionDetails
 
-	// ObservationMessage is a Debug level message that is sent to the
-	// reconciler when there is a change in the observed Managed Resource.
-	// It is useful for finding what change there is between what was
-	// observed and the resource's definition.
-	ObservationMessage string
+	// Diff is a Debug level message that is sent to the reconciler when
+	// there is a change in the observed Managed Resource. It is useful for
+	// finding where the observed diverges from the desired state.
+	// The string should be a cmp.Diff that details the difference.
+	Diff string
 }
 
 // An ExternalCreation is the result of the creation of an external resource.
@@ -795,7 +795,9 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
-	log.Debug(observation.ObservationMessage)
+	if observation.Diff != "" {
+		log.Debug("External resource differs from desired state", "diff", observation.Diff)
+	}
 
 	update, err := external.Update(externalCtx, managed)
 	if err != nil {

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -306,6 +306,12 @@ type ExternalObservation struct {
 	// unless an existing key is overwritten. Crossplane may publish these
 	// credentials to a store (e.g. a Secret).
 	ConnectionDetails ConnectionDetails
+
+	// ObservationMessage is a Debug level message that is sent to the
+	// reconciler when there is a change in the observed Managed Resource.
+	// It is useful for finding what change there is between what was
+	// observed and the resource's definition.
+	ObservationMessage string
 }
 
 // An ExternalCreation is the result of the creation of an external resource.
@@ -788,6 +794,8 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		managed.SetConditions(xpv1.ReconcileSuccess())
 		return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
+
+	log.Debug(observation.ObservationMessage)
 
 	update, err := external.Update(externalCtx, managed)
 	if err != nil {


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The issue I'm having is that I have a resource that is out-of-sync, and I am having a hard time debugging the reason it keeps getting flagged as out-of-sync. I would like to add the option of an additional debug level log that details why a resource's observed state does not match its desired state.

This requires an update to crossplane-runtime because the Reconcile function that will trigger checking the observed state of the Managed Resource and updating the MR is in this library. I am trying to follow what was laid on out on #108 where the reconciler scaffold will send the log messages.


Fixes #271 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've tested this by building provider-aws against this commit (with changes to the IAM controller as well), and ensure that the proper log messages are shown at the Debug level. See this output:
```
2021-07-11T19:51:27.152-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/iamrolepolicyattachment.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role-rolepolicyattachment", "uid": "a197b39c-19d7-4099-82f2-f1ccd5105761", "version": "109686", "external-name": "cc-crossplane-iam-role-rolepolicyattachment", "requeue-after": "2021-07-11T19:52:27.152-0400"}
2021-07-11T19:52:22.998-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/iampolicy.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role"}
2021-07-11T19:52:23.000-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/iamrole.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role"}
2021-07-11T19:52:23.281-0400	DEBUG	provider-aws	Found observed difference in IAM role
  &iam.Role{
  	Arn:                      &"arn:aws:iam::111111111111:role/cc-crossplane-iam-role",
- 	AssumeRolePolicyDocument: &"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%"...,
+ 	AssumeRolePolicyDocument: &"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%"...,
  	CreateDate:               &s"2021-07-11 23:51:21 +0000 UTC",
  	Description:              nil,
  	... // 7 identical fields
  }

desired assume role policy: %7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22sts%3AExternalId%22%3A%22000000000000%22%7D%7D%7D%5D%7D
observed assume role policy: %7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22sts%3AExternalId%22%3A%2211111%22%7D%7D%7D%5D%7D	{"controller": "managed/iamrole.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role", "uid": "67d1d6fb-a50e-4f51-b333-275bc3ebe4cf", "version": "109674", "external-name": "cc-crossplane-iam-role"}
2021-07-11T19:52:23.338-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/iampolicy.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role", "uid": "470f8e08-85b1-4e5d-960b-937fdbae93ff", "version": "109681", "external-name": "arn:aws:iam::111111111111:policy/cc-crossplane-iam-role", "requeue-after": "2021-07-11T19:53:23.338-0400"}
```

[contribution process]: https://git.io/fj2m9
