### PR TITLE
tests(fuzz): add FuzzParse test case

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"bytes"
 	"context"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -177,4 +178,14 @@ func TestParser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		objScheme := runtime.NewScheme()
+		metaScheme := runtime.NewScheme()
+		p := New(metaScheme, objScheme)
+		r := io.NopCloser(bytes.NewReader(data))
+		_, _ = p.Parse(context.Background(), r)
+	})
 }

--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+#
+# DO NOT DELETE: this script is used from oss-fuzz. You can find more details
+# in the official documentation:
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/
+#
+# To run this locally you can go through the following steps: - $ git clone
+# https://github.com/google/oss-fuzz --depth=1 - $ cd
+# oss-fuzz/projects/crossplane
+# - modify Dockerfile to point to your branch with all the fuzzers being merged.
+# - modify build.sh to call the build script in Crossplanes repository
+# - $ python3 ../../infra/helper.py build_image crossplane
+# - $ python3 ../../infra/helper.py build_fuzzers crossplane
+
+set -o nounset
+set -o pipefail
+set -o errexit
+set -x
+
+printf "package main\nimport ( \n _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n )\n" > register.go
+
+# Moving all the fuzz_test.go to fuzz_test_fuzz.go, as oss-fuzz uses go build to build fuzzers
+# shellcheck disable=SC2016
+grep --line-buffered --include '*_test.go' -Pr 'func Fuzz.*\(.* \*testing\.F' | cut -d: -f1 | sort -u | xargs -I{} sh -c '
+  file="{}"
+  file_no_ext="$(basename "$file" | cut -d"." -f1)"
+  folder="$(dirname $file)"
+  mv "$file" "$folder/${file_no_ext}_fuzz.go"
+'
+
+# Now we can tidy and download all our dependencies
+go mod tidy
+go mod vendor
+
+# Find all native fuzzers and compile them
+# shellcheck disable=SC2016
+grep --line-buffered --include '*_test_fuzz.go' -Pr 'func Fuzz.*\(.* \*testing\.F' | sed -E 's/(func Fuzz(.*)\(.*)/\2/' | xargs -I{} sh -c '
+  file="$(echo "{}" | cut -d: -f1)"
+  folder="$(dirname $file)"
+  func="Fuzz$(echo "{}" | cut -d: -f2)"
+  compile_native_go_fuzzer github.com/crossplane-runtime/$folder $func $func
+'


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

While moving all the fuzz test cases over to `crossplane/crossplane` in https://github.com/crossplane/crossplane/pull/3671, we decided not to add `FuzzParse` because it belonged to this repo instead, as discussed [here](https://github.com/crossplane/crossplane/pull/3671%23discussion_r1089313171), so I'm adding it here and we'll configure [oss-fuzz](https://github.com/google/oss-fuzz/tree/master/projects/crossplane) to also build fuzzers for this project, as suggested by @AdamKorcz.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Running `go test -fuzz=FuzzParse` from the `pkg/parser` directory.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
