### PR TITLE
Deprecate in-tree Vault

### DIFF
--- a/apis/common/v1/connection_details.go
+++ b/apis/common/v1/connection_details.go
@@ -123,6 +123,9 @@ type SecretStoreConfig struct {
 	Kubernetes *KubernetesSecretStoreConfig `json:"kubernetes,omitempty"`
 
 	// Vault configures a Vault secret store.
+	// Deprecated: This API is scheduled to be removed in a future release.
+	// Vault should be used as a plugin going forward. See
+	// https://github.com/crossplane-contrib/ess-plugin-vault for more information.
 	// +optional
 	Vault *VaultSecretStoreConfig `json:"vault,omitempty"`
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR adds a comment for deprecating in-tree Vault support. We can use Vault as external secret store with [ess-plugin-vault](https://github.com/crossplane-contrib/ess-plugin-vault).

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/team-control-planes/issues/924

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
N/A
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
