### PR TITLE
add support for float pointer references

### DIFF
--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -18,6 +18,7 @@ package reference
 
 import (
 	"context"
+	"strconv"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -50,12 +51,32 @@ func FromPtrValue(v *string) string {
 	return *v
 }
 
+// FromFloatPtrValue adapts a float pointer field for use as a CurrentValue.
+func FromFloatPtrValue(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', 0, 64)
+}
+
 // ToPtrValue adapts a ResolvedValue for use as a string pointer field.
 func ToPtrValue(v string) *string {
 	if v == "" {
 		return nil
 	}
 	return &v
+}
+
+// ToFloatPtrValue adapts a ResolvedValue for use as a float64 pointer field.
+func ToFloatPtrValue(v string) *float64 {
+	if v == "" {
+		return nil
+	}
+	vParsed, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return nil
+	}
+	return &vParsed
 }
 
 // FromPtrValues adapts a slice of string pointer fields for use as CurrentValues.
@@ -71,6 +92,15 @@ func FromPtrValues(v []*string) []string {
 	return res
 }
 
+// FromFloatPtrValues adapts a slice of float64 pointer fields for use as CurrentValues.
+func FromFloatPtrValues(v []*float64) []string {
+	var res = make([]string, len(v))
+	for i := 0; i < len(v); i++ {
+		res[i] = FromFloatPtrValue(v[i])
+	}
+	return res
+}
+
 // ToPtrValues adapts ResolvedValues for use as a slice of string pointer fields.
 // NOTE: Do not use this utility function unless you have to.
 // Using pointer slices does not adhere to our current API practices.
@@ -80,6 +110,15 @@ func ToPtrValues(v []string) []*string {
 	var res = make([]*string, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = ToPtrValue(v[i])
+	}
+	return res
+}
+
+// ToFloatPtrValues adapts ResolvedValues for use as a slice of float64 pointer fields.
+func ToFloatPtrValues(v []string) []*float64 {
+	var res = make([]*float64, len(v))
+	for i := 0; i < len(v); i++ {
+		res[i] = ToFloatPtrValue(v[i])
 	}
 	return res
 }

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -66,6 +66,25 @@ func TestToAndFromPtr(t *testing.T) {
 	}
 }
 
+func TestToAndFromFloatPtr(t *testing.T) {
+	cases := map[string]struct {
+		want string
+	}{
+		"Zero":    {want: ""},
+		"NonZero": {want: "1123581321"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := FromFloatPtrValue(ToFloatPtrValue(tc.want))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FromPtrValue(ToPtrValue(%s): -want, +got: %s", tc.want, diff)
+
+			}
+		})
+
+	}
+}
+
 func TestToAndFromPtrValues(t *testing.T) {
 	cases := map[string]struct {
 		want []string
@@ -78,6 +97,26 @@ func TestToAndFromPtrValues(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := FromPtrValues(ToPtrValues(tc.want))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FromPtrValues(ToPtrValues(%s): -want, +got: %s", tc.want, diff)
+
+			}
+		})
+	}
+}
+
+func TestToAndFromFloatPtrValues(t *testing.T) {
+	cases := map[string]struct {
+		want []string
+	}{
+		"Nil":      {want: []string{}},
+		"Zero":     {want: []string{""}},
+		"NonZero":  {want: []string{"1123581321"}},
+		"Multiple": {want: []string{"1123581321", "1234567890"}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := FromFloatPtrValues(ToFloatPtrValues(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromPtrValues(ToPtrValues(%s): -want, +got: %s", tc.want, diff)
 


### PR DESCRIPTION
### Description of your changes
This change allows for types of references that are not strings. some terraform providers use "number" types for resource IDs which seem to get translated to float64 as part of upjet. when trying to use them as references previously only strings were supported, this PR along with a PR in crossplane-tools allows for "number" IDs to also be supported as references

Fixes #366 

I have:

- [ x ] Read and followed Crossplane's [contribution process].
- [ x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This has been tested by adding unit tests to cover the new functions, and this code has also been tested by the [linode-provider](https://github.com/linode/provider-linode), which is using my forked version of this repo and the crossplane-tools repo

