### PR TITLE
tests: move FuzzParse to separate file

### DIFF
--- a/pkg/parser/fuzz_test.go
+++ b/pkg/parser/fuzz_test.go
@@ -1,0 +1,20 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func FuzzParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		objScheme := runtime.NewScheme()
+		metaScheme := runtime.NewScheme()
+		p := New(metaScheme, objScheme)
+		r := io.NopCloser(bytes.NewReader(data))
+		_, _ = p.Parse(context.Background(), r)
+	})
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"bytes"
 	"context"
-	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -178,14 +177,4 @@ func TestParser(t *testing.T) {
 			}
 		})
 	}
-}
-
-func FuzzParse(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
-		objScheme := runtime.NewScheme()
-		metaScheme := runtime.NewScheme()
-		p := New(metaScheme, objScheme)
-		r := io.NopCloser(bytes.NewReader(data))
-		_, _ = p.Parse(context.Background(), r)
-	})
 }

--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -eu
 #
+# IMPORTANT: Fuzz* test cases should be in a dedicated file, conventionally
+# called `fuzz_test.go`, but that's not a requirement. Otherwise once the file
+# name is changed to have the _test_fuzz.go termination instead of _test.go as
+# required by oss-fuzz, the code won't compile as other Test* test cases might
+# not find some requirements given that they are not in a _test.go file.
+#
 # DO NOT DELETE: this script is used from oss-fuzz. You can find more details
 # in the official documentation:
 # https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relates to #394.

`./test/fuzz/oss_fuzz_build.sh` expects Fuzz tests to be in a separate file, so I'm moving FuzzParse to a dedicated file.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Running locally the build fuzzer procedure described in `./test/fuzz/oss_fuzz_build.sh`.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
