### PR TITLE
Add validator and mutator chain executors to be used by provider webhooks

### DIFF
--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var _ webhook.CustomDefaulter = &Mutator{}
+
+// WithMutatorFns allows you to initiate the mutator with given list of mutator
+// functions.
+func WithMutatorFns(fns ...MutatorFn) MutatorOption {
+	return func(m *Mutator) {
+		m.MutatorChain = fns
+	}
+}
+
+// MutatorOption configures given Mutator.
+type MutatorOption func(*Mutator)
+
+// MutatorFn is a single mutating function that can be used by Mutator.
+type MutatorFn func(ctx context.Context, obj runtime.Object) error
+
+// NewMutator returns a new instance of Mutator that can be used as CustomDefaulter.
+func NewMutator(opts ...MutatorOption) *Mutator {
+	m := &Mutator{
+		MutatorChain: []MutatorFn{},
+	}
+	for _, f := range opts {
+		f(m)
+	}
+	return m
+}
+
+// Mutator satisfies CustomDefaulter interface with an ordered MutatorFn list.
+type Mutator struct {
+	MutatorChain []MutatorFn
+}
+
+// Default executes the MutatorFns in given order. Its name might sound misleading
+// since defaulting seems to be the first use case used by controller-runtime
+// but MutatorFns can make any changes on given resource.
+func (m *Mutator) Default(ctx context.Context, obj runtime.Object) error {
+	for _, f := range m.MutatorChain {
+		if err := f(ctx, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -20,29 +20,26 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-var _ webhook.CustomDefaulter = &Mutator{}
-
-// WithMutatorFns allows you to initiate the mutator with given list of mutator
+// WithMutationFns allows you to initiate the mutator with given list of mutator
 // functions.
-func WithMutatorFns(fns ...MutatorFn) MutatorOption {
+func WithMutationFns(fns ...MutateFn) MutatorOption {
 	return func(m *Mutator) {
-		m.MutatorChain = fns
+		m.MutationChain = fns
 	}
 }
 
 // MutatorOption configures given Mutator.
 type MutatorOption func(*Mutator)
 
-// MutatorFn is a single mutating function that can be used by Mutator.
-type MutatorFn func(ctx context.Context, obj runtime.Object) error
+// MutateFn is a single mutating function that can be used by Mutator.
+type MutateFn func(ctx context.Context, obj runtime.Object) error
 
 // NewMutator returns a new instance of Mutator that can be used as CustomDefaulter.
 func NewMutator(opts ...MutatorOption) *Mutator {
 	m := &Mutator{
-		MutatorChain: []MutatorFn{},
+		MutationChain: []MutateFn{},
 	}
 	for _, f := range opts {
 		f(m)
@@ -50,16 +47,16 @@ func NewMutator(opts ...MutatorOption) *Mutator {
 	return m
 }
 
-// Mutator satisfies CustomDefaulter interface with an ordered MutatorFn list.
+// Mutator satisfies CustomDefaulter interface with an ordered MutateFn list.
 type Mutator struct {
-	MutatorChain []MutatorFn
+	MutationChain []MutateFn
 }
 
 // Default executes the MutatorFns in given order. Its name might sound misleading
 // since defaulting seems to be the first use case used by controller-runtime
 // but MutatorFns can make any changes on given resource.
 func (m *Mutator) Default(ctx context.Context, obj runtime.Object) error {
-	for _, f := range m.MutatorChain {
+	for _, f := range m.MutationChain {
 		if err := f(ctx, obj); err != nil {
 			return err
 		}

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+// Mutator has to satisfy CustomDefaulter interface so that it can be used by
+// controller-runtime Manager.
+var _ webhook.CustomDefaulter = &Mutator{}
+
+func TestDefault(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+		fns []MutateFn
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"Success": {
+			reason: "Functions without errors should be executed successfully",
+			args: args{
+				fns: []MutateFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return nil
+					},
+				},
+			},
+		},
+		"Failure": {
+			reason: "Functions with errors should return with error",
+			args: args{
+				fns: []MutateFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return errBoom
+					},
+				},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v := NewMutator(WithMutationFns(tc.fns...))
+			err := v.Default(context.TODO(), tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDefault(...): -want, +got\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -25,9 +25,9 @@ import (
 
 var _ webhook.CustomValidator = &Validator{}
 
-// WithValidateCreateFns initializes the Validator with given set of creation
+// WithValidateCreationFns initializes the Validator with given set of creation
 // validation functions.
-func WithValidateCreateFns(fns ...ValidateCreateFn) ValidatorOption {
+func WithValidateCreationFns(fns ...ValidateCreateFn) ValidatorOption {
 	return func(v *Validator) {
 		v.CreationChain = fns
 	}

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ admission.CustomValidator = &Validator{}
+
+// NewValidator returns a new Validator with no-op defaults.
+func NewValidator() *Validator {
+	vc := &Validator{
+		CreationChain: []ValidateCreateFn{NopValidateCreate},
+		UpdateChain:   []ValidateUpdateFn{NopValidateUpdate},
+		DeletionChain: []ValidateDeleteFn{NopValidateDelete},
+	}
+	return vc
+}
+
+// ValidateCreateFn is function type for creation validation.
+type ValidateCreateFn func(ctx context.Context, obj runtime.Object) error
+
+// ValidateUpdateFn is function type for update validation.
+type ValidateUpdateFn func(ctx context.Context, oldObj, newObj runtime.Object) error
+
+// ValidateDeleteFn is function type for deletion validation.
+type ValidateDeleteFn func(ctx context.Context, obj runtime.Object) error
+
+// No-op validator functions.
+var (
+	NopValidateCreate ValidateCreateFn = func(_ context.Context, _ runtime.Object) error {
+		return nil
+	}
+	NopValidateUpdate ValidateUpdateFn = func(_ context.Context, _, _ runtime.Object) error {
+		return nil
+	}
+	NopValidateDelete ValidateDeleteFn = func(_ context.Context, _ runtime.Object) error {
+		return nil
+	}
+)
+
+// Validator runs the given validation chains in order.
+type Validator struct {
+	CreationChain []ValidateCreateFn
+	UpdateChain   []ValidateUpdateFn
+	DeletionChain []ValidateDeleteFn
+}
+
+// ValidateCreate runs functions in creation chain in order.
+func (vc *Validator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	for _, f := range vc.CreationChain {
+		if err := f(ctx, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateUpdate runs functions in update chain in order.
+func (vc *Validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	for _, f := range vc.UpdateChain {
+		if err := f(ctx, oldObj, newObj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateDelete runs functions in deletion chain in order.
+func (vc *Validator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	for _, f := range vc.DeletionChain {
+		if err := f(ctx, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-var _ admission.CustomValidator = &Validator{}
+var _ webhook.CustomValidator = &Validator{}
 
 // NewValidator returns a new Validator with no-op defaults.
 func NewValidator() *Validator {

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -20,10 +20,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
-
-var _ webhook.CustomValidator = &Validator{}
 
 // WithValidateCreationFns initializes the Validator with given set of creation
 // validation functions.

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -20,13 +20,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
+
+// Validator has to satisfy CustomValidator interface so that it can be used by
+// controller-runtime Manager.
+var _ webhook.CustomValidator = &Validator{}
 
 var errBoom = errors.New("boom")
 

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+)
+
+var errBoom = errors.New("boom")
+
+func TestValidateCreate(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+		fns []ValidateCreateFn
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"Success": {
+			reason: "Functions without errors should be executed successfully",
+			args: args{
+				fns: []ValidateCreateFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return nil
+					},
+				},
+			},
+		},
+		"Failure": {
+			reason: "Functions with errors should return with error",
+			args: args{
+				fns: []ValidateCreateFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return errBoom
+					},
+				},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v := NewValidator(WithValidateCreationFns(tc.fns...))
+			err := v.ValidateCreate(context.TODO(), tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nValidateCreate(...): -want, +got\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	type args struct {
+		oldObj runtime.Object
+		newObj runtime.Object
+		fns    []ValidateUpdateFn
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"Success": {
+			reason: "Functions without errors should be executed successfully",
+			args: args{
+				fns: []ValidateUpdateFn{
+					func(_ context.Context, _, _ runtime.Object) error {
+						return nil
+					},
+				},
+			},
+		},
+		"Failure": {
+			reason: "Functions with errors should return with error",
+			args: args{
+				fns: []ValidateUpdateFn{
+					func(_ context.Context, _, _ runtime.Object) error {
+						return errBoom
+					},
+				},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v := NewValidator(WithValidateUpdateFns(tc.fns...))
+			err := v.ValidateUpdate(context.TODO(), tc.args.oldObj, tc.args.newObj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nValidateUpdate(...): -want, +got\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestValidateDelete(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+		fns []ValidateDeleteFn
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"Success": {
+			reason: "Functions without errors should be executed successfully",
+			args: args{
+				fns: []ValidateDeleteFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return nil
+					},
+				},
+			},
+		},
+		"Failure": {
+			reason: "Functions with errors should return with error",
+			args: args{
+				fns: []ValidateDeleteFn{
+					func(_ context.Context, _ runtime.Object) error {
+						return errBoom
+					},
+				},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v := NewValidator(WithValidateDeletionFns(tc.fns...))
+			err := v.ValidateDelete(context.TODO(), tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nValidateDelete(...): -want, +got\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Adds two utilities to be used in webhook implementations of the providers so that they can append webhook functionality from multiple places so that generated and non-generated functions can live in different files/packages.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

You can see an example usage in https://github.com/crossplane/provider-aws/pull/1191

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
