### PR TITLE
chore(linter): switching from goimports to gci enforcing imports sorting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,10 +31,14 @@ linters-settings:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
 
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/crossplane
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/crossplane/crossplane-runtime)
+      - blank
+      - dot
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
@@ -110,7 +114,7 @@ linters:
     - gocyclo
     - gocritic
     - goconst
-    - goimports
+    - gci
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
     - revive

--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/pkg/connection/store/vault/kv/v2.go
+++ b/pkg/connection/store/vault/kv/v2.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"path/filepath"
 
-	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
-
 	"github.com/hashicorp/vault/api"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -21,13 +21,12 @@ import (
 	"testing"
 	"time"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/resource/late_initializer_test.go
+++ b/pkg/resource/late_initializer_test.go
@@ -20,9 +20,8 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestLateInitializeStringPtr(t *testing.T) {

--- a/pkg/test/integration/server.go
+++ b/pkg/test/integration/server.go
@@ -28,11 +28,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	// Allow auth to cloud providers
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	// Allow auth to cloud providers
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const (

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Replacing `goimports` linter with `gci` to enforce imports sorting here too as done for `crossplane/crossplane`: https://github.com/crossplane/crossplane/pull/3924

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N.A. Just sorting imports, `make reviewable` passing.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
