### PR TITLE
package.parser: make Or linter work with arbitrary number of linters

### DIFF
--- a/pkg/parser/linter.go
+++ b/pkg/parser/linter.go
@@ -99,7 +99,7 @@ func (l *PackageLinter) Lint(pkg *Package) error {
 // error.
 func Or(linters ...ObjectLinterFn) ObjectLinterFn {
 	return func(o runtime.Object) error {
-		var errSet string
+		var errs []string
 		for _, l := range linters {
 			if l == nil {
 				return errors.New(errNilLinterFn)
@@ -108,8 +108,8 @@ func Or(linters ...ObjectLinterFn) ObjectLinterFn {
 			if err == nil {
 				return nil
 			}
-			errSet += err.Error() + ", "
+			errs = append(errs, err.Error())
 		}
-		return errors.Errorf(errOrFmt, strings.TrimSuffix(errSet, ", "))
+		return errors.Errorf(errOrFmt, strings.Join(errs, ", "))
 	}
 }

--- a/pkg/parser/linter_test.go
+++ b/pkg/parser/linter_test.go
@@ -112,7 +112,7 @@ func TestLinter(t *testing.T) {
 					objects: []runtime.Object{crd},
 				},
 			},
-			err: errors.Errorf(errOrFmt, errBoom, errBoom),
+			err: errors.Errorf(errOrFmt, errBoom.Error()+", "+errBoom.Error()),
 		},
 	}
 
@@ -160,7 +160,7 @@ func TestOr(t *testing.T) {
 				one: objFail,
 				two: objFail,
 			},
-			err: errors.Errorf(errOrFmt, errBoom, errBoom),
+			err: errors.Errorf(errOrFmt, errBoom.Error()+", "+errBoom.Error()),
 		},
 		"ErrNilLinter": {
 			reason: "Passing a nil linter will should always return error.",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

We need this in provider linter where we need to allow three distinct types, `CustomResourceDefinition`, `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests. No breaking change in the interface only the format of the printed error is different now.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
