### PR TITLE
Add support for applying jitter when requeuing resources after reconcile

### DIFF
--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -1031,12 +1031,12 @@ func TestReconciler(t *testing.T) {
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 					WithPollIntervalHook(func(managed resource.Managed, pollInterval time.Duration) time.Duration {
-						return 2*pollInterval
+						return 2 * pollInterval
 					}),
 				},
 			},
 			want: want{
-				result: reconcile.Result{RequeueAfter: 2*defaultPollInterval},
+				result: reconcile.Result{RequeueAfter: 2 * defaultPollInterval},
 			},
 		},
 		"UpdateExternalError": {

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -50,8 +50,9 @@ func TestReconciler(t *testing.T) {
 	}
 
 	type want struct {
-		result reconcile.Result
-		err    error
+		result        reconcile.Result
+		resultCmpOpts []cmp.Option
+		err           error
 	}
 
 	errBoom := errors.New("boom")
@@ -324,7 +325,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ExternalObserveError": {
 			reason: "Errors observing the external resource should trigger a requeue after a short wait.",
@@ -949,7 +950,53 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+		},
+		"ExternalResourceUpToDateWithJitter": {
+			reason: "When the external resource exists and is up to date a requeue should be triggered after a long wait with jitter added.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := &fake.Managed{}
+							want.SetConditions(xpv1.ReconcileSuccess())
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "A successful no-op reconcile should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.Managed{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+							},
+						}
+						return c, nil
+					})),
+					WithConnectionPublishers(),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+					WithPollJitter(time.Second),
+				},
+			},
+			want: want{
+				result: reconcile.Result{RequeueAfter: defaultPollInterval},
+				resultCmpOpts: []cmp.Option{cmp.Comparer(func(l, r time.Duration) bool {
+					diff := l - r
+					if diff < 0 {
+						diff = -diff
+					}
+					return diff < time.Second
+				})},
+			},
 		},
 		"UpdateExternalError": {
 			reason: "Errors while updating an external resource should trigger a requeue after a short wait.",
@@ -1077,7 +1124,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ReconciliationPausedSuccessful": {
 			reason: `If a managed resource has the pause annotation with value "true", there should be no further requeue requests.`,
@@ -1182,7 +1229,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ReconciliationPausedError": {
 			reason: `If a managed resource has the pause annotation with value "true" and the status update due to reconciliation being paused fails, error should be reported causing an exponentially backed-off requeue.`,
@@ -1418,7 +1465,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ManagementPolicyAllCreateSuccessful": {
 			reason: "Successful managed resource creation using management policy all should trigger a requeue after a short wait.",
@@ -1544,7 +1591,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ManagementPolicyAllUpdateSuccessful": {
 			reason: "A successful managed resource update using management policies should trigger a requeue after a long wait.",
@@ -1589,7 +1636,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ManagementPolicyUpdateUpdateSuccessful": {
 			reason: "A successful managed resource update using management policies should trigger a requeue after a long wait.",
@@ -1634,7 +1681,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ManagementPolicySkipLateInitialize": {
 			reason: "Should skip updating a managed resource to persist late initialized fields and should trigger a requeue after a long wait.",
@@ -1677,7 +1724,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultpollInterval}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 	}
 
@@ -1690,7 +1737,7 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("\nReason: %s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+			if diff := cmp.Diff(tc.want.result, got, tc.want.resultCmpOpts...); diff != "" {
 				t.Errorf("\nReason: %s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -998,7 +998,7 @@ func TestReconciler(t *testing.T) {
 				})},
 			},
 		},
-		"ExternalResourceUpToDateWithJitterAndIntervalHook": {
+		"ExternalResourceUpToDateWithPollIntervalHook": {
 			reason: "When the external resource exists and is up to date a requeue should be triggered after a long wait processed by the interval hook.",
 			args: args{
 				m: &fake.Manager{
@@ -1030,21 +1030,13 @@ func TestReconciler(t *testing.T) {
 					})),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
-					WithPollJitter(time.Second),
-					WithPollIntervalHook(func(managed resource.Managed, configuredPollInterval, computedJitter time.Duration) time.Duration {
-						return 2*configuredPollInterval + computedJitter
+					WithPollIntervalHook(func(managed resource.Managed, pollInterval time.Duration) time.Duration {
+						return 2*pollInterval
 					}),
 				},
 			},
 			want: want{
 				result: reconcile.Result{RequeueAfter: 2*defaultPollInterval},
-				resultCmpOpts: []cmp.Option{cmp.Comparer(func(l, r time.Duration) bool {
-					diff := l - r
-					if diff < 0 {
-						diff = -diff
-					}
-					return diff < time.Second
-				})},
 			},
 		},
 		"UpdateExternalError": {


### PR DESCRIPTION
### Description of your changes

Adds a WithPollJitter option to managed.Reconciler to support adding jitter to reconcile delay. Jitter defaults to 0, meaning this has no behavioural change unless the WithPollJitter option is set.

Fixes #312

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran tests in pkg/reconciler/managed/reconciler_test.go

[contribution process]: https://git.io/fj2m9
