### PR TITLE
Add a `controller.Options` type

### DIFF
--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -27,6 +27,18 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 )
 
+// DefaultOptions returns a functional set of options with conservative
+// defaults.
+func DefaultOptions() Options {
+	return Options{
+		Logger:                  logging.NewNopLogger(),
+		GlobalRateLimiter:       ratelimiter.NewGlobal(ratelimiter.DefaultGlobalRPS),
+		PollInterval:            1 * time.Minute,
+		MaxConcurrentReconciles: 1,
+		Features:                &feature.Flags{},
+	}
+}
+
 // Options frequently used by most Crossplane controllers.
 type Options struct {
 	// The Logger controllers should use.

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// Options frequently used by most Crossplane controllers.
+type Options struct {
+	// The Logger controllers should use.
+	Logger logging.Logger
+
+	// The GlobalRateLimiter used by this controller manager. The rate of
+	// reconciles across all controllers will be subject to this limit.
+	GlobalRateLimiter workqueue.RateLimiter
+
+	// PollInterval at which each controller should speculatively poll to
+	// determine whether it has work to do.
+	PollInterval time.Duration
+
+	// MaxConcurrentReconciles for each controller.
+	MaxConcurrentReconciles int
+
+	// Features that should be enabled.
+	Features *feature.Flags
+}

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 )
 
 // Options frequently used by most Crossplane controllers.
@@ -43,4 +45,12 @@ type Options struct {
 
 	// Features that should be enabled.
 	Features *feature.Flags
+}
+
+// ForControllerRuntime extracts options for controller-runtime.
+func (o Options) ForControllerRuntime() controller.Options {
+	return controller.Options{
+		MaxConcurrentReconciles: o.MaxConcurrentReconciles,
+		RateLimiter:             ratelimiter.NewController(o.GlobalRateLimiter),
+	}
 }

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -42,6 +42,9 @@ func (fs *Flags) Enable(f Flag) {
 
 // Enabled returns true if the supplied feature flag is enabled.
 func (fs *Flags) Enabled(f Flag) bool {
+	if fs == nil {
+		return false
+	}
 	fs.m.RLock()
 	defer fs.m.RUnlock()
 	return fs.enabled[f]

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package feature contains utilities for managing Crossplane features.
+package feature
+
+import (
+	"sync"
+)
+
+// A Flag enables a particular feature.
+type Flag string
+
+// Flags that are enabled. The zero value - i.e. &feature.Flags{} - is usable.
+type Flags struct {
+	m       sync.RWMutex
+	enabled map[Flag]bool
+}
+
+// Enable a feature flag.
+func (fs *Flags) Enable(f Flag) {
+	fs.m.Lock()
+	if fs.enabled == nil {
+		fs.enabled = make(map[Flag]bool)
+	}
+	fs.enabled[f] = true
+	fs.m.Unlock()
+}
+
+// Enabled returns true if the supplied feature flag is enabled.
+func (fs *Flags) Enabled(f Flag) bool {
+	fs.m.RLock()
+	defer fs.m.RUnlock()
+	return fs.enabled[f]
+}

--- a/pkg/feature/feature_test.go
+++ b/pkg/feature/feature_test.go
@@ -37,8 +37,19 @@ func TestEnable(t *testing.T) {
 		}
 	})
 
-	t.Run("EnabledOnZeroValueReturnsFalse", func(t *testing.T) {
+	t.Run("EnabledOnEmptyFlagsReturnsFalse", func(t *testing.T) {
 		f := &Flags{}
+
+		want := false
+		got := f.Enabled(cool)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("f.Enabled(...): -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("EnabledOnNilReturnsFalse", func(t *testing.T) {
+		var f *Flags
 
 		want := false
 		got := f.Enabled(cool)

--- a/pkg/feature/feature_test.go
+++ b/pkg/feature/feature_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEnable(t *testing.T) {
+	var cool Flag = "cool"
+
+	t.Run("EnableMutatesZeroValue", func(t *testing.T) {
+		f := &Flags{}
+		f.Enable(cool)
+
+		want := true
+		got := f.Enabled(cool)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("f.Enabled(...): -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("EnabledOnZeroValueReturnsFalse", func(t *testing.T) {
+		f := &Flags{}
+
+		want := false
+		got := f.Enabled(cool)
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("f.Enabled(...): -want, +got:\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This type is intended to be passed as the argument to most Crossplane Setup functions, for example:

```go
func Setup(mgr ctrl.Manager, o controller.Options) error
```

This allows us to add new options to be plumbed down to all or most controllers without increasing the number of arguments provided to each Setup function. Sets of controllers that require additional arguments (e.g. the pkg controllers from crossplane/crossplane) can define their own Options struct that embeds this one.

This PR also migrates the `*feature.Flags` type from crossplane/crossplane, and generalises the names of the two levels of default rate limiters we use. This is all in preparation of adding more configuration knobs to crossplane/crossplane and our providers (e.g. poll interval, average global RPS) 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've built crossplane/crossplane in a branch that uses this commit and ensured it works.