### PR TITLE
Add GetLogger method to fake.Manager

### DIFF
--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -454,6 +455,7 @@ type Manager struct {
 	Scheme     *runtime.Scheme
 	Config     *rest.Config
 	RESTMapper meta.RESTMapper
+	Logger     logr.Logger
 }
 
 // Elected returns a closed channel.
@@ -474,6 +476,9 @@ func (m *Manager) GetConfig() *rest.Config { return m.Config }
 
 // GetRESTMapper returns the REST mapper.
 func (m *Manager) GetRESTMapper() meta.RESTMapper { return m.RESTMapper }
+
+// GetLogger returns the logger.
+func (m *Manager) GetLogger() logr.Logger { return m.Logger }
 
 // GV returns a mock schema.GroupVersion.
 var GV = schema.GroupVersion{Group: "g", Version: "v"}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As in title, I propose to add an ability to add logr.Logger as a field to fake.Manager along with override for `GetLogger` method which would return that field. Useful when doing something in https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/handler#MapFunc, which doesnt have an option to return an error, so we just log it and `return`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
