### PR TITLE
Track resources that are pending external name assignment

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -31,9 +32,23 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-// AnnotationKeyExternalName is the key in the annotations map of a resource for
-// the name of the resource as it appears on provider's systems.
-const AnnotationKeyExternalName = "crossplane.io/external-name"
+const (
+	// AnnotationKeyExternalName is the annotation key used to indicate the
+	// 'external' name, or unique identifier, of a managed resource. The
+	// external name may differ from the managed resource name - i.e. the
+	// resource's metadata.name.
+	AnnotationKeyExternalName = "crossplane.io/external-name"
+
+	// AnnotationKeyExternalNamePending is the annotation key used to
+	// indicate that a resource's external name is pending assignment.
+	// Crossplane prefers to use deterministic external names where it can,
+	// but in some cases this is not possible - for example when an API
+	// generates and returns the name at create time. In such cases this
+	// annotation should be set before an external resource is created.
+	// Crossplane uses this annotation to ensure it creates at most one
+	// external resource.
+	AnnotationKeyExternalNamePending = "crossplane.io/external-name-pending"
+)
 
 // Supported resources with all of these annotations will be fully or partially
 // propagated to the named resource of the same kind, assuming it exists and
@@ -236,13 +251,42 @@ func WasCreated(o metav1.Object) bool {
 }
 
 // GetExternalName returns the external name annotation value on the resource.
+// See AnnotationKeyExternalName for details.
 func GetExternalName(o metav1.Object) string {
 	return o.GetAnnotations()[AnnotationKeyExternalName]
 }
 
-// SetExternalName sets the external name annotation of the resource.
+// SetExternalName sets the external name annotation of the resource. It also
+// clears the "external name pending" annotation, if set. See
+// AnnotationKeyExternalName and AnnotationKeyExternalNamePending for details.
 func SetExternalName(o metav1.Object, name string) {
 	AddAnnotations(o, map[string]string{AnnotationKeyExternalName: name})
+	UnsetExternalNamePending(o)
+}
+
+// GetExternalNamePending indicates whether the supplied object is pending
+// assignment of a name by an external system. See
+// AnnotationKeyExternalNamePending for more detail.
+func GetExternalNamePending(o metav1.Object) bool {
+	// We consider any value to indicate the external name is pending.
+	_, ok := o.GetAnnotations()[AnnotationKeyExternalNamePending]
+	return ok
+}
+
+// SetExternalNamePending indicates that the external name of of the supplied
+// object is (about to be) pending assignment by an external system. See
+// AnnotationKeyExternalNamePending for more detail.
+func SetExternalNamePending(o metav1.Object) {
+	// We consider any value to indicate the external name is pending, but
+	// we write a timestamp by convention to aid in human debugging.
+	AddAnnotations(o, map[string]string{AnnotationKeyExternalNamePending: metav1.Now().Format(time.RFC3339)})
+}
+
+// UnsetExternalNamePending indicates that the external name of the supplied
+// object is not currently pending assignment by an external system. See
+// AnnotationKeyExternalNamePending for more detail.
+func UnsetExternalNamePending(o metav1.Object) {
+	RemoveAnnotations(o, AnnotationKeyExternalNamePending)
 }
 
 // AllowPropagation from one object to another by adding consenting annotations

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"hash/fnv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -889,6 +891,11 @@ func TestSetExternalName(t *testing.T) {
 			name: name,
 			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalName: name}}},
 		},
