### PR TITLE
chore: configure single group for all kubernetes related prs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,7 +74,7 @@
       "matchDatasources": [
         "go"
       ],
-      "groupName": "kubernetes patches",
+      "groupName": "kubernetes deps",
       "matchUpdateTypes": [
         "digest",
       ],
@@ -84,28 +84,16 @@
         "sigs.k8s.io"
       ]
     }, {
-// We want a single PR for all the patches bumps of kubernetes related
-// dependencies, as most of the times these are all strictly related.
+// We want a single PR for all the bumps of kubernetes related dependencies, as
+// most of the times these are all strictly related.
       "matchDatasources": [
         "go"
       ],
-      "groupName": "kubernetes patches",
-      "matchUpdateTypes": [
-        "patch",
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each minor and major bumps to kubernetes related
-// dependencies.
-      "matchDatasources": [
-        "go"
-      ],
+      "groupName": "kubernetes deps",
       "matchUpdateTypes": [
         "major",
-        "minor"
+        "minor",
+        "patch"
       ],
       "matchPackagePrefixes": [
         "k8s.io",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Address https://github.com/crossplane/crossplane/pull/4113#issuecomment-1564554033, will merge https://github.com/crossplane/crossplane-runtime/pull/433 and coming k8s related PRs in a single one.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N.A. used `renovate-config-validator` to validate the config.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
