### PR TITLE
Allow manage objects with scope Namespaced

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -176,7 +176,7 @@ func NewRetryingCriticalAnnotationUpdater(c client.Client) *RetryingCriticalAnno
 func (u *RetryingCriticalAnnotationUpdater) UpdateCriticalAnnotations(ctx context.Context, o client.Object) error {
 	a := o.GetAnnotations()
 	err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
-		nn := types.NamespacedName{Name: o.GetName()}
+		nn := types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
 		if err := u.client.Get(ctx, nn, o); err != nil {
 			return err
 		}

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -215,7 +215,7 @@ func (r *APIResolver) Resolve(ctx context.Context, req ResolutionRequest) (Resol
 
 	// The reference is already set - resolve it.
 	if req.Reference != nil {
-		if err := r.client.Get(ctx, types.NamespacedName{Name: req.Reference.Name}, req.To.Managed); err != nil {
+		if err := r.client.Get(ctx, types.NamespacedName{Name: req.Reference.Name, Namespace: r.from.GetNamespace()}, req.To.Managed); err != nil {
 			return ResolutionResponse{}, errors.Wrap(err, errGetManaged)
 		}
 
@@ -224,7 +224,7 @@ func (r *APIResolver) Resolve(ctx context.Context, req ResolutionRequest) (Resol
 	}
 
 	// The reference was not set, but a selector was. Select a reference.
-	if err := r.client.List(ctx, req.To.List, client.MatchingLabels(req.Selector.MatchLabels)); err != nil {
+	if err := r.client.List(ctx, req.To.List, client.MatchingLabels(req.Selector.MatchLabels), client.InNamespace(r.from.GetNamespace())); err != nil {
 		return ResolutionResponse{}, errors.Wrap(err, errListManaged)
 	}
 
@@ -254,7 +254,7 @@ func (r *APIResolver) ResolveMultiple(ctx context.Context, req MultiResolutionRe
 	if len(req.References) > 0 {
 		vals := make([]string, len(req.References))
 		for i := range req.References {
-			if err := r.client.Get(ctx, types.NamespacedName{Name: req.References[i].Name}, req.To.Managed); err != nil {
+			if err := r.client.Get(ctx, types.NamespacedName{Name: req.References[i].Name, Namespace: r.from.GetNamespace()}, req.To.Managed); err != nil {
 				return MultiResolutionResponse{}, errors.Wrap(err, errGetManaged)
 			}
 			vals[i] = req.Extract(req.To.Managed)
@@ -265,7 +265,7 @@ func (r *APIResolver) ResolveMultiple(ctx context.Context, req MultiResolutionRe
 	}
 
 	// No references were set, but a selector was. Select and resolve references.
-	if err := r.client.List(ctx, req.To.List, client.MatchingLabels(req.Selector.MatchLabels)); err != nil {
+	if err := r.client.List(ctx, req.To.List, client.MatchingLabels(req.Selector.MatchLabels), client.InNamespace(r.from.GetNamespace())); err != nil {
 		return MultiResolutionResponse{}, errors.Wrap(err, errListManaged)
 	}
 

--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -149,6 +149,7 @@ func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg Managed) erro
 		Kind:       gvk.Kind,
 		Name:       mg.GetName(),
 	})
+	pcu.SetNamespace(mg.GetNamespace())
 
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),


### PR DESCRIPTION
Signed-off-by: vaspahomov <vas2142553@gmail.com>

### Description of your changes

Added support of Namespaced Managed Resources. In my mind this patch will not affect on current behaviour with Cluster scoped resources. But with this patch you can use Namespaced objects as well as Cluster scoped.

Fixes #251

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested with provider-aws, provider-azure with replace in go.mod

[contribution process]: https://git.io/fj2m9
