### PR TITLE
Add wildcard expand method to fieldpath.Paved

### DIFF
--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -78,7 +78,7 @@ func (sg Segments) String() string {
 	for _, s := range sg {
 		switch s.Type {
 		case SegmentField:
-			if strings.ContainsRune(s.Field, period) {
+			if s.Field == wildcard || strings.ContainsRune(s.Field, period) {
 				b.WriteString(fmt.Sprintf("[%s]", s.Field))
 				continue
 			}
@@ -138,6 +138,8 @@ const (
 	period       = '.'
 	leftBracket  = '['
 	rightBracket = ']'
+
+	wildcard = "*"
 )
 
 type itemType int

--- a/pkg/fieldpath/fieldpath_test.go
+++ b/pkg/fieldpath/fieldpath_test.go
@@ -56,6 +56,15 @@ func TestSegments(t *testing.T) {
 			},
 			want: "data[.config.yml]",
 		},
+		"Wildcard": {
+			s: Segments{
+				Field("spec"),
+				Field("containers"),
+				FieldOrIndex("*"),
+				Field("name"),
+			},
+			want: "spec.containers[*].name",
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fieldpath
 
 import (
+	"strconv"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 
@@ -83,7 +85,10 @@ func (p *Paved) SetUnstructuredContent(content map[string]interface{}) {
 }
 
 func (p *Paved) getValue(s Segments) (interface{}, error) {
-	var it interface{} = p.object
+	return getValueFromInterface(p.object, s)
+}
+
+func getValueFromInterface(it interface{}, s Segments) (interface{}, error) {
 	for i, current := range s {
 		final := i == len(s)-1
 		switch current.Type {
@@ -99,7 +104,6 @@ func (p *Paved) getValue(s Segments) (interface{}, error) {
 				return array[current.Index], nil
 			}
 			it = array[current.Index]
-
 		case SegmentField:
 			object, ok := it.(map[string]interface{})
 			if !ok {
@@ -118,6 +122,69 @@ func (p *Paved) getValue(s Segments) (interface{}, error) {
 
 	// This should be unreachable.
 	return nil, nil
+}
+
+func (p *Paved) ExpandWildcards(path string) ([]string, error) {
+	segments, err := Parse(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse path %q", path)
+	}
+	segmentsArray, err := expandWildcards(p.object, segments)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot expand wildcards for segments: %q", segments)
+	}
+	paths := make([]string, len(segmentsArray))
+	for i, s := range segmentsArray {
+		paths[i] = s.String()
+	}
+	return paths, nil
+}
+
+func expandWildcards(data interface{}, segments Segments) ([]Segments, error) {
+	var res []Segments
+	it := data
+	for i, current := range segments {
+		if current.Type == SegmentField && current.Field == "*" {
+			switch mapOrArray := it.(type) {
+			case nil:
+				return nil, nil
+			case []interface{}:
+				for ix := range mapOrArray {
+					expanded := make(Segments, len(segments))
+					copy(expanded, segments)
+					expanded = append(append(expanded[:i], FieldOrIndex(strconv.Itoa(ix))), expanded[i+1:]...)
+					r, err := expandWildcards(data, expanded)
+					if err != nil {
+						return nil, errors.Wrapf(err, "%q: cannot expand wildcards", expanded)
+					}
+					res = append(res, r...)
+				}
+			case map[string]interface{}:
+				for k := range mapOrArray {
+					expanded := make(Segments, len(segments))
+					copy(expanded, segments)
+					expanded = append(append(expanded[:i], Field(k)), expanded[i+1:]...)
+					r, err := expandWildcards(data, expanded)
+					if err != nil {
+						return nil, errors.Wrapf(err, "%q: cannot expand wildcards", expanded)
+					}
+					res = append(res, r...)
+				}
+			default:
+				return nil, errors.Errorf("%q: unexpected wildcard usage", segments[:i])
+			}
+			return res, nil
+		}
+		var err error
+		it, err = getValueFromInterface(data, segments[:i+1])
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return append(res, segments), nil
 }
 
 // GetValue of the supplied field path.

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -157,7 +157,7 @@ func expandWildcards(data interface{}, segments Segments) ([]Segments, error) { 
 	it := data
 	for i, current := range segments {
 		// wildcards are regular fields with "*" as string
-		if current.Type == SegmentField && current.Field == "*" {
+		if current.Type == SegmentField && current.Field == wildcard {
 			switch mapOrArray := it.(type) {
 			case []interface{}:
 				for ix := range mapOrArray {

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -942,7 +942,7 @@ func TestExpandWildcards(t *testing.T) {
 			path:   "spec.containers[0].name[*]",
 			data:   []byte(`{"spec":{"containers":[{"name":"cool"}]}}`),
 			want: want{
-				err: errors.Wrapf(errors.Errorf("%q: unexpected wildcard usage", "spec.containers[0].name"), "cannot expand wildcards for segments: %q", "spec.containers[0].name.*"),
+				err: errors.Wrapf(errors.Errorf("%q: unexpected wildcard usage", "spec.containers[0].name"), "cannot expand wildcards for segments: %q", "spec.containers[0].name[*]"),
 			},
 		},
 		"NotAnArray": {

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -824,6 +825,165 @@ func TestSetValue(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.object, p.object); diff != "" {
 				t.Fatalf("\np.SetValue(%s, %v): %s: -want, +got:\n%s", tc.args.path, tc.args.value, tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestExpandWildcards(t *testing.T) {
+	type want struct {
+		expanded []string
+		err      error
+	}
+	cases := map[string]struct {
+		reason string
+		path   string
+		data   []byte
+		want   want
+	}{
+		"NoWildcardExisting": {
+			reason: "It should return same path if no wildcard in an existing path",
+			path:   "password",
+			data:   []byte(`{"password":"top-secret"}`),
+			want: want{
+				expanded: []string{"password"},
+			},
+		},
+		"NoWildcardNonExisting": {
+			reason: "It should return no results if no wildcard in a non-existing path",
+			path:   "username",
+			data:   []byte(`{"password":"top-secret"}`),
+			want: want{
+				expanded: []string{},
+			},
+		},
+		"NestedNoWildcardExisting": {
+			reason: "It should return same path if no wildcard in an existing path",
+			path:   "items[0][1]",
+			data:   []byte(`{"items":[["a", "b"]]}`),
+			want: want{
+				expanded: []string{"items[0][1]"},
+			},
+		},
+		"NestedNoWildcardNonExisting": {
+			reason: "It should return no results if no wildcard in a non-existing path",
+			path:   "items[0][5]",
+			data:   []byte(`{"items":[["a", "b"]]}`),
+			want: want{
+				expanded: []string{},
+			},
+		},
+		"NestedArray": {
+			reason: "It should return all possible paths for an array",
+			path:   "items[*][*]",
+			data:   []byte(`{"items":[["a", "b", "c"], ["d"]]}`),
+			want: want{
+				expanded: []string{"items[0][0]", "items[0][1]", "items[0][2]", "items[1][0]"},
+			},
+		},
+		"KeysOfMap": {
+			reason: "It should return all possible paths for a map in proper syntax",
+			path:   "items[*]",
+			data:   []byte(`{"items":{ "key1": "val1", "key2.as.annotation": "val2"}}`),
+			want: want{
+				expanded: []string{"items.key1", "items[key2.as.annotation]"},
+			},
+		},
+		"ArrayOfObjects": {
+			reason: "It should return all possible paths for an array of objects",
+			path:   "spec.containers[*][*]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now"]}]}}`),
+			want: want{
+				expanded: []string{"spec.containers[0].name", "spec.containers[0].image", "spec.containers[0].args"},
+			},
+		},
+		"MultiLayer": {
+			reason: "It should return all possible paths for a multilayer input",
+			path:   "spec.containers[*].args[*]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now", "debug"]}]}}`),
+			want: want{
+				expanded: []string{"spec.containers[0].args[0]", "spec.containers[0].args[1]", "spec.containers[0].args[2]"},
+			},
+		},
+		"WildcardInTheBeginning": {
+			reason: "It should return all possible paths for a multilayer input with wildcard in the beginning",
+			path:   "spec.containers[*].args[1]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now", "debug"]}]}}`),
+			want: want{
+				expanded: []string{"spec.containers[0].args[1]"},
+			},
+		},
+		"WildcardAtTheEnd": {
+			reason: "It should return all possible paths for a multilayer input with wildcard at the end",
+			path:   "spec.containers[0].args[*]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now", "debug"]}]}}`),
+			want: want{
+				expanded: []string{"spec.containers[0].args[0]", "spec.containers[0].args[1]", "spec.containers[0].args[2]"},
+			},
+		},
+		"NoData": {
+			reason: "If there is no input data, no expanded fields could be found",
+			path:   "metadata[*]",
+			data:   nil,
+			want: want{
+				expanded: []string{},
+			},
+		},
+		"InsufficientContainers": {
+			reason: "Requesting a non-existent array element should return nothing",
+			path:   "spec.containers[1].args[*]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool"}]}}`),
+			want: want{
+				expanded: []string{},
+			},
+		},
+		"UnexpectedWildcard": {
+			reason: "Requesting a wildcard for an object should fail",
+			path:   "spec.containers[0].name[*]",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool"}]}}`),
+			want: want{
+				err: errors.Wrapf(errors.Errorf("%q: unexpected wildcard usage", "spec.containers[0].name"), "cannot expand wildcards for segments: %q", "spec.containers[0].name.*"),
+			},
+		},
+		"NotAnArray": {
+			reason: "Indexing an object should fail",
+			path:   "metadata[1]",
+			data:   []byte(`{"metadata":{"nope":"cool"}}`),
+			want: want{
+				err: errors.Wrapf(errors.New("metadata: not an array"), "cannot expand wildcards for segments: %q", "metadata[1]"),
+			},
+		},
+		"NotAnObject": {
+			reason: "Requesting a field in an array should fail",
+			path:   "spec.containers[nope].name",
+			data:   []byte(`{"spec":{"containers":[{"name":"cool"}]}}`),
+			want: want{
+				err: errors.Wrapf(errors.New("spec.containers: not an object"), "cannot expand wildcards for segments: %q", "spec.containers.nope.name"),
+			},
+		},
+		"MalformedPath": {
+			reason: "Requesting an invalid field path should fail",
+			path:   "spec[]",
+			want: want{
+				err: errors.Wrap(errors.New("unexpected ']' at position 5"), "cannot parse path \"spec[]\""),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			in := make(map[string]interface{})
+			_ = json.Unmarshal(tc.data, &in)
+			p := Pave(in)
+
+			got, err := p.ExpandWildcards(tc.path)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("\np.ExpandWildcards(%s): %s: -want error, +got error:\n%s", tc.path, tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.expanded, got, cmpopts.SortSlices(func(x, y string) bool {
+				return x < y
+			})); diff != "" {
+				t.Errorf("\np.ExpandWildcards(%s): %s: -want, +got:\n%s", tc.path, tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

During terrajet work, we need a way to define [sensitive fields](https://github.com/crossplane-contrib/terrajet/pull/77) as fieldpaths. However, since these paths are defined during code generation, where actual data is not available yet (e.g. managed resource spec), we needed a way to define them as wildcards for fields with arrays and/or maps. 

This PR adds `ExpandWildcards` method on `fieldpath.Paved` object. This function returns available fieldpaths by expanding wildcard (`*`) characters in the given input.

Example: 

For a Paved object with the following data: 
```
[]byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now", "debug"]}]}}`),
```

`ExpandWildcards("spec.containers[*].args[*]")` returns:

`[]string{"spec.containers[0].args[0]", "spec.containers[0].args[1]", "spec.containers[0].args[2]"}`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

With unit tests and [the terrajet PR](https://github.com/crossplane-contrib/terrajet/pull/77) relying on this functionality.

[contribution process]: https://git.io/fj2m9
