### PR TITLE
feat(remove): remove deprecated providerRef

### DIFF
--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -197,11 +197,6 @@ type ResourceSpec struct {
 	// +kubebuilder:default={"name": "default"}
 	ProviderConfigReference *Reference `json:"providerConfigRef,omitempty"`
 
-	// ProviderReference specifies the provider that will be used to create,
-	// observe, update, and delete this managed resource.
-	// Deprecated: Please use ProviderConfigReference, i.e. `providerConfigRef`
-	ProviderReference *Reference `json:"providerRef,omitempty"`
-
 	// THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
 	// unless the relevant Crossplane feature flag is enabled, and may be
 	// changed or removed without notice.

--- a/apis/common/v1/zz_generated.deepcopy.go
+++ b/apis/common/v1/zz_generated.deepcopy.go
@@ -399,11 +399,6 @@ func (in *ResourceSpec) DeepCopyInto(out *ResourceSpec) {
 		*out = new(Reference)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ProviderReference != nil {
-		in, out := &in.ProviderReference, &out.ProviderReference
-		*out = new(Reference)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.ManagementPolicies != nil {
 		in, out := &in.ManagementPolicies, &out.ManagementPolicies
 		*out = make(ManagementPolicies, len(*in))

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -63,17 +63,8 @@ func (m *ManagedResourceReferencer) SetResourceReference(r *corev1.ObjectReferen
 // GetResourceReference gets the ResourceReference.
 func (m *ManagedResourceReferencer) GetResourceReference() *corev1.ObjectReference { return m.Ref }
 
-// ProviderReferencer is a mock that implements ProviderReferencer interface.
-type ProviderReferencer struct{ Ref *xpv1.Reference } //nolint:musttag // This is a fake implementation to be used in unit tests only.
-
-// SetProviderReference sets the ProviderReference.
-func (m *ProviderReferencer) SetProviderReference(p *xpv1.Reference) { m.Ref = p }
-
-// GetProviderReference gets the ProviderReference.
-func (m *ProviderReferencer) GetProviderReference() *xpv1.Reference { return m.Ref }
-
 // ProviderConfigReferencer is a mock that implements ProviderConfigReferencer interface.
-type ProviderConfigReferencer struct{ Ref *xpv1.Reference }
+type ProviderConfigReferencer struct{ Ref *xpv1.Reference } //nolint:musttag // This is a fake implementation to be used in unit tests only.
 
 // SetProviderConfigReference sets the ProviderConfigReference.
 func (m *ProviderConfigReferencer) SetProviderConfigReference(p *xpv1.Reference) { m.Ref = p }
@@ -331,7 +322,6 @@ func (o *Object) DeepCopyObject() runtime.Object {
 // Managed is a mock that implements Managed interface.
 type Managed struct {
 	metav1.ObjectMeta
-	ProviderReferencer
 	ProviderConfigReferencer
 	ConnectionSecretWriterTo
 	ConnectionDetailsPublisherTo

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -79,12 +79,6 @@ type Orphanable interface {
 	GetDeletionPolicy() xpv1.DeletionPolicy
 }
 
-// A ProviderReferencer may reference a provider resource.
-type ProviderReferencer interface {
-	GetProviderReference() *xpv1.Reference
-	SetProviderReference(p *xpv1.Reference)
-}
-
 // A ProviderConfigReferencer may reference a provider config resource.
 type ProviderConfigReferencer interface {
 	GetProviderConfigReference() *xpv1.Reference
@@ -192,7 +186,6 @@ type Object interface {
 type Managed interface {
 	Object
 
-	ProviderReferencer
 	ProviderConfigReferencer
 	ConnectionSecretWriterTo
 	ConnectionDetailsPublisherTo

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -369,13 +369,8 @@ func GetExternalTags(mg Managed) map[string]string {
 		ExternalResourceTagKeyName: mg.GetName(),
 	}
 
-	switch {
-	case mg.GetProviderConfigReference() != nil && mg.GetProviderConfigReference().Name != "":
+	if mg.GetProviderConfigReference() != nil && mg.GetProviderConfigReference().Name != "" {
 		tags[ExternalResourceTagKeyProvider] = mg.GetProviderConfigReference().Name
-	// TODO(muvaf): Remove the branch once Provider type has been removed from
-	// everywhere.
-	case mg.GetProviderReference() != nil && mg.GetProviderReference().Name != "":
-		tags[ExternalResourceTagKeyProvider] = mg.GetProviderReference().Name
 	}
 	return tags
 }

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -615,18 +615,6 @@ func TestGetExternalTags(t *testing.T) {
 		o    Managed
 		want map[string]string
 	}{
-		"Successful": {
-			o: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-				ProviderReferencer: fake.ProviderReferencer{Ref: &xpv1.Reference{Name: provName}},
-			},
-			want: map[string]string{
-				ExternalResourceTagKeyKind:     strings.ToLower((&fake.Managed{}).GetObjectKind().GroupVersionKind().GroupKind().String()),
-				ExternalResourceTagKeyName:     name,
-				ExternalResourceTagKeyProvider: provName,
-			},
-		},
 		"SuccessfulWithProviderConfig": {
 			o: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
 				Name: name,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
remove the very long deprecated providerRef - from time to time we see questions regarding providerRef - because this field is available in all providers

did we have anything i am not aware of why we want to use this field ?

few examples:
https://marketplace.upbound.io/providers/upbound/provider-aws-accessanalyzer/v0.37.0/resources/accessanalyzer.aws.upbound.io/Analyzer/v1beta1#doc:spec-providerRef

https://marketplace.upbound.io/providers/upbound/provider-azure-alertsmanagement/v0.34.0/resources/alertsmanagement.azure.upbound.io/MonitorActionRuleActionGroup/v1beta1#doc:spec-providerRef

https://marketplace.upbound.io/providers/upbound/provider-gcp-activedirectory/v0.34.0/resources/activedirectory.gcp.upbound.io/Domain/v1beta1#doc:spec-providerRef
https://marketplace.upbound.io/providers/upbound/provider-terraform/v0.8.0/resources/tf.upbound.io/Workspace/v1beta1#doc:spec-providerRef

https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.41.1/resources/acm.aws.crossplane.io/Certificate/v1beta1#doc:spec-providerRef

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
