### PR TITLE
Add Disconnect call in Reconcile

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -616,7 +616,7 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOp
 }
 
 // Reconcile a managed resource with an external resource.
-func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (result reconcile.Result, err error) { // nolint:gocyclo
+func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconcile.Result, error) { // nolint:gocyclo
 	// NOTE(negz): This method is a well over our cyclomatic complexity goal.
 	// Be wary of adding additional complexity.
 
@@ -745,13 +745,7 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (result
 		if disconnectErr := r.external.Disconnect(ctx); disconnectErr != nil {
 			log.Debug("Cannot disconnect from provider", "error", disconnectErr)
 			record.Event(managed, event.Warning(reasonCannotDisconnect, disconnectErr))
-			disconnectErr = errors.Wrap(disconnectErr, errReconcileDisconnect)
-			managed.SetConditions(xpv1.ReconcileError(disconnectErr))
-			if err != nil {
-				err = errors.Wrap(err, disconnectErr.Error())
-			} else {
-				err = disconnectErr
-			}
+			managed.SetConditions(xpv1.ReconcileError(errors.Wrap(disconnectErr, errReconcileDisconnect)))
 		}
 	}()
 

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -287,7 +287,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalDisconnectError": {
-			reason: "Errors disconnecting from the provider should return error.",
+			reason: "Error disconnecting from the provider should not trigger requeue.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -324,10 +324,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{
-				result: reconcile.Result{RequeueAfter: defaultpollInterval},
-				err:    errors.Wrap(errors.New("boom"), "disconnect failed"),
-			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
 		},
 		"ExternalObserveErrorDisconnectError": {
 			reason: "Errors disconnecting from the provider after error observing the external resource should trigger a requeue after a short wait and return error.",
@@ -364,10 +361,7 @@ func TestReconciler(t *testing.T) {
 					),
 				},
 			},
-			want: want{
-				result: reconcile.Result{Requeue: true},
-				err:    errors.Wrap(errors.New("boom"), "disconnect failed"),
-			},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ExternalObserveError": {
 			reason: "Errors observing the external resource should trigger a requeue after a short wait.",

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -286,6 +286,89 @@ func TestReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
+		"ExternalDisconnectError": {
+			reason: "Errors disconnecting from the provider should return error.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							want.SetConditions(xpv1.ReconcileSuccess())
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "A successful no-op reconcile should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnectDisconnecter(NewExternalConnectDisconnecter(
+						ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+							c := &ExternalClientFns{
+								ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+									return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+								},
+							}
+							return c, nil
+						}), ExternalDisconnectorFn(func(_ context.Context) error {
+							return errBoom
+						})),
+					),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{
+				result: reconcile.Result{RequeueAfter: defaultpollInterval},
+				err:    errors.Wrap(errors.New("boom"), "disconnect failed"),
+			},
+		},
+		"ExternalObserveErrorDisconnectError": {
+			reason: "Errors disconnecting from the provider after error observing the external resource should trigger a requeue after a short wait and return error.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+							want := &fake.Managed{}
+							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileObserve)))
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "Errors observing the managed resource should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithExternalConnectDisconnecter(NewExternalConnectDisconnecter(
+						ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+							c := &ExternalClientFns{
+								ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+									return ExternalObservation{}, errBoom
+								},
+							}
+							return c, nil
+						}), ExternalDisconnectorFn(func(_ context.Context) error {
+							return errBoom
+						})),
+					),
+				},
+			},
+			want: want{
+				result: reconcile.Result{Requeue: true},
+				err:    errors.Wrap(errors.New("boom"), "disconnect failed"),
+			},
+		},
 		"ExternalObserveError": {
 			reason: "Errors observing the external resource should trigger a requeue after a short wait.",
 			args: args{


### PR DESCRIPTION
### Description of your changes

I've add Disconnect call in end of Reconcile.
Some sdks required Close call after use. But I still want to create sdk in Connect call rather then create sdk in each Observe, Create, Update, Delete. And it's not possible to dispose sdk in the end of Reconcile.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.