### PR TITLE
Add DesiredStateChanged to Filter out Updates on Status

### DIFF
--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -146,3 +146,17 @@ func IsNamed(name string) PredicateFn {
 		return mo.GetName() == name
 	}
 }
+
+// DesiredStateChanged accepts objects that have changed their desired state, i.e.
+// the state that is not managed by the controller.
+// To be more specific, it accepts update events that have changes in one of the followings:
+// - `metadata.annotations`
+// - `metadata.labels`
+// - `spec`
+func DesiredStateChanged() predicate.Predicate {
+	return predicate.Or(
+		predicate.AnnotationChangedPredicate{},
+		predicate.LabelChangedPredicate{},
+		predicate.GenerationChangedPredicate{},
+	)
+}

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -27,10 +27,14 @@ import (
 )
 
 // A PredicateFn returns true if the supplied object should be reconciled.
+// Deprecated: This type will be removed soon. Please use
+// controller-runtime's predicate.NewPredicateFuncs instead.
 type PredicateFn func(obj runtime.Object) bool
 
 // NewPredicates returns a set of Funcs that are all satisfied by the supplied
 // PredicateFn. The PredicateFn is run against the new object during updates.
+// Deprecated: This function will be removed soon. Please use
+// controller-runtime's predicate.NewPredicateFuncs instead.
 func NewPredicates(fn PredicateFn) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return fn(e.Object) },
@@ -41,6 +45,8 @@ func NewPredicates(fn PredicateFn) predicate.Funcs {
 }
 
 // AnyOf accepts objects that pass any of the supplied predicate functions.
