### PR TITLE
Add omitempty json tag to fake.ConnectionDetailsLastPublishedTimer.Time field

### DIFF
--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -249,7 +249,13 @@ func (m *EnvironmentConfigReferencer) GetEnvironmentConfigReferences() []corev1.
 
 // ConnectionDetailsLastPublishedTimer is a mock that implements the
 // ConnectionDetailsLastPublishedTimer interface.
-type ConnectionDetailsLastPublishedTimer struct{ Time *metav1.Time }
+type ConnectionDetailsLastPublishedTimer struct {
+	// NOTE: runtime.DefaultUnstructuredConverter.ToUnstructured
+	// cannot currently handle if `Time` is nil here.
+	// The `omitempty` json tag is a workaround that
+	// prevents a panic.
+	Time *metav1.Time `json:"lastPublishedTime,omitempty"`
+}
 
 // SetConnectionDetailsLastPublishedTime sets the published time.
 func (c *ConnectionDetailsLastPublishedTimer) SetConnectionDetailsLastPublishedTime(t *metav1.Time) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
If the `runtime.DefaultUnstructuredConverter.ToUnstructured` attempts to convert a nil `fake.ConnectionDetailsLastPublishedTimer.Time`, it panics with something like:
```
panic: value method k8s.io/apimachinery/pkg/apis/meta/v1.Time.ToUnstructured called using nil *Time pointer [recovered]
	panic: value method k8s.io/apimachinery/pkg/apis/meta/v1.Time.ToUnstructured called using nil *Time pointer

goroutine 187 [running]:
testing.tRunner.func1.2({0x103d3a520, 0x140003b8f00})
	/Users/alper/.goenv/versions/1.19.1/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
	/Users/alper/.goenv/versions/1.19.1/src/testing/testing.go:1399 +0x378
panic({0x103d3a520, 0x140003b8f00})
	/Users/alper/.goenv/versions/1.19.1/src/runtime/panic.go:884 +0x204
k8s.io/apimachinery/pkg/apis/meta/v1.(*Time).ToUnstructured(0x100000001?)
	<autogenerated>:1 +0x48
sigs.k8s.io/structured-merge-diff/v4/value.TypeReflectCacheEntry.ToUnstructured({0x1, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, {0x0, 0x0, 0x0}}, ...)
	/Users/alper/data/workspaces/go/pkg/mod/sigs.k8s.io/structured-merge-diff/v4@v4.2.1/value/reflectcache.go:188 +0x6b0
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x103ec4bc0?, 0x1400052e478?, 0x0?}, {0x103d1a7a0?, 0x140003b8ec0?, 0x1030d966c?})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:655 +0x8a0
k8s.io/apimachinery/pkg/runtime.structToUnstructured({0x103d62f80?, 0x1400052e478?, 0x1400025d928?}, {0x103d1a7a0?, 0x140003b8e80?, 0xed00000000000196?})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:843 +0x7ac
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x103d62f80?, 0x1400052e478?, 0xb?}, {0x103d1a7a0?, 0x140003b8e80?, 0x98?})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:692 +0x7f4
k8s.io/apimachinery/pkg/runtime.structToUnstructured({0x103e66b60?, 0x1400052e300?, 0x103eee610?}, {0x103d31660?, 0x140000ca080?, 0x196?})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:843 +0x7ac
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x103e66b60?, 0x1400052e300?, 0x1400052e300?}, {0x103d31660?, 0x140000ca080?, 0x14000329540?})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:692 +0x7f4
k8s.io/apimachinery/pkg/runtime.(*unstructuredConverter).ToUnstructured(0x1048b2270, {0x103ec3300?, 0x1400052e300})
	/Users/alper/data/workspaces/go/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/runtime/converter.go:586 +0x364
github.com/crossplane/crossplane/apis/apiextensions/v1.(*Patch).applyFromFieldPathPatch(0x140000fa430, {0x103ed1fe0?, 0x1400052e300?}, {0x103ed1fb8, 0x140001819e0})
	/Users/alper/data/workspaces/github.com/ulucinar/crossplane/crossplane/apis/apiextensions/v1/composition_patches.go:225 +0x98
github.com/crossplane/crossplane/apis/apiextensions/v1.(*Patch).Apply(0x140000fa430, {0x12c7d25d8?, 0x1400052e300}, {0x103eef960?, 0x140001819e0}, {0x0?, 0x1400048beb8?, 0x102d03c2c?})
	/Users/alper/data/workspaces/github.com/ulucinar/crossplane/crossplane/apis/apiextensions/v1/composition_patches.go:130 +0x164
github.com/crossplane/crossplane/apis/apiextensions/v1.TestPatchApply.func3(0x140004831e0)
	/Users/alper/data/workspaces/github.com/ulucinar/crossplane/crossplane/apis/apiextensions/v1/composition_patches_test.go:863 +0x84
testing.tRunner(0x140004831e0, 0x140003b86a0)
	/Users/alper/.goenv/versions/1.19.1/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
	/Users/alper/.goenv/versions/1.19.1/src/testing/testing.go:1493 +0x300
```

This PR proposes an `omitempty` json tag to be added to `fake.ConnectionDetailsLastPublishedTimer.Time`, so that `runtime.DefaultUnstructuredConverter.ToUnstructured` will not fail. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Consumed and tested in PR https://github.com/crossplane/crossplane/pull/3394.

[contribution process]: https://git.io/fj2m9
