### PR TITLE
Add machinery for tracking external resource create time

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -270,9 +270,9 @@ func GetExternalCreateTime(o metav1.Object) *metav1.Time {
 }
 
 // SetExternalCreateTime sets the time at which the external resource was most
-// recently created to the current time.
-func SetExternalCreateTime(o metav1.Object) {
-	AddAnnotations(o, map[string]string{AnnotationKeyExternalCreateTime: metav1.Now().Format(time.RFC3339)})
+// recently created to the supplied time.
+func SetExternalCreateTime(o metav1.Object, t metav1.Time) {
+	AddAnnotations(o, map[string]string{AnnotationKeyExternalCreateTime: t.Format(time.RFC3339)})
 }
 
 // AllowPropagation from one object to another by adding consenting annotations

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -923,7 +922,7 @@ func TestGetExternalCreateTime(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetExternalCreateTime(tc.o)
-			if diff := cmp.Diff(tc.want, got, cmpopts.EquateApproxTime(1*time.Minute)); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("GetExternalCreateTime(...): -want, +got:\n%s", diff)
 			}
 		})
@@ -931,20 +930,24 @@ func TestGetExternalCreateTime(t *testing.T) {
 }
 
 func TestSetExternalCreateTime(t *testing.T) {
+	now := metav1.Now()
+
 	cases := map[string]struct {
 		o    metav1.Object
+		t    metav1.Time
 		want metav1.Object
 	}{
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateTime: time.Now().Format(time.RFC3339)}}},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateTime: now.Format(time.RFC3339)}}},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			SetExternalCreateTime(tc.o)
-			if diff := cmp.Diff(tc.want, tc.o, cmpopts.EquateApproxTime(1*time.Minute)); diff != "" {
+			SetExternalCreateTime(tc.o, tc.t)
+			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
 				t.Errorf("SetExternalCreateTime(...): -want, +got:\n%s", diff)
 			}
 		})


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Adds plumbing to fix at least one variant of https://github.com/crossplane/provider-aws/issues/802.

Per https://github.com/crossplane/provider-aws/issues/802 some external APIs (including some AWS APIs) appear to experience some delay between the time a new resource is successfully created and the time at which that resource appears in queries.

This commit adds a new 'crossplane.io/external-create-time' annotation and a new 'ResourcePending' field in the Observation struct. Together these can be used by an Observe method to allow for a small grace period before it determines that a resource does not exist. For example:

```go
func Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
  err := api.Get(AsInput(mg))
  if IsNotFound(err) {
    if t := meta.GetExternalCreateTime(); t != nil && time.Since(t.Time) < 1 * time.Minute {
      // We're in the grace period - wait a bit longer for the resource to appear.
      return managed.ExternalObservation{ResourcePending: true}, nil
    }
    // The resource does not exist.
    return managed.ExternalObservation{ResourceExists: false}, nil
  }
  if err != nil {
    return managed.ExternalObservation{}, err
  }
  return managed.ExternalObervation{ResourceExists: true}
}

func Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
  _ := api.Create(AsInput(mg))
  meta.SetExternalCreateTime()
  return managed.ExternalCreation{ExternalCreateTimeSet: true}, nil
}
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Per https://github.com/crossplane/crossplane-runtime/pull/279 I've updated the AWS `RouteTable` and `InternetGateway` controllers to use the above pattern and run the script in https://gist.github.com/negz/e1f2e74f18802d15440214a1a1abc981 for 12+ hours. I did not observe any leaked route tables or internet gateways during my testing, whereas without this fix I reliably see 2-3 leaked resources after 2-3 hours.