### PR TITLE
Mark test.EquateErrors as deprecated

### DIFF
--- a/pkg/test/cmp.go
+++ b/pkg/test/cmp.go
@@ -33,6 +33,8 @@ import (
 // This differs from cmpopts.EquateErrors, which does not test for error strings
 // and instead returns whether one error 'is' (in the errors.Is sense) the
 // other.
+//
+// Deprecated: Use cmpopts.EquateErrors instead.
 func EquateErrors() cmp.Option {
 	return cmp.Comparer(func(a, b error) bool {
 		if a == nil || b == nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
See https://github.com/crossplane/crossplane/issues/4514 for context.

We can't remove this (it would be a breaking API change) but I want to discourage and redirect folks.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
