### PR TITLE
Add support for a pause annotation which pauses reconciliations on managed resources

### DIFF
--- a/apis/common/v1/condition.go
+++ b/apis/common/v1/condition.go
@@ -51,6 +51,7 @@ const (
 const (
 	ReasonReconcileSuccess ConditionReason = "ReconcileSuccess"
 	ReasonReconcileError   ConditionReason = "ReconcileError"
+	ReasonReconcilePaused  ConditionReason = "ReconcilePaused"
 )
 
 // A Condition that may apply to a resource.
@@ -248,5 +249,16 @@ func ReconcileError(err error) Condition {
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonReconcileError,
 		Message:            err.Error(),
+	}
+}
+
+// ReconcilePaused returns a condition that indicates reconciliation on
+// the managed resource is paused via the pause annotation.
+func ReconcilePaused() Condition {
+	return Condition{
+		Type:               TypeSynced,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonReconcilePaused,
 	}
 }

--- a/apis/common/v1/condition_test.go
+++ b/apis/common/v1/condition_test.go
@@ -57,6 +57,15 @@ func TestConditionEqual(t *testing.T) {
 			b:    Condition{Message: "uncool"},
 			want: false,
 		},
+		"CheckReconcilePaused": {
+			a: ReconcilePaused(),
+			b: Condition{
+				Type:   TypeSynced,
+				Status: corev1.ConditionFalse,
+				Reason: ReasonReconcilePaused,
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -57,6 +57,13 @@ const (
 	// of a resource that indicates the last time creation of the external
 	// resource failed. Its value must be an RFC3999 timestamp.
 	AnnotationKeyExternalCreateFailed = "crossplane.io/external-create-failed"
+
+	// AnnotationKeyReconciliationPaused is the key in the annotations map
+	// of a resource that indicates that further reconciliations on the
+	// resource are paused. All create/update/delete/generic events on
+	// the resource will be filtered and thus no further reconcile requests
+	// will be queued for the resource.
+	AnnotationKeyReconciliationPaused = "crossplane.io/paused"
 )
 
 // Supported resources with all of these annotations will be fully or partially

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -419,3 +419,9 @@ func AllowsPropagationTo(from metav1.Object) map[types.NamespacedName]bool {
 
 	return to
 }
+
+// IsPaused returns true if the object has the AnnotationKeyReconciliationPaused
+// annotation set to `true`.
+func IsPaused(o metav1.Object) bool {
+	return o.GetAnnotations()[AnnotationKeyReconciliationPaused] == "true"
+}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1320,3 +1320,43 @@ func TestAllowsPropagationTo(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPaused(t *testing.T) {
+	cases := map[string]struct {
+		o    metav1.Object
+		want bool
+	}{
+		"HasPauseAnnotationSetTrue": {
+			o: func() metav1.Object {
+				p := &corev1.Pod{}
+				p.SetAnnotations(map[string]string{
+					AnnotationKeyReconciliationPaused: "true",
+				})
+				return p
+			}(),
+			want: true,
+		},
+		"NoPauseAnnotation": {
+			o:    &corev1.Pod{},
+			want: false,
+		},
+		"HasEmptyPauseAnnotation": {
+			o: func() metav1.Object {
+				p := &corev1.Pod{}
+				p.SetAnnotations(map[string]string{
+					AnnotationKeyReconciliationPaused: "",
+				})
+				return p
+			}(),
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IsPaused(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("IsPaused(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -664,9 +664,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		"external-name", meta.GetExternalName(managed),
 	)
 
-	// check the pause annotation and return if it has the value "true"
+	// Check the pause annotation and return if it has the value "true"
 	// after logging, publishing an event and updating the SYNC status condition
-	if managed.GetAnnotations()[meta.AnnotationKeyReconciliationPaused] == "true" {
+	if meta.IsPaused(managed) {
 		log.Debug("Reconciliation is paused via the pause annotation", "annotation", meta.AnnotationKeyReconciliationPaused, "value", "true")
 		record.Event(managed, event.Normal(reasonReconciliationPaused, "Reconciliation is paused via the pause annotation"))
 		managed.SetConditions(xpv1.ReconcilePaused())


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #351 

With this PR, if a managed resource has the `crossplane.io/paused` annotation with its value set to `true`, then the managed reconciler emits an event indicating that further reconciliations on that resource are paused and returns early after setting a `Synced` status condition with `False` status and `ReconcilePaused` reason. If the annotation is removed or its value is changed, reconciliation resumes.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested with the following resource manifest:
```yaml
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
metadata:
  name: paused
  annotations:
    crossplane.io/paused: "true"
spec:
  forProvider:
    cidrBlock: 192.168.0.0/16
    region: us-west-2
    tags:
      Name: alper-xp-351
  providerConfigRef:
    name: default
```

With the `crossplane.io/paused: "true"` annotation, the managed resource acquires the following status condition:
```yaml
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2022-09-28T12:30:45Z"
    reason: ReconcilePaused
    status: "False"
    type: Synced
```
And the following associated events are emitted:
```
Events:
  Type    Reason                Age                  From                                          Message
  ----    ------                ----                 ----                                          -------
  Normal  ReconciliationPaused  2m3s (x2 over 2m3s)  managed/ec2.aws.upbound.io/v1beta1, kind=vpc  Reconciliation is paused via the pause annotation
```

If the value of the annotation is changed to `false`, reconciliation resumes and the status of the `Synced` status condition is updated:
```yaml
status:
  atProvider:
     ...
  conditions:
  - lastTransitionTime: "2022-09-28T12:34:30Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```

[contribution process]: https://git.io/fj2m9
