### PR TITLE
[Backport release-0.20] Ignore k8s secret not found when ESS enabled

### DIFF
--- a/pkg/connection/store/kubernetes/store.go
+++ b/pkg/connection/store/kubernetes/store.go
@@ -93,7 +93,7 @@ func buildClient(ctx context.Context, local client.Client, cfg v1.SecretStoreCon
 // ReadKeyValues reads and returns key value pairs for a given Kubernetes Secret.
 func (ss *SecretStore) ReadKeyValues(ctx context.Context, n store.ScopedName, s *store.Secret) error {
 	ks := &corev1.Secret{}
-	if err := ss.client.Get(ctx, types.NamespacedName{Name: n.Name, Namespace: ss.namespaceForSecret(n)}, ks); err != nil {
+	if err := ss.client.Get(ctx, types.NamespacedName{Name: n.Name, Namespace: ss.namespaceForSecret(n)}, ks); resource.IgnoreNotFound(err) != nil {
 		return errors.Wrap(err, errGetSecret)
 	}
 	s.Data = ks.Data


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Backports the PR -> https://github.com/crossplane/crossplane-runtime/pull/492
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
with unit tests
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
