### PR TITLE
Only attempt object scheme parsing if object is not registered in meta

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -150,7 +149,7 @@ func isWhiteSpace(bytes []byte) bool {
 // annotateErr annotates an error if the reader is an AnnotatedReadCloser.
 func annotateErr(err error, reader io.ReadCloser) error {
 	if anno, ok := reader.(AnnotatedReadCloser); ok {
-		return errors.Wrap(err, fmt.Sprintf("%+v", anno.Annotate()))
+		return errors.Wrapf(err, "%+v", anno.Annotate())
 	}
 	return err
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -112,26 +112,19 @@ func (p *PackageParser) Parse(ctx context.Context, reader io.ReadCloser) (*Packa
 		if len(bytes) == 0 {
 			continue
 		}
+		if isWhiteSpace(bytes) {
+			continue
+		}
 		m, _, err := dm.Decode(bytes, nil, nil)
 		if err != nil {
+			// NOTE(hasheddan): we only try to decode with object scheme if the
+			// error is due the object not being registered in the meta scheme.
+			if !runtime.IsNotRegisteredError(err) {
+				return pkg, annotateErr(err, reader)
+			}
 			o, _, err := do.Decode(bytes, nil, nil)
 			if err != nil {
-				empty := true
-				for _, b := range bytes {
-					if !unicode.IsSpace(rune(b)) {
-						empty = false
-						break
-					}
-				}
-				// If the YAML document only contains Unicode White Space we
-				// ignore and do not return an error.
-				if empty {
-					continue
-				}
-				if anno, ok := reader.(AnnotatedReadCloser); ok {
-					return pkg, errors.Wrap(err, fmt.Sprintf("%+v", anno.Annotate()))
-				}
-				return pkg, err
+				return pkg, annotateErr(err, reader)
 			}
 			pkg.objects = append(pkg.objects, o)
 			continue
@@ -139,6 +132,27 @@ func (p *PackageParser) Parse(ctx context.Context, reader io.ReadCloser) (*Packa
 		pkg.meta = append(pkg.meta, m)
 	}
 	return pkg, nil
+}
+
+// isWhiteSpace determines whether the passed in bytes are all unicode white
+// space.
+func isWhiteSpace(bytes []byte) bool {
+	empty := true
+	for _, b := range bytes {
+		if !unicode.IsSpace(rune(b)) {
+			empty = false
+			break
+		}
+	}
+	return empty
+}
+
+// annotateErr annotates an error if the reader is an AnnotatedReadCloser.
+func annotateErr(err error, reader io.ReadCloser) error {
+	if anno, ok := reader.(AnnotatedReadCloser); ok {
+		return errors.Wrap(err, fmt.Sprintf("%+v", anno.Annotate()))
+	}
+	return err
 }
 
 // BackendOption modifies the parser backend. Backends may accept options at


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the package parsing logic to only attempt decoding with the
object scheme in the case that the error from decoding in the meta
scheme is due to the GVK not being registered. This does not change the
definition of a valid package, but does result in more informative
errors being returned when a package is invalid due to a malformed meta
type.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #299 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested with example in #299 and returned the following error (this is using Crossplane CLI, but same parsing is used in package manager, minus the annotated file position):
```
kubectl crossplane: error: failed to build package: failed to parse package: {path:/home/dan/code/github.com/crossplane/crossplane/pack/crossplane.yaml position:0}: v1alpha1.Provider.Spec: v1alpha1.ProviderSpec.Controller: readObjectStart: expect { or n, but found ", error found in #10 byte of ...|troller":"image cros|..., bigger context ...|cp"},"name":"provider-gcp"},"spec":{"controller":"image crossplane/provider-gcp-controller:VERSION"}|...
```

[contribution process]: https://git.io/fj2m9
