### PR TITLE
Account for two different kinds of consistency issues

### DIFF
--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -903,11 +903,11 @@ func TestSetExternalName(t *testing.T) {
 }
 
 func TestGetExternalCreatePending(t *testing.T) {
-	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+	now := time.Now().Round(time.Second)
 
 	cases := map[string]struct {
 		o    metav1.Object
-		want *metav1.Time
+		want time.Time
 	}{
 		"ExternalCreatePendingExists": {
 			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
@@ -915,7 +915,7 @@ func TestGetExternalCreatePending(t *testing.T) {
 		},
 		"NoExternalCreatePending": {
 			o:    &corev1.Pod{},
-			want: nil,
+			want: time.Time{},
 		},
 	}
 
@@ -930,11 +930,11 @@ func TestGetExternalCreatePending(t *testing.T) {
 }
 
 func TestSetExternalCreatePending(t *testing.T) {
-	now := metav1.Now()
+	now := time.Now()
 
 	cases := map[string]struct {
 		o    metav1.Object
-		t    metav1.Time
+		t    time.Time
 		want metav1.Object
 	}{
 		"SetsTheCorrectKey": {
@@ -955,11 +955,11 @@ func TestSetExternalCreatePending(t *testing.T) {
 }
 
 func TestGetExternalCreateSucceeded(t *testing.T) {
-	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+	now := time.Now().Round(time.Second)
 
 	cases := map[string]struct {
 		o    metav1.Object
-		want *metav1.Time
+		want time.Time
 	}{
 		"ExternalCreateTimeExists": {
 			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
@@ -967,7 +967,7 @@ func TestGetExternalCreateSucceeded(t *testing.T) {
 		},
 		"NoExternalCreateTime": {
 			o:    &corev1.Pod{},
-			want: nil,
+			want: time.Time{},
 		},
 	}
 
@@ -982,20 +982,15 @@ func TestGetExternalCreateSucceeded(t *testing.T) {
 }
 
 func TestSetExternalCreateSucceeded(t *testing.T) {
-	now := metav1.Now()
+	now := time.Now()
 
 	cases := map[string]struct {
 		o    metav1.Object
-		t    metav1.Time
+		t    time.Time
 		want metav1.Object
 	}{
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
-			t:    now,
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
-		},
-		"RemovesCreatePendingKey": {
-			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
 			t:    now,
 			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
 		},
@@ -1012,11 +1007,11 @@ func TestSetExternalCreateSucceeded(t *testing.T) {
 }
 
 func TestGetExternalCreateFailed(t *testing.T) {
-	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+	now := time.Now().Round(time.Second)
 
 	cases := map[string]struct {
 		o    metav1.Object
-		want *metav1.Time
+		want time.Time
 	}{
 		"ExternalCreateFailedExists": {
 			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
@@ -1024,7 +1019,7 @@ func TestGetExternalCreateFailed(t *testing.T) {
 		},
 		"NoExternalCreateFailed": {
 			o:    &corev1.Pod{},
-			want: nil,
+			want: time.Time{},
 		},
 	}
 
@@ -1039,20 +1034,15 @@ func TestGetExternalCreateFailed(t *testing.T) {
 }
 
 func TestSetExternalCreateFailed(t *testing.T) {
-	now := metav1.Now()
+	now := time.Now()
 
 	cases := map[string]struct {
 		o    metav1.Object
-		t    metav1.Time
+		t    time.Time
 		want metav1.Object
 	}{
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
-			t:    now,
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
-		},
-		"RemovesCreatePendingKey": {
-			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
 			t:    now,
 			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
 		},
@@ -1090,7 +1080,7 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 				o: func() metav1.Object {
 					o := &corev1.Pod{}
 					t := time.Now().Add(-2 * time.Minute)
-					SetExternalCreateSucceeded(o, metav1.NewTime(t))
+					SetExternalCreateSucceeded(o, t)
 					return o
 				}(),
 				d: 1 * time.Minute,
@@ -1102,7 +1092,7 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 				o: func() metav1.Object {
 					o := &corev1.Pod{}
 					t := time.Now().Add(-30 * time.Second)
-					SetExternalCreateSucceeded(o, metav1.NewTime(t))
+					SetExternalCreateSucceeded(o, t)
 					return o
 				}(),
 				d: 1 * time.Minute,
@@ -1116,6 +1106,75 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 			got := ExternalCreateSucceededDuring(tc.args.o, tc.args.d)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("ExternalCreateSucceededDuring(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExternalCreateIncomplete(t *testing.T) {
+
+	now := time.Now().Format(time.RFC3339)
+	earlier := time.Now().Add(-1 * time.Second).Format(time.RFC3339)
+	evenEarlier := time.Now().Add(-1 * time.Minute).Format(time.RFC3339)
+
+	cases := map[string]struct {
+		reason string
+		o      metav1.Object
+		want   bool
+	}{
+		"CreateNeverPending": {
+			reason: "If we've never called Create it can't be incomplete.",
+			o:      &corev1.Pod{},
+			want:   false,
+		},
+		"CreateSucceeded": {
+			reason: "If Create succeeded since it was pending, it's complete.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyExternalCreateFailed:    evenEarlier,
+				AnnotationKeyExternalCreatePending:   earlier,
+				AnnotationKeyExternalCreateSucceeded: now,
+			}}},
+			want: false,
+		},
+		"CreateFailed": {
+			reason: "If Create failed since it was pending, it's complete.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyExternalCreateSucceeded: evenEarlier,
+				AnnotationKeyExternalCreatePending:   earlier,
+				AnnotationKeyExternalCreateFailed:    now,
+			}}},
+			want: false,
+		},
+		"CreateNeverCompleted": {
+			reason: "If Create was pending but never succeeded or failed, it's incomplete.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyExternalCreatePending: earlier,
+			}}},
+			want: true,
+		},
+		"RecreateNeverCompleted": {
+			reason: "If Create is pending and there's an older success we're probably trying to recreate a deleted external resource, and it's incomplete.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyExternalCreateSucceeded: earlier,
+				AnnotationKeyExternalCreatePending:   now,
+			}}},
+			want: true,
+		},
+		"RetryNeverCompleted": {
+			reason: "If Create is pending and there's an older failure we're probably trying to recreate a deleted external resource, and it's incomplete.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyExternalCreateFailed:  earlier,
+				AnnotationKeyExternalCreatePending: now,
+			}}},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ExternalCreateIncomplete(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExternalCreateIncomplete(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -896,6 +897,225 @@ func TestSetExternalName(t *testing.T) {
 			SetExternalName(tc.o, tc.name)
 			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
 				t.Errorf("SetExternalName(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExternalCreatePending(t *testing.T) {
+	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+
+	cases := map[string]struct {
+		o    metav1.Object
+		want *metav1.Time
+	}{
+		"ExternalCreatePendingExists": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
+			want: now,
+		},
+		"NoExternalCreatePending": {
+			o:    &corev1.Pod{},
+			want: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetExternalCreatePending(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetExternalCreatePending(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalCreatePending(t *testing.T) {
+	now := metav1.Now()
+
+	cases := map[string]struct {
+		o    metav1.Object
+		t    metav1.Time
+		want metav1.Object
+	}{
+		"SetsTheCorrectKey": {
+			o:    &corev1.Pod{},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SetExternalCreatePending(tc.o, tc.t)
+			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
+				t.Errorf("SetExternalCreatePending(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExternalCreateSucceeded(t *testing.T) {
+	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+
+	cases := map[string]struct {
+		o    metav1.Object
+		want *metav1.Time
+	}{
+		"ExternalCreateTimeExists": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
+			want: now,
+		},
+		"NoExternalCreateTime": {
+			o:    &corev1.Pod{},
+			want: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetExternalCreateSucceeded(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetExternalCreateSucceeded(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalCreateSucceeded(t *testing.T) {
+	now := metav1.Now()
+
+	cases := map[string]struct {
+		o    metav1.Object
+		t    metav1.Time
+		want metav1.Object
+	}{
+		"SetsTheCorrectKey": {
+			o:    &corev1.Pod{},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
+		},
+		"RemovesCreatePendingKey": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateSucceeded: now.Format(time.RFC3339)}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SetExternalCreateSucceeded(tc.o, tc.t)
+			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
+				t.Errorf("SetExternalCreateSucceeded(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExternalCreateFailed(t *testing.T) {
+	now := &metav1.Time{Time: time.Now().Round(time.Second)}
+
+	cases := map[string]struct {
+		o    metav1.Object
+		want *metav1.Time
+	}{
+		"ExternalCreateFailedExists": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
+			want: now,
+		},
+		"NoExternalCreateFailed": {
+			o:    &corev1.Pod{},
+			want: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetExternalCreateFailed(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetExternalCreateFailed(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalCreateFailed(t *testing.T) {
+	now := metav1.Now()
+
+	cases := map[string]struct {
+		o    metav1.Object
+		t    metav1.Time
+		want metav1.Object
+	}{
+		"SetsTheCorrectKey": {
+			o:    &corev1.Pod{},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
+		},
+		"RemovesCreatePendingKey": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreatePending: now.Format(time.RFC3339)}}},
+			t:    now,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationKeyExternalCreateFailed: now.Format(time.RFC3339)}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SetExternalCreateFailed(tc.o, tc.t)
+			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
+				t.Errorf("SetExternalCreateFailed(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExternalCreateSucceededDuring(t *testing.T) {
+	type args struct {
+		o metav1.Object
+		d time.Duration
+	}
+
+	cases := map[string]struct {
+		args args
+		want bool
+	}{
+		"NotYetSuccessfullyCreated": {
+			args: args{
+				o: &corev1.Pod{},
+				d: 1 * time.Minute,
+			},
+			want: false,
+		},
+		"SuccessfullyCreatedTooLongAgo": {
+			args: args{
+				o: func() metav1.Object {
+					o := &corev1.Pod{}
+					t := time.Now().Add(-2 * time.Minute)
+					SetExternalCreateSucceeded(o, metav1.NewTime(t))
+					return o
+				}(),
+				d: 1 * time.Minute,
+			},
+			want: false,
+		},
+		"SuccessfullyCreatedWithinDuration": {
+			args: args{
+				o: func() metav1.Object {
+					o := &corev1.Pod{}
+					t := time.Now().Add(-30 * time.Second)
+					SetExternalCreateSucceeded(o, metav1.NewTime(t))
+					return o
+				}(),
+				d: 1 * time.Minute,
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ExternalCreateSucceededDuring(tc.args.o, tc.args.d)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExternalCreateSucceededDuring(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -31,10 +33,11 @@ import (
 
 // Error strings.
 const (
-	errCreateOrUpdateSecret = "cannot create or update connection secret"
-	errUpdateManaged        = "cannot update managed resource"
-	errUpdateManagedStatus  = "cannot update managed resource status"
-	errResolveReferences    = "cannot resolve references"
+	errCreateOrUpdateSecret      = "cannot create or update connection secret"
+	errUpdateManaged             = "cannot update managed resource"
+	errUpdateManagedStatus       = "cannot update managed resource status"
+	errResolveReferences         = "cannot resolve references"
+	errUpdateCriticalAnnotations = "cannot update critical annotations"
 )
 
 // NameAsExternalName writes the name of the managed resource to
@@ -151,4 +154,34 @@ func (a *APISimpleReferenceResolver) ResolveReferences(ctx context.Context, mg r
 	}
 
 	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
+}
+
+// A RetryingCriticalAnnotationUpdater is a CriticalAnnotationUpdater that
+// retries annotation updates in the face of API server errors.
+type RetryingCriticalAnnotationUpdater struct {
+	client client.Client
+}
+
+// NewRetryingCriticalAnnotationUpdater returns a CriticalAnnotationUpdater that
+// retries annotation updates in the face of API server errors.
+func NewRetryingCriticalAnnotationUpdater(c client.Client) *RetryingCriticalAnnotationUpdater {
+	return &RetryingCriticalAnnotationUpdater{client: c}
+}
+
+// UpdateCriticalAnnotations updates (i.e. persists) the annotations of the
+// supplied Object. It retries in the face of any API server error several times
+// in order to ensure annotations that contain critical state are persisted. Any
+// pending changes to the supplied Object's spec, status, or other metadata are
+// reset to their current state according to the API server.
+func (u *RetryingCriticalAnnotationUpdater) UpdateCriticalAnnotations(ctx context.Context, o client.Object) error {
+	a := o.GetAnnotations()
+	err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
+		nn := types.NamespacedName{Name: o.GetName()}
+		if err := u.client.Get(ctx, nn, o); err != nil {
+			return err
+		}
+		meta.AddAnnotations(o, a)
+		return u.client.Update(ctx, o)
+	})
+	return errors.Wrap(err, errUpdateCriticalAnnotations)
 }

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,13 +40,14 @@ const (
 	reconcileTimeout     = 1 * time.Minute
 
 	defaultpollInterval = 1 * time.Minute
+	defaultGracePeriod  = 30 * time.Second
 )
 
 // Error strings.
 const (
 	errGetManaged               = "cannot get managed resource"
-	errCreatePending            = "refusing to reconcile managed resource with " + meta.AnnotationKeyExternalCreatePending + " annotation - remove if it is safe to proceed"
 	errUpdateManagedAnnotations = "cannot update managed resource annotations"
+	errCreateIncomplete         = "cannot determine creation result - remove the " + meta.AnnotationKeyExternalCreatePending + " annotation if it is safe to proceed"
 	errReconcileConnect         = "connect failed"
 	errReconcileObserve         = "observe failed"
 	errReconcileCreate          = "create failed"
@@ -442,7 +441,8 @@ func WithPollInterval(after time.Duration) ReconcilerOption {
 // WithCreationGracePeriod configures an optional period during which we will
 // wait for the external API to report that a newly created external resource
 // exists. This allows us to tolerate eventually consistent APIs that do not
-// immediately report that newly created resources exist when queried.
+// immediately report that newly created resources exist when queried. All
+// resources have a 30 second grace period by default.
 func WithCreationGracePeriod(d time.Duration) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.creationGracePeriod = d
@@ -530,14 +530,15 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOp
 	_ = nm()
 
 	r := &Reconciler{
-		client:       m.GetClient(),
-		newManaged:   nm,
-		pollInterval: defaultpollInterval,
-		timeout:      reconcileTimeout,
-		managed:      defaultMRManaged(m),
-		external:     defaultMRExternal(),
-		log:          logging.NewNopLogger(),
-		record:       event.NewNopRecorder(),
+		client:              m.GetClient(),
+		newManaged:          nm,
+		pollInterval:        defaultpollInterval,
+		creationGracePeriod: defaultGracePeriod,
+		timeout:             reconcileTimeout,
+		managed:             defaultMRManaged(m),
+		external:            defaultMRExternal(),
+		log:                 logging.NewNopLogger(),
+		record:              event.NewNopRecorder(),
 	}
 
 	for _, ro := range o {
@@ -628,16 +629,15 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
-	// A resource would only be pending creation at this point if we failed
-	// to persist our annotations after the ExternalClient's Create method
-	// was called. If that is the case we may have lost a critical update to
-	// the external name and leaked a resource. The safest thing to do is to
-	// refuse to proceed.
-	if meta.GetExternalCreatePending(managed) != nil {
-		log.Debug(errCreatePending)
-		record.Event(managed, event.Warning(reasonCannotInitialize, errors.New(errCreatePending)))
-		managed.SetConditions(xpv1.ReconcileError(errors.New(errCreatePending)))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+	// If we started but never completed creation of an external resource we
+	// may have lost critical information. For example if we didn't persist
+	// an updated external name we've leaked a resource. The safest thing to
+	// do is to refuse to proceed.
+	if meta.ExternalCreateIncomplete(managed) {
+		log.Debug(errCreateIncomplete)
+		record.Event(managed, event.Warning(reasonCannotInitialize, errors.New(errCreateIncomplete)))
+		managed.SetConditions(xpv1.ReconcileError(errors.New(errCreateIncomplete)))
+		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
 	// We resolve any references before observing our external resource because
@@ -781,7 +781,6 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 	}
 
 	if !observation.ResourceExists {
-
 		// We write this annotation for two reasons. Firstly, it helps
 		// us to detect the case in which we fail to persist critical
 		// information (like the external name) that may be set by the
@@ -789,7 +788,7 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 		// we're operating on the latest version of our resource. We
 		// don't use the CriticalAnnotationUpdater because we _want_ the
 		// update to fail if we get a 409 due to a stale version.
-		meta.SetExternalCreatePending(managed, metav1.Now())
+		meta.SetExternalCreatePending(managed, time.Now())
 		if err := r.client.Update(ctx, managed); err != nil {
 			log.Debug(errUpdateManaged, "error", err)
 			record.Event(managed, event.Warning(reasonCannotUpdateManaged, errors.Wrap(err, errUpdateManaged)))
@@ -810,11 +809,11 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 
 			// We handle annotations specially here because it's
 			// critical that they are persisted to the API server.
-			// If we don't remove the external-create-pending
-			// annotation the reconciler will refuse to proceed,
-			// because it won't know whether or not it created an
-			// external resource.
-			meta.SetExternalCreateFailed(managed, metav1.Now())
+			// If we don't add the external-create-failed annotation
+			// the reconciler will refuse to proceed, because it
+			// won't know whether or not it created an external
+			// resource.
+			meta.SetExternalCreateFailed(managed, time.Now())
 			if err := r.managed.UpdateCriticalAnnotations(ctx, managed); err != nil {
 				log.Debug(errUpdateManagedAnnotations, "error", err)
 				record.Event(managed, event.Warning(reasonCannotUpdateManaged, errors.Wrap(err, errUpdateManagedAnnotations)))
@@ -836,15 +835,15 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 
 		// We handle annotations specially here because it's critical
 		// that they are persisted to the API server. If we don't remove
-		// the external-create-pending annotation the reconciler will
-		// refuse to proceed, because it won't know whether or not it
-		// created an external resource. This is important in cases
-		// where we must record an external-name annotation set by the
-		// Create call. Any other changes made during Create will be
+		// add the external-create-succeeded annotation the reconciler
+		// will refuse to proceed, because it won't know whether or not
+		// it created an external resource. This is also important in
+		// cases where we must record an external-name annotation set by
+		// the Create call. Any other changes made during Create will be
 		// reverted when annotations are updated; at the time of writing
 		// Create implementations are advised not to alter status, but
 		// we may revisit this in future.
-		meta.SetExternalCreateSucceeded(managed, metav1.Now())
+		meta.SetExternalCreateSucceeded(managed, time.Now())
 		if err := r.managed.UpdateCriticalAnnotations(ctx, managed); err != nil {
 			log.Debug(errUpdateManagedAnnotations, "error", err)
 			record.Event(managed, event.Warning(reasonCannotUpdateManaged, errors.Wrap(err, errUpdateManagedAnnotations)))


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/802
Closes https://github.com/crossplane/crossplane-runtime/pull/279
Closes https://github.com/crossplane/crossplane-runtime/pull/280

This PR is intended to address two issues that we diagnosed while investigating https://github.com/crossplane/provider-aws/issues/802. It addresses feedback from and supercedes https://github.com/crossplane/crossplane-runtime/pull/279 and https://github.com/crossplane/crossplane-runtime/pull/280. Both issues are known to cause 'leaked' and duplicate managed resources. I have only been able to personally reproduce the second issue but we have evidence of the first happening in the wild.

The first issue is that controller-runtime does not guarantee reads from cache will return the freshest version of a resource. It's possible we could create an external resource in one reconcile, then shortly after trigger another in which it appears that the managed resource was never created because we didn't record its external-name. This only affects the subset of managed resources with non-deterministic external-names that are assigned during creation.

The second issue is that some external APIs are eventually consistent. A newly created external resource may take some time before our ExternalClient's observe call can confirm it exists. AWS EC2 is an example of one such API.

This PR attempts to address the first issue by making an Update to a managed resource immediately before Create it called. This Update call will be rejected by the API server if the managed resource we read from cache was not the latest version.

It attempts to address the second issue by allowing managed resource controller authors to configure an optional grace period that begins when an external resource is successfully created. During this grace period we'll requeue and keep waiting if Observe determines that the external resource doesn't exist, rather than (re)creating it.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

https://gist.github.com/negz/e1f2e74f18802d15440214a1a1abc981

I've run the script from the above gist for about 12 hours against provider-aws built with this PR and observed zero leaked resources.