### PR TITLE
Add composition revision selectors

### DIFF
--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -191,6 +191,19 @@ func (m *CompositionRevisionReferencer) GetCompositionRevisionReference() *corev
 	return m.Ref
 }
 
+// CompositionRevisionSelector is a mock that implements CompositionRevisionSelector interface.
+type CompositionRevisionSelector struct{ Sel *metav1.LabelSelector }
+
+// SetCompositionRevisionReference sets the CompositionRevisionReference.
+func (m *CompositionRevisionSelector) SetCompositionRevisionSelector(ls *metav1.LabelSelector) {
+	m.Sel = ls
+}
+
+// GetCompositionRevisionSelector gets the CompositionRevisionSelector.
+func (m *CompositionRevisionSelector) GetCompositionRevisionSelector() *metav1.LabelSelector {
+	return m.Sel
+}
+
 // CompositionUpdater is a mock that implements CompositionUpdater interface.
 type CompositionUpdater struct{ Policy *xpv1.UpdatePolicy }
 
@@ -336,6 +349,7 @@ type Composite struct {
 	CompositionSelector
 	CompositionReferencer
 	CompositionRevisionReferencer
+	CompositionRevisionSelector
 	CompositionUpdater
 	ComposedResourcesReferencer
 	EnvironmentConfigReferencer
@@ -393,6 +407,7 @@ type CompositeClaim struct {
 	CompositionSelector
 	CompositionReferencer
 	CompositionRevisionReferencer
+	CompositionRevisionSelector
 	CompositeResourceDeleter
 	CompositionUpdater
 	CompositeResourceReferencer

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -123,6 +123,13 @@ type CompositionRevisionReferencer interface {
 	GetCompositionRevisionReference() *corev1.ObjectReference
 }
 
+// A CompositionRevisionSelector may reference a set of
+// composition revisions.
+type CompositionRevisionSelector interface {
+	SetCompositionRevisionSelector(selector *metav1.LabelSelector)
+	GetCompositionRevisionSelector() *metav1.LabelSelector
+}
+
 // A CompositionUpdater uses a composition, and may update which revision of
 // that composition it uses.
 type CompositionUpdater interface {
@@ -228,6 +235,7 @@ type Composite interface {
 	CompositionReferencer
 	CompositionUpdater
 	CompositionRevisionReferencer
+	CompositionRevisionSelector
 	ComposedResourcesReferencer
 	EnvironmentConfigReferencer
 	ClaimReferencer
@@ -255,6 +263,7 @@ type CompositeClaim interface {
 	CompositionReferencer
 	CompositionUpdater
 	CompositionRevisionReferencer
+	CompositionRevisionSelector
 	CompositeResourceDeleter
 	CompositeResourceReferencer
 	LocalConnectionSecretWriterTo

--- a/pkg/resource/unstructured/claim/claim.go
+++ b/pkg/resource/unstructured/claim/claim.go
@@ -107,6 +107,20 @@ func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.ObjectReferen
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionRef", ref)
 }
 
+// GetCompositionRevisionSelector of this resource claim.
+func (c *Unstructured) GetCompositionRevisionSelector() *metav1.LabelSelector {
+	out := &metav1.LabelSelector{}
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionRevisionSelector", out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// SetCompositionRevisionSelector of this resource claim.
+func (c *Unstructured) SetCompositionRevisionSelector(ref *metav1.LabelSelector) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionSelector", ref)
+}
+
 // SetCompositionUpdatePolicy of this resource claim.
 func (c *Unstructured) SetCompositionUpdatePolicy(p *xpv1.UpdatePolicy) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionUpdatePolicy", p)

--- a/pkg/resource/unstructured/claim/claim_test.go
+++ b/pkg/resource/unstructured/claim/claim_test.go
@@ -191,6 +191,31 @@ func TestCompositionRevisionReference(t *testing.T) {
 	}
 }
 
+func TestCompositionRevisionSelector(t *testing.T) {
+	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"cool": "very"}}
+	cases := map[string]struct {
+		u    *Unstructured
+		set  *metav1.LabelSelector
+		want *metav1.LabelSelector
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  sel,
+			want: sel,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetCompositionRevisionSelector(tc.set)
+			got := tc.u.GetCompositionRevisionSelector()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetCompositionRevisionSelector(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCompositionUpdatePolicy(t *testing.T) {
 	p := xpv1.UpdateManual
 	cases := map[string]struct {

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -107,6 +107,20 @@ func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.ObjectReferen
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionRef", ref)
 }
 
+// GetCompositionRevisionSelector of this resource claim.
+func (c *Unstructured) GetCompositionRevisionSelector() *metav1.LabelSelector {
+	out := &metav1.LabelSelector{}
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionRevisionSelector", out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// SetCompositionRevisionSelector of this resource claim.
+func (c *Unstructured) SetCompositionRevisionSelector(sel *metav1.LabelSelector) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionSelector", sel)
+}
+
 // SetCompositionUpdatePolicy of this Composite resource.
 func (c *Unstructured) SetCompositionUpdatePolicy(p *xpv1.UpdatePolicy) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionUpdatePolicy", p)

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -190,6 +190,31 @@ func TestCompositionRevisionReference(t *testing.T) {
 	}
 }
 
+func TestCompositionRevisionSelector(t *testing.T) {
+	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"cool": "very"}}
+	cases := map[string]struct {
+		u    *Unstructured
+		set  *metav1.LabelSelector
+		want *metav1.LabelSelector
+	}{
+		"NewRef": {
+			u:    New(),
+			set:  sel,
+			want: sel,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.u.SetCompositionRevisionSelector(tc.set)
+			got := tc.u.GetCompositionRevisionSelector()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\nu.GetCompositionRevisionSelector(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCompositionUpdatePolicy(t *testing.T) {
 	p := xpv1.UpdateManual
 	cases := map[string]struct {


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR adds the composition revision selector support to composites and claims. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested with unit tests and consumed the change in Crossplane for functional testing. Created a composition with `env: dev` label:
```bash
kg compositionrevisions -o=custom-columns='NAME:.metadata.name,REVISION:.spec.revision,CURRENT:status.conditions[0].type,LABEL:.metadata.labels.env'
NAME                                            REVISION   CURRENT   LABEL
ezginetworks.aws.platformref.upbound.io-efbd7   1          Current   dev
```
and created two claims with `env: dev` and `env: staging`:
```bash
kubectl get claim -o=custom-columns='NAME:.metadata.name,SYNCED:.status.conditions[0].status,REVISION:.spec.compositionRevisionRef.name,POLICY:.spec.compositionUpdatePolicy,MATCHLABEL:.spec.compositionRevisionSelector.matchLabels'
NAME          SYNCED   REVISION                                        POLICY      MATCHLABEL
vpc-dev       True     ezginetworks.aws.platformref.upbound.io-efbd7   Automatic   map[env:dev]
vpc-staging   True     <none>                                          Automatic   map[env:staging]
```
Verified that, the claim with `env: dev` selector is set with the revision whereas the claim with `env: staging` doesn't have a revision assigned. 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
