### PR TITLE
managed: make finalizer name string public

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -35,7 +35,10 @@ import (
 )
 
 const (
-	managedFinalizerName = "finalizer.managedresource.crossplane.io"
+	// FinalizerName is the string that is used as finalizer on managed resource
+	// objects.
+	FinalizerName = "finalizer.managedresource.crossplane.io"
+
 	reconcileGracePeriod = 30 * time.Second
 	reconcileTimeout     = 1 * time.Minute
 
@@ -398,7 +401,7 @@ func defaultMRManaged(m manager.Manager) mrManaged {
 	return mrManaged{
 		CriticalAnnotationUpdater: NewRetryingCriticalAnnotationUpdater(m.GetClient()),
 		ConnectionPublisher:       NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
-		Finalizer:                 resource.NewAPIFinalizer(m.GetClient(), managedFinalizerName),
+		Finalizer:                 resource.NewAPIFinalizer(m.GetClient(), FinalizerName),
 		Initializer:               NewNameAsExternalName(m.GetClient()),
 		ReferenceResolver:         NewAPISimpleReferenceResolver(m.GetClient()),
 	}


### PR DESCRIPTION
### Description of your changes

We'll need to run some cleanup logic in Terrajet in `RemoveFinalizer` call but also keep using the existing finalizer object. However, constructing it just like other managed resources requires us to use this string.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Compiles.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
