### PR TITLE
Support true global reconcile rate limiting

### DIFF
--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -32,7 +32,7 @@ import (
 func DefaultOptions() Options {
 	return Options{
 		Logger:                  logging.NewNopLogger(),
-		GlobalRateLimiter:       ratelimiter.NewGlobal(ratelimiter.DefaultGlobalRPS),
+		GlobalRateLimiter:       ratelimiter.NewController(),
 		PollInterval:            1 * time.Minute,
 		MaxConcurrentReconciles: 1,
 		Features:                &feature.Flags{},
@@ -63,6 +63,6 @@ type Options struct {
 func (o Options) ForControllerRuntime() controller.Options {
 	return controller.Options{
 		MaxConcurrentReconciles: o.MaxConcurrentReconciles,
-		RateLimiter:             ratelimiter.NewController(o.GlobalRateLimiter),
+		RateLimiter:             ratelimiter.NewController(),
 	}
 }

--- a/pkg/ratelimiter/default.go
+++ b/pkg/ratelimiter/default.go
@@ -21,26 +21,22 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 )
 
 const (
-	// DefaultGlobalRPS is the recommended default average requeues per
-	// second tolerated by Crossplane controller managers.
-	DefaultGlobalRPS = 1
-
 	// DefaultProviderRPS is the recommended default average requeues per
 	// second tolerated by a Crossplane provider.
 	//
-	// Deprecated: Use DefaultGlobalRPS
-	DefaultProviderRPS = DefaultGlobalRPS
+	// Deprecated. Use a flag.
+	DefaultProviderRPS = 1
 )
 
 // NewGlobal returns a token bucket rate limiter meant for limiting the number
 // of average total requeues per second for all controllers registered with a
-// controller manager. The bucket size is a linear function of the requeues per
-// second.
+// controller manager. The bucket size (i.e. allowed burst) is rps * 10.
 func NewGlobal(rps int) *workqueue.BucketRateLimiter {
 	return &workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(rps), rps*10)}
 }
@@ -48,11 +44,8 @@ func NewGlobal(rps int) *workqueue.BucketRateLimiter {
 // NewController returns a rate limiter that takes the maximum delay between the
 // passed rate limiter and a per-item exponential backoff limiter. The
 // exponential backoff limiter has a base delay of 1s and a maximum of 60s.
-func NewController(global ratelimiter.RateLimiter) ratelimiter.RateLimiter {
-	return workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second),
-		global,
-	)
+func NewController() ratelimiter.RateLimiter {
+	return workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second)
 }
 
 // NewDefaultProviderRateLimiter returns a token bucket rate limiter meant for
@@ -71,5 +64,18 @@ func NewDefaultProviderRateLimiter(rps int) *workqueue.BucketRateLimiter {
 //
 // Deprecated: Use NewController.
 func NewDefaultManagedRateLimiter(provider ratelimiter.RateLimiter) ratelimiter.RateLimiter {
-	return NewController(provider)
+	return workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second),
+		provider,
+	)
+}
+
+// LimitRESTConfig configures the supplied REST config with rate limits derived
+// from the supplied rate of reconciles per second.
+func LimitRESTConfig(cfg *rest.Config, rps int) {
+	// The Kubernetes controller manager and controller-runtime controller
+	// managers use 20qps with 30 burst. We default to 10 reconciles per
+	// second so our defaults are designed to accommodate that.
+	cfg.QPS = float32(rps * 2)
+	cfg.Burst = 3
 }

--- a/pkg/ratelimiter/default_test.go
+++ b/pkg/ratelimiter/default_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-func TestDefaultMangedRateLimiter(t *testing.T) {
+func TestDefaultManagedRateLimiter(t *testing.T) {
 	limiter := NewDefaultManagedRateLimiter(NewDefaultProviderRateLimiter(DefaultProviderRPS))
 	backoffSchedule := []int{1, 2, 4, 8, 16, 32, 60}
 	for _, d := range backoffSchedule {

--- a/pkg/ratelimiter/reconciler.go
+++ b/pkg/ratelimiter/reconciler.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// A Reconciler rate limits an inner, wrapped Reconciler. Requests that are rate
+// limited immediately return RequeueAfter: d without calling the wrapped
+// Reconciler, where d is imposed by the rate limiter.
+type Reconciler struct {
+	name  string
+	inner reconcile.Reconciler
+	limit ratelimiter.RateLimiter
+}
+
+// NewReconciler wraps the supplied Reconciler, ensuring requests are passed to
+// it no more frequently than the supplied RateLimiter allows. Multiple uniquely
+// named Reconcilers can share the same RateLimiter.
+func NewReconciler(name string, r reconcile.Reconciler, l ratelimiter.RateLimiter) *Reconciler {
+	return &Reconciler{name: name, inner: r, limit: l}
+}
+
+// Reconcile the supplied request subject to rate limiting.
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	item := r.name + req.String()
+	if d := r.limit.When(item); d > time.Duration(0) {
+		return reconcile.Result{RequeueAfter: d}, nil
+	}
+	r.limit.Forget(item)
+	return r.inner.Reconcile(ctx, req)
+}

--- a/pkg/ratelimiter/reconciler_test.go
+++ b/pkg/ratelimiter/reconciler_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimiter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+var _ ratelimiter.RateLimiter = &predictableRateLimiter{}
+
+type predictableRateLimiter struct{ d time.Duration }
+
+func (r *predictableRateLimiter) When(_ interface{}) time.Duration { return r.d }
+func (r *predictableRateLimiter) Forget(_ interface{})             {}
+func (r *predictableRateLimiter) NumRequeues(_ interface{}) int    { return 0 }
+
+func TestReconcile(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req reconcile.Request
+	}
+	type want struct {
+		res reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		r      reconcile.Reconciler
+		args   args
+		want   want
+	}{
+		"NotRateLimited": {
+			reason: "Requests that are not rate limited should be passed to the inner Reconciler.",
+			r: NewReconciler("test",
+				reconcile.Func(func(c context.Context, r reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{Requeue: true}, nil
+				}),
+				&predictableRateLimiter{}),
+			want: want{
+				res: reconcile.Result{Requeue: true},
+				err: nil,
+			},
+		},
+		"RateLimited": {
+			reason: "Requests that are rate limited should be requeued after the duration specified by the RateLimiter.",
+			r:      NewReconciler("test", nil, &predictableRateLimiter{d: 8 * time.Second}),
+			want: want{
+				res: reconcile.Result{RequeueAfter: 8 * time.Second},
+				err: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.r.Reconcile(tc.args.ctx, tc.args.req)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nr.Reconcile(...): -want, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.res, got); diff != "" {
+				t.Errorf("%s\nr.Reconcile(...): -want, +got result:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR tweaks how ratelimiters are applied to support _actual_ global reconcile
rate limiting - that is all reconcile triggers are rate limited, not just some.

See https://github.com/crossplane/crossplane/issues/2595 for details.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've built crossplane/crossplane against this change and tested that it works. I'd like to do a little more testing to validate that the rate limiter is actually working as expected though.