### PR TITLE
Add a Server-Side Applicator

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -173,17 +173,14 @@ func NewAPIServerSideApplicator(c client.Client, owner string) *APIServerSideApp
 // apply that will calculate the diff in server-side and patch the object in
 // the storage instead of client calculating the diff.
 // This is preferred over client-side apply implementations in general.
-func (a *APIServerSideApplicator) Apply(ctx context.Context, o client.Object, ao ...ApplyOption) error {
+func (a *APIServerSideApplicator) Apply(ctx context.Context, o client.Object, _ ...ApplyOption) error {
 	m, ok := o.(metav1.Object)
 	if !ok {
 		return errors.New("cannot access object metadata")
 	}
-
-	if m.GetName() == "" && m.GetGenerateName() != "" {
-		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
-	}
-	// Required by server-side apply.
-	o.SetManagedFields(nil)
+	m.SetManagedFields(nil)
+	m.SetUID("")
+	m.SetResourceVersion("")
 	return errors.Wrap(
 		a.client.Patch(
 			ctx,


### PR DESCRIPTION
### Description of your changes

Adds the ability to utilize server-side apply mechanism by providers and core Crossplane. Unfortunately, `ApplyOption` argument is not relevant for this method since there is no fetching of an existing object. However, there are some patching options that users may want to set per-call, especially the owner. Initially, it was part of `NewAPIServerSideApplicator` function but that'd force you to use single owner for many calls, i.e. we'd have to use `composite` as owner for all managed resources. Now, we can actually use the composite name, which would be more accurate and helpful for debugging purposes.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests and basic usage test. I'll expand this section with more usage in composition.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