+// Deprecated: This function will be removed soon. Please use
+// controller-runtime's predicate.Or instead.
 func AnyOf(fn ...PredicateFn) PredicateFn {
 	return func(obj runtime.Object) bool {
 		for _, f := range fn {
@@ -53,6 +59,8 @@ func AnyOf(fn ...PredicateFn) PredicateFn {
 }
 
 // AllOf accepts objects that pass all of the supplied predicate functions.
+// Deprecated: This function will be removed soon. Please use
+// controller-runtime's predicate.And instead.
 func AllOf(fn ...PredicateFn) PredicateFn {
 	return func(obj runtime.Object) bool {
 		for _, f := range fn {
@@ -66,6 +74,7 @@ func AllOf(fn ...PredicateFn) PredicateFn {
 
 // HasManagedResourceReferenceKind accepts objects that reference the supplied
 // managed resource kind.
+// Deprecated: This function will be removed soon.
 func HasManagedResourceReferenceKind(k ManagedKind) PredicateFn {
 	return func(obj runtime.Object) bool {
 		r, ok := obj.(ManagedResourceReferencer)
@@ -82,6 +91,7 @@ func HasManagedResourceReferenceKind(k ManagedKind) PredicateFn {
 }
 
 // IsManagedKind accepts objects that are of the supplied managed resource kind.
+// Deprecated: This function will be removed soon.
 func IsManagedKind(k ManagedKind, ot runtime.ObjectTyper) PredicateFn {
 	return func(obj runtime.Object) bool {
 		gvk, err := GetKind(obj, ot)
@@ -94,6 +104,7 @@ func IsManagedKind(k ManagedKind, ot runtime.ObjectTyper) PredicateFn {
 
 // IsControlledByKind accepts objects that are controlled by a resource of the
 // supplied kind.
+// Deprecated: This function will be removed soon.
 func IsControlledByKind(k schema.GroupVersionKind) PredicateFn {
 	return func(obj runtime.Object) bool {
 		mo, ok := obj.(metav1.Object)
@@ -112,6 +123,7 @@ func IsControlledByKind(k schema.GroupVersionKind) PredicateFn {
 
 // IsPropagator accepts objects that request to be partially or fully propagated
 // to another object of the same kind.
+// Deprecated: This function will be removed soon.
 func IsPropagator() PredicateFn {
 	return func(obj runtime.Object) bool {
 		from, ok := obj.(metav1.Object)
@@ -125,6 +137,7 @@ func IsPropagator() PredicateFn {
 
 // IsPropagated accepts objects that consent to be partially or fully propagated
 // from another object of the same kind.
+// Deprecated: This function will be removed soon.
 func IsPropagated() PredicateFn {
 	return func(obj runtime.Object) bool {
 		to, ok := obj.(metav1.Object)
@@ -137,6 +150,7 @@ func IsPropagated() PredicateFn {
 }
 
 // IsNamed accepts objects that is named as the given name.
+// Deprecated: This function will be removed soon.
 func IsNamed(name string) PredicateFn {
 	return func(obj runtime.Object) bool {
 		mo, ok := obj.(metav1.Object)


### PR DESCRIPTION
### Description of your changes

This PR adds a new predicate function named `DesiredStateChanged()` which does nothing but combines (with a `predicate.Or`) the following controller-runtime predicates:

- [GenerationChangedPredicate](https://github.com/kubernetes-sigs/controller-runtime/blob/9241bceb3098499d7243fa6aee0cd6930bfc03e8/pkg/predicate/predicate.go#L156)
  > // GenerationChangedPredicate implements a default update predicate function on Generation change.
  > //
  > // This predicate will skip update events that have no change in the object's metadata.generation field.
  > // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
  > // This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
  > //
  > // For CustomResource objects the Generation is only incremented when the status subresource is enabled.
  > //
  > // Caveats:
  > //
  > // * The assumption that the Generation is incremented only on writing to the spec does not hold for all APIs.
  > // E.g For Deployment objects the Generation is also incremented on writes to the metadata.annotations field.
  > // For object types other than CustomResources be sure to verify which fields will trigger a Generation increment when they are written to.
  > //
  > // * With this predicate, any update events with writes only to the status field will not be reconciled.
  > // So in the event that the status block is overwritten or wiped by someone else the controller will not self-correct to restore the correct status.

- [AnnotationChangedPredicate](https://github.com/kubernetes-sigs/controller-runtime/blob/9241bceb3098499d7243fa6aee0cd6930bfc03e8/pkg/predicate/predicate.go#L186)
  > // AnnotationChangedPredicate implements a default update predicate function on annotation change.
  > //
  > // This predicate will skip update events that have no change in the object's annotation.
  > // It is intended to be used in conjunction with the GenerationChangedPredicate, as in the following example:
  > //
  > //	Controller.Watch(
  > //		&source.Kind{Type: v1.MyCustomKind},
  > //		&handler.EnqueueRequestForObject{},
  > //		predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
  > //
  > // This is mostly useful for controllers that needs to trigger both when the resource's generation is incremented
  > // (i.e., when the resource' .spec changes), or an annotation changes (e.g., for a staging/alpha API).

- [LabelChangedPredicate](https://github.com/kubernetes-sigs/controller-runtime/blob/9241bceb3098499d7243fa6aee0cd6930bfc03e8/pkg/predicate/predicate.go#L217)
  > // LabelChangedPredicate implements a default update predicate function on label change.
  > //
  > // This predicate will skip update events that have no change in the object's label.
  > // It is intended to be used in conjunction with the GenerationChangedPredicate, as in the following example:
  > //
  > // Controller.Watch(
  > //
  > //	&source.Kind{Type: v1.MyCustomKind},
  > //	&handler.EnqueueRequestForObject{},
  > //	predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))
  > //
  > // This will be helpful when object's labels is carrying some extra specification information beyond object's spec,
  > // and the controller will be triggered if any valid spec change (not only in spec, but also in labels) happens.

Fixes https://github.com/crossplane/crossplane/issues/3455

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

See https://github.com/crossplane-contrib/provider-aws/pull/1645 to see how this can be consumed by provider controllers and also the result of testing.

[contribution process]: https://git.io/fj2m9
