### PR TITLE
fix: add missing secretStoreType validation annotation

### DIFF
--- a/apis/common/v1/connection_details.go
+++ b/apis/common/v1/connection_details.go
@@ -84,6 +84,7 @@ func (in *ConnectionSecretMetadata) GetOwnerUID() string {
 }
 
 // SecretStoreType represents a secret store type.
+// +kubebuilder:validation:Enum=Kubernetes;Vault
 type SecretStoreType string
 
 const (


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Added kubebuilder enum validation annotation to have CRDs correctly validating possible values.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Generated `crossplane/crossplane` CRDs pointing to updated crossplane-runtime version.

[contribution process]: https://git.io/fj2m9