+		"ClearsExternalNamePending": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalNamePending: metav1.Now().Format(time.RFC3339)}}},
+			name: name,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalName: name}}},
+		},
 	}
 
 	for name, tc := range cases {
@@ -896,6 +903,56 @@ func TestSetExternalName(t *testing.T) {
 			SetExternalName(tc.o, tc.name)
 			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
 				t.Errorf("SetExternalName(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExternalNamePending(t *testing.T) {
+	cases := map[string]struct {
+		o    metav1.Object
+		want bool
+	}{
+		"AnnotationWithTimestamp": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalNamePending: metav1.Now().Format(time.RFC3339)}}},
+			want: true,
+		},
+		"AnnotationWithArbitraryValue": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalNamePending: "I'm an arbitrary string!"}}},
+			want: true,
+		},
+		"NoAnnotation": {
+			o:    &corev1.Pod{},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetExternalNamePending(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetExternalNamePending(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalNamePending(t *testing.T) {
+	cases := map[string]struct {
+		o    metav1.Object
+		want metav1.Object
+	}{
+		"SetsTheCorrectKey": {
+			o:    &corev1.Pod{},
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalNamePending: metav1.Now().Format(time.RFC3339)}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SetExternalNamePending(tc.o)
+			if diff := cmp.Diff(tc.want, tc.o, cmpopts.EquateApproxTime(1*time.Minute)); diff != "" {
+				t.Errorf("SetExternalNamePending(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -19,12 +19,14 @@ package managed
 import (
 	"context"
 	"testing"
+	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -53,6 +55,7 @@ func TestReconciler(t *testing.T) {
 
 	errBoom := errors.New("boom")
 	now := metav1.Now()
+	externalName := "Dr. Lucien Sanchez"
 
 	cases := map[string]struct {
 		reason string
@@ -559,17 +562,113 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"CreateExternalError": {
-			reason: "Errors while creating an external resource should trigger a requeue after a short wait.",
+			reason: "Errors while creating an external resource should trigger a requeue after a short wait, and remove the external name pending annotation",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						// We don't have an external name set so we expect it
+						// was added before Create was called.
+						MockGet:    test.NewMockGetFn(nil),
+						MockUpdate: test.NewMockUpdateFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileCreate)))
 							want.SetConditions(xpv1.Creating())
-							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateEmpty()); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+							CreateFn: func(_ context.Context, _ resource.Managed) (ExternalCreation, error) {
+								return ExternalCreation{}, errBoom
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
+		"UnsetExternalNamePendingGetError": {
+			reason: "Errors while getting a fresh copy of the managed resource to unset its external name pending annotation should only be emitted as a log and an event",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							if pending := meta.GetExternalNamePending(obj); pending {
+								return errBoom
+							}
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							meta.SetExternalNamePending(want)
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileCreate)))
+							want.SetConditions(xpv1.Creating())
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateEmpty()); diff != "" {
+								reason := "(Only) errors while creating an external resource should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+							CreateFn: func(_ context.Context, _ resource.Managed) (ExternalCreation, error) {
+								return ExternalCreation{}, errBoom
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
+		"UnsetExternalNamePendingUpdateError": {
+			reason: "Errors while updating the managed resource to unset its external name pending annotation should only be emitted as a log and an event",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+							if pending := meta.GetExternalNamePending(obj); pending {
+								return nil
+							}
+							return errBoom
+						}),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileCreate)))
+							want.SetConditions(xpv1.Creating())
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateEmpty()); diff != "" {
+								reason := "(Only) errors while creating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
 							return nil
@@ -603,9 +702,13 @@ func TestReconciler(t *testing.T) {
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							meta.SetExternalName(obj, externalName)
+							return nil
+						}),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
+							meta.SetExternalName(want, externalName)
 							want.SetConditions(xpv1.ReconcileError(errBoom))
 							want.SetConditions(xpv1.Creating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
@@ -649,14 +752,96 @@ func TestReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
+		"CreateWithExternalNamePending": {
+			reason: "If the 'external name pending' annotation is set at create time we should return an error.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							meta.SetExternalNamePending(obj)
+							return nil
+						}),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							meta.SetExternalNamePending(want)
+							want.SetConditions(xpv1.ReconcileError(errors.New(errExternalNamePending)))
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Minute)); diff != "" {
+								reason := "Failed managed resource creation should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
+		"SetExternalNamePendingError": {
+			reason: "If we can't set the 'external name pending' annotation we should return an error.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet:    test.NewMockGetFn(nil),
+						MockUpdate: test.NewMockUpdateFn(errBoom),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							meta.SetExternalNamePending(want)
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateExternalNamePending)))
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Minute)); diff != "" {
+								reason := "Failed managed resource creation should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
 		"CreateSuccessful": {
 			reason: "Successful managed resource creation should trigger a requeue after a short wait.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							meta.SetExternalName(obj, externalName)
+							return nil
+						}),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
+							meta.SetExternalName(want, externalName)
 							want.SetConditions(xpv1.ReconcileSuccess())
 							want.SetConditions(xpv1.Creating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
@@ -688,7 +873,7 @@ func TestReconciler(t *testing.T) {
 						MockUpdate: test.NewMockUpdateFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
-							meta.SetExternalName(want, "test")
+							meta.SetExternalName(want, externalName)
 							want.SetConditions(xpv1.ReconcileSuccess())
 							want.SetConditions(xpv1.Creating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
@@ -707,7 +892,7 @@ func TestReconciler(t *testing.T) {
 					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							CreateFn: func(_ context.Context, mg resource.Managed) (ExternalCreation, error) {
-								meta.SetExternalName(mg, "test")
+								meta.SetExternalName(mg, externalName)
 								return ExternalCreation{ExternalNameAssigned: true}, nil
 							},
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
@@ -728,18 +913,19 @@ func TestReconciler(t *testing.T) {
 				m: &fake.Manager{
 					Client: &test.MockClient{
 						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							if meta.GetExternalName(obj.(metav1.Object)) == "test" {
+							if meta.GetExternalName(obj) == externalName {
 								return errBoom
 							}
 							return nil
 						},
+						MockUpdate: test.NewMockUpdateFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
-							meta.SetExternalName(want, "test")
-							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManagedAfterCreate)))
+							meta.SetExternalName(want, externalName)
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateExternalName)))
 							want.SetConditions(xpv1.Creating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
-								reason := "Successful managed resource creation should be reported as a conditioned status."
+								reason := "A failed get should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
 							return nil
@@ -754,7 +940,7 @@ func TestReconciler(t *testing.T) {
 					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							CreateFn: func(_ context.Context, mg resource.Managed) (ExternalCreation, error) {
-								meta.SetExternalName(mg, "test")
+								meta.SetExternalName(mg, externalName)
 								return ExternalCreation{ExternalNameAssigned: true}, nil
 							},
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
@@ -774,15 +960,21 @@ func TestReconciler(t *testing.T) {
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(errBoom),
+						MockGet: test.NewMockGetFn(nil),
+						MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+							// Don't return an error until after the external name has been set.
+							if meta.GetExternalName(obj) == externalName {
+								return errBoom
+							}
+							return nil
+						}),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							want := &fake.Managed{}
-							meta.SetExternalName(want, "test")
-							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManagedAfterCreate)))
+							meta.SetExternalName(want, externalName)
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateExternalName)))
 							want.SetConditions(xpv1.Creating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
-								reason := "Successful managed resource creation should be reported as a conditioned status."
+								reason := "A failed update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
 							return nil
@@ -797,7 +989,7 @@ func TestReconciler(t *testing.T) {
 					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							CreateFn: func(_ context.Context, mg resource.Managed) (ExternalCreation, error) {
-								meta.SetExternalName(mg, "test")
+								meta.SetExternalName(mg, externalName)
 								return ExternalCreation{ExternalNameAssigned: true}, nil
 							},
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -999,7 +999,7 @@ func TestReconciler(t *testing.T) {
 					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
-								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false, Diff: "I'm different!"}, nil
 							},
 							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
 								return ExternalUpdate{}, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Edit: I had originally hoped this would fix https://github.com/crossplane/provider-aws/issues/802, but it appears there was a simpler fix for that specific case. Nonetheless, I do believe we're hypothetically vulnerable to the issue this PR addresses, so we may want to consider merging it anyhow.

Some Crossplane resources have non-deterministic external names that are returned at Create time. We must record those names and rely on them to determine whether the external resources exist during subsequent Observe calls.

The absence of an external name does not guarantee that we didn't create an external resource. It's possible that we created the resource but failed to update its name. It's also possible that we did update the name but have since read a stale, unnamed, version of the resource from cache.

To deal with this we set a 'pending external name' annotation immediately before creating our external resource. If we get to the Create call because we have a stale view of our managed resource the Update call that persists the annotation will fail. If we are already pending external name assignment when we get to the Create call we know it's possible that we created an external resource but did not persist its name, so we refuse to proceed rather than creating a duplicate.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

It has not yet. I'll move it out of draft once it has been tested.