### PR TITLE
385: send event when resource is available to use

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -53,6 +53,10 @@ const (
 	// external resource exists.
 	AnnotationKeyExternalCreateSucceeded = "crossplane.io/external-create-succeeded"
 
+	// AnnotationKeyExternalCreateEventStatus is the key in the annotations
+	// map of a resource that indicates if a create event was sent or in a pending state.
+	AnnotationKeyExternalCreateEventStatus = "crossplane.io/external-create-event-status"
+
 	// AnnotationKeyExternalCreateFailed is the key in the annotations map
 	// of a resource that indicates the last time creation of the external
 	// resource failed. Its value must be an RFC3999 timestamp.
@@ -309,6 +313,11 @@ func GetExternalCreateSucceeded(o metav1.Object) time.Time {
 // most recently created to the supplied time.
 func SetExternalCreateSucceeded(o metav1.Object, t time.Time) {
 	AddAnnotations(o, map[string]string{AnnotationKeyExternalCreateSucceeded: t.Format(time.RFC3339)})
+}
+
+// SetExternalCreateEventStatus sets the status of a creation notification event.
+func SetExternalCreateEventStatus(o metav1.Object, s string) {
+	AddAnnotations(o, map[string]string{AnnotationKeyExternalCreateEventStatus: s})
 }
 
 // GetExternalCreateFailed returns the time at which the external resource

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -758,6 +758,7 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManagedAnnotations)))
 							want.SetConditions(xpv1.Creating())
+							meta.SetExternalCreateEventStatus(want, eventEmitPending)
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors updating critical annotations after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -801,6 +802,7 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errBoom))
 							want.SetConditions(xpv1.Creating())
+							meta.SetExternalCreateEventStatus(want, eventEmitPending)
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors publishing connection details after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -856,6 +858,7 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess())
 							want.SetConditions(xpv1.Creating())
+							meta.SetExternalCreateEventStatus(want, eventEmitPending)
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1038,6 +1041,56 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
+		},
+		"SendCreateEventIsSuccessful": {
+			reason: "A successful managed resource update should trigger a requeue after a long wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := obj.(*fake.Managed)
+							mg.SetConditions(xpv1.Available())
+							mg.SetName("external-resource-name")
+							meta.SetExternalCreatePending(obj, now.Time)
+							meta.SetExternalCreateSucceeded(obj, time.Now())
+							meta.SetExternalCreateEventStatus(obj, eventEmitPending)
+
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := &fake.Managed{}
+							meta.SetExternalCreateEventStatus(want, eventEmitComplete)
+							want.SetConditions(xpv1.ReconcileSuccess())
+							if diff := cmp.Diff(want.GetAnnotations()[meta.AnnotationKeyExternalCreateEventStatus], eventEmitComplete, test.EquateConditions()); diff != "" {
+								reason := "A successful managed resource creation should update annotation when condition."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+							},
+							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
+								return ExternalUpdate{}, nil
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
 		},
 		"UpdateSuccessful": {
 			reason: "A successful managed resource update should trigger a requeue after a long wait.",


### PR DESCRIPTION
### Description of your changes

This PR is a suggested approach for  issue  #385.  The change uses annotation to track if an event notifying that the external resource is available, has been created/sent .  If a resource is "Available" and an event has not been sent the reconcile will create/send an event.   I have not had any feedback regarding issue 385 so I thought this may be a good way of getting the discussion going if the issue was not clear. 

Fixes #385:

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have added new tests testing that the annotation is added on the creation and the event is sent in the correct scenarios.

[contribution process]: https://git.io/fj2m9
