### PR TITLE
pkg/resource: output progress logs in applicators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	dario.cat/mergo v1.0.0
 	github.com/bufbuild/buf v1.26.1
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/spf13/afero v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/pkg/connection/store/kubernetes/store.go
+++ b/pkg/connection/store/kubernetes/store.go
@@ -66,7 +66,7 @@ func NewSecretStore(ctx context.Context, local client.Client, _ *tls.Config, cfg
 	return &SecretStore{
 		client: resource.ClientApplicator{
 			Client:     kube,
-			Applicator: resource.NewApplicatorWithRetry(resource.NewAPIPatchingApplicator(kube), resource.IsAPIErrorWrapped, nil),
+			Applicator: resource.NewApplicatorWithRetry(resource.NewAPIPatchingApplicator(kube), resource.IsNonConflictAPIErrorWrapped, nil),
 		},
 		defaultNamespace: cfg.DefaultScope,
 	}, nil

--- a/pkg/logging/helpers.go
+++ b/pkg/logging/helpers.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ForResource returns logging values for a resource.
+func ForResource(object client.Object) []string {
+	ret := make([]string, 0, 10)
+	gvk := object.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		gvk.Kind = fmt.Sprintf("%T", object) // best effort for native Go types
+	}
+	ret = append(ret,
+		"name", object.GetName(),
+		"kind", gvk.Kind,
+		"version", gvk.Version,
+		"group", gvk.Group,
+	)
+	if ns := object.GetNamespace(); ns != "" {
+		ret = append(ret, "namespace", ns)
+	}
+
+	return ret
+}

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -74,7 +74,7 @@ func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPu
 	// backward compatibility with the original API of this function.
 	return &APISecretPublisher{
 		secret: resource.NewApplicatorWithRetry(resource.NewAPIPatchingApplicator(c),
-			resource.IsAPIErrorWrapped, nil),
+			resource.IsNonConflictAPIErrorWrapped, nil),
 		typer: ot,
 	}
 }

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -127,9 +127,6 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o client.Object, ao .
 		}
 	}
 
-	// NOTE(hasheddan): we must set the resource version of the desired object
-	// to that of the current or the update will always fail.
-	m.SetResourceVersion(current.(metav1.Object).GetResourceVersion())
 	return errors.Wrap(a.client.Update(ctx, m), "cannot update object")
 }
 

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,8 +35,24 @@ import (
 
 func TestAPIPatchingApplicator(t *testing.T) {
 	errBoom := errors.New("boom")
-	desired := &object{}
-	desired.SetName("desired")
+
+	current := &object{Spec: "old"}
+	current.SetName("foo")
+
+	desired := &object{Spec: "new"}
+	desired.SetName("foo")
+
+	withRV := func(rv string, o client.Object) client.Object {
+		cpy := *(o.(*object))
+		cpy.SetResourceVersion(rv)
+		return &cpy
+	}
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Thing"}
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "things"}
+	singular := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "thing"}
+	fakeRESTMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gvk.GroupVersion()})
+	fakeRESTMapper.AddSpecific(gvk, gvr, singular, meta.RESTScopeRoot)
 
 	type args struct {
 		ctx context.Context
@@ -56,53 +73,71 @@ func TestAPIPatchingApplicator(t *testing.T) {
 	}{
 		"GetError": {
 			reason: "An error should be returned if we can't get the object",
-			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			c: &test.MockClient{
+				MockGet:                 test.NewMockGetFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+			},
 			args: args{
-				o: &object{},
+				o: withRV("42", desired),
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot get object"),
+				o: withRV("42", desired),
+				// this is intentionally not a wrapped error because this comes from a client
+				err: errBoom,
 			},
 		},
 		"CreateError": {
 			reason: "No error should be returned if we successfully create a new object",
 			c: &test.MockClient{
-				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-				MockCreate: test.NewMockCreateFn(errBoom),
+				MockGet:                 test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate:              test.NewMockCreateFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: &object{},
+				o: desired,
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot create object"),
+				o: desired,
+				// this is intentionally not a wrapped error because this comes from a client
+				err: errBoom,
 			},
 		},
 		"ApplyOptionError": {
 			reason: "Any errors from an apply option should be returned",
-			c:      &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *current
+					o.SetResourceVersion("42")
+					return nil
+				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+			},
 			args: args{
-				o:  &object{},
+				o:  withRV("42", desired),
 				ao: []ApplyOption{func(_ context.Context, _, _ runtime.Object) error { return errBoom }},
 			},
 			want: want{
-				o:   &object{},
-				err: errBoom,
+				o:   withRV("42", desired),
+				err: errors.Wrapf(errBoom, "apply option failed for thing \"foo\""),
 			},
 		},
 		"PatchError": {
 			reason: "An error should be returned if we can't patch the object",
 			c: &test.MockClient{
-				MockGet:   test.NewMockGetFn(nil),
-				MockPatch: test.NewMockPatchFn(errBoom),
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *current
+					o.SetResourceVersion("42")
+					return nil
+				}),
+				MockPatch:               test.NewMockPatchFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: &object{},
+				o: withRV("42", desired),
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot patch object"),
+				o:   withRV("42", desired),
+				err: errBoom, // this is intentionally not a wrapped error because this comes from a client
 			},
 		},
 		"Created": {
@@ -111,8 +146,10 @@ func TestAPIPatchingApplicator(t *testing.T) {
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				MockCreate: test.NewMockCreateFn(nil, func(o client.Object) error {
 					*o.(*object) = *desired
+					o.SetResourceVersion("1")
 					return nil
 				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
 				o: desired,
@@ -124,17 +161,64 @@ func TestAPIPatchingApplicator(t *testing.T) {
 		"Patched": {
 			reason: "No error should be returned if we successfully patch an existing object",
 			c: &test.MockClient{
-				MockGet: test.NewMockGetFn(nil),
-				MockPatch: test.NewMockPatchFn(nil, func(o client.Object) error {
-					*o.(*object) = *desired
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *current
+					o.SetResourceVersion("42")
 					return nil
 				}),
+				MockPatch: test.NewMockPatchFn(nil, func(o client.Object) error {
+					*o.(*object) = *desired
+					o.SetResourceVersion("43")
+					return nil
+				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: desired,
+				o: withRV("42", desired),
 			},
 			want: want{
-				o: desired,
+				o: withRV("43", desired),
+			},
+		},
+		"GetConflictError": {
+			reason: "No error should be returned if we successfully patch an existing object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *current
+					o.SetResourceVersion("100")
+					return nil
+				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+				MockRESTMapper:          test.NewMockRESTMapperFn(fakeRESTMapper),
+			},
+			args: args{
+				o: withRV("42", desired),
+			},
+			want: want{
+				o: withRV("42", desired),
+				// this is intentionally not a wrapped error because this comes from a client
+				err: kerrors.NewConflict(schema.GroupResource{Group: "example.com", Resource: "things"}, current.GetName(), errors.New(errOptimisticLock)),
+			},
+		},
+		"PatchConflictError": {
+			reason: "No error should be returned if we successfully patch an existing object",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *current
+					o.SetResourceVersion("42")
+					return nil
+				}),
+				MockPatch:               test.NewMockPatchFn(kerrors.NewConflict(schema.GroupResource{Group: "example.com", Resource: "things"}, "foo", errors.New(errOptimisticLock))),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+				MockRESTMapper:          test.NewMockRESTMapperFn(fakeRESTMapper),
+			},
+			args: args{
+				o: withRV("42", desired),
+			},
+			want: want{
+				o: withRV("42", desired),
+				// this is intentionally not a wrapped error because this comes from a client
+				err: kerrors.NewConflict(schema.GroupResource{Group: "example.com", Resource: "things"}, current.GetName(), errors.New(errOptimisticLock)),
 			},
 		},
 	}
@@ -155,10 +239,24 @@ func TestAPIPatchingApplicator(t *testing.T) {
 
 func TestAPIUpdatingApplicator(t *testing.T) {
 	errBoom := errors.New("boom")
-	desired := &object{}
-	desired.SetName("desired")
-	current := &object{}
-	current.SetName("current")
+
+	current := &object{Spec: "old"}
+	current.SetName("foo")
+
+	desired := &object{Spec: "new"}
+	desired.SetName("foo")
+
+	withRV := func(rv string, o client.Object) client.Object {
+		cpy := *(o.(*object))
+		cpy.SetResourceVersion(rv)
+		return &cpy
+	}
+
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Thing"}
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "things"}
+	singular := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "thing"}
+	fakeRESTMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gvk.GroupVersion()})
+	fakeRESTMapper.AddSpecific(gvk, gvr, singular, meta.RESTScopeRoot)
 
 	type args struct {
 		ctx context.Context
@@ -179,90 +277,114 @@ func TestAPIUpdatingApplicator(t *testing.T) {
 	}{
 		"GetError": {
 			reason: "An error should be returned if we can't get the object",
-			c:      &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			c: &test.MockClient{
+				MockGet:                 test.NewMockGetFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+			},
 			args: args{
-				o: &object{},
+				o: withRV("42", desired),
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot get object"),
+				o: withRV("42", desired),
+				// this is intentionally not a wrapped error because this comes from a client
+				err: errBoom,
 			},
 		},
 		"CreateError": {
 			reason: "No error should be returned if we successfully create a new object",
 			c: &test.MockClient{
-				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-				MockCreate: test.NewMockCreateFn(errBoom),
+				MockGet:                 test.NewMockGetFn(kerrors.NewNotFound(gvr.GroupResource(), desired.GetName())),
+				MockCreate:              test.NewMockCreateFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: &object{},
+				o: desired,
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot create object"),
+				o: desired,
+				// this is intentionally not a wrapped error because this comes from a client
+				err: errBoom,
 			},
 		},
 		"ApplyOptionError": {
 			reason: "Any errors from an apply option should be returned",
-			c:      &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *desired
+					o.SetResourceVersion("42")
+					return nil
+				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
+			},
 			args: args{
-				o:  &object{},
+				o:  withRV("42", desired),
 				ao: []ApplyOption{func(_ context.Context, _, _ runtime.Object) error { return errBoom }},
 			},
 			want: want{
-				o:   &object{},
-				err: errBoom,
+				o:   withRV("42", desired),
+				err: errors.Wrapf(errBoom, "apply option failed for thing \"foo\""),
 			},
 		},
 		"UpdateError": {
 			reason: "An error should be returned if we can't update the object",
 			c: &test.MockClient{
-				MockGet:    test.NewMockGetFn(nil),
-				MockUpdate: test.NewMockUpdateFn(errBoom),
+				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+					*o.(*object) = *desired
+					o.SetResourceVersion("42")
+					return nil
+				}),
+				MockUpdate:              test.NewMockUpdateFn(errBoom),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: &object{},
+				o: withRV("42", desired),
 			},
 			want: want{
-				o:   &object{},
-				err: errors.Wrap(errBoom, "cannot update object"),
+				o: withRV("42", desired),
+				// this is intentionally not a wrapped error because this comes from a client
+				err: errBoom,
 			},
 		},
 		"Created": {
 			reason: "No error should be returned if we successfully create a new object",
 			c: &test.MockClient{
-				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockGet: test.NewMockGetFn(kerrors.NewNotFound(gvr.GroupResource(), desired.GetName())),
 				MockCreate: test.NewMockCreateFn(nil, func(o client.Object) error {
 					*o.(*object) = *desired
+					o.SetResourceVersion("1")
 					return nil
 				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
 				o: desired,
 			},
 			want: want{
-				o: desired,
+				o: withRV("1", desired),
 			},
 		},
 		"Updated": {
 			reason: "No error should be returned if we successfully update an existing object. If no ApplyOption is passed the existing should not be modified",
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
-					*o.(*object) = *current
+					*o.(*object) = *desired
+					o.SetResourceVersion("42")
 					return nil
 				}),
 				MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
-					if diff := cmp.Diff(*desired, *o.(*object)); diff != "" {
+					if diff := cmp.Diff(withRV("42", desired), o); diff != "" {
 						t.Errorf("r: -want, +got:\n%s", diff)
 					}
+					o.SetResourceVersion("43")
 					return nil
 				}),
+				MockGroupVersionKindFor: test.NewMockGroupVersionKindForFn(nil, gvk),
 			},
 			args: args{
-				o: desired,
+				o: withRV("42", desired),
 			},
 			want: want{
-				o: desired,
+				o: withRV("43", desired),
 			},
 		},
 	}

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -27,6 +27,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -317,7 +318,7 @@ func TestTrack(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ut := &ProviderConfigUsageTracker{c: tc.fields.c, of: tc.fields.of}
+			ut := &ProviderConfigUsageTracker{c: tc.fields.c, of: tc.fields.of, log: logging.NewNopLogger()}
 			got := ut.Track(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nut.Track(...): -want error, +got error:\n%s\n", tc.reason, diff)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -190,6 +190,13 @@ func IsAPIErrorWrapped(err error) bool {
 	return IsAPIError(errors.Cause(err))
 }
 
+// IsNonConflictAPIErrorWrapped returns true if err is a non-conflict K8s API
+// error, or recursively wraps a K8s API error
+func IsNonConflictAPIErrorWrapped(err error) bool {
+	cause := errors.Cause(err)
+	return IsAPIError(cause) && !kerrors.IsConflict(cause)
+}
+
 // IsConditionTrue returns if condition status is true
 func IsConditionTrue(c xpv1.Condition) bool {
 	return c.Status == corev1.ConditionTrue

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -202,8 +203,12 @@ func IsConditionTrue(c xpv1.Condition) bool {
 	return c.Status == corev1.ConditionTrue
 }
 
-// An Applicator applies changes to an object.
+// An Applicator applies changes to an object. The passed object is expected to
+// be complete, i.e. not partial.
 type Applicator interface {
+	// Apply updates the given object to exactly the given state. It conflicts
+	// if the resource version stored on the apiserver does not match anymore
+	// the one in the given object.
 	Apply(context.Context, client.Object, ...ApplyOption) error
 }
 
@@ -380,4 +385,36 @@ func GetExternalTags(mg Managed) map[string]string {
 		tags[ExternalResourceTagKeyProvider] = mg.GetProviderConfigReference().Name
 	}
 	return tags
+}
+
+// HumanReadableReference returns a human readable object reference like
+// "pod default/database", e.g. to be used in error strings.
+//
+// The client is optional and can be nil. Then the kind is guessed from the
+// object.
+func HumanReadableReference(c client.Client, o runtime.Object) string {
+	gvk := o.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" && c != nil {
+		gvk, _ = c.GroupVersionKindFor(o)
+	}
+	if gvk.Kind == "" {
+		gvk.Kind = fmt.Sprintf("%T", o) // best effort
+	}
+
+	co, ok := o.(client.Object)
+	if !ok {
+		return gvk.Kind
+	}
+
+	name := co.GetName()
+	infix := ""
+	if gn := co.GetGenerateName(); name == "" && gn != "" {
+		name = gn
+		infix = "with generated name "
+	}
+	if ns := co.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s %s%s/%s", strings.ToLower(gvk.Kind), infix, ns, name)
+	}
+
+	return fmt.Sprintf("%s %s%q", strings.ToLower(gvk.Kind), infix, name)
 }

--- a/pkg/test/fake.go
+++ b/pkg/test/fake.go
@@ -63,6 +63,9 @@ type MockSubResourcePatchFn func(ctx context.Context, obj client.Object, patch c
 // A MockSchemeFn is used to mock client.Client's Scheme implementation.
 type MockSchemeFn func() *runtime.Scheme
 
+// A MockRESTMapperFn is used to mock client.RESTMapper.
+type MockRESTMapperFn func() meta.RESTMapper
+
 // A MockGroupVersionKindForFn is used to mock client.Client's GroupVersionKindFor implementation.
 type MockGroupVersionKindForFn func(runtime.Object) (schema.GroupVersionKind, error)
 
@@ -201,10 +204,17 @@ func NewMockSubResourcePatchFn(err error, ofn ...ObjectFn) MockSubResourcePatchF
 	}
 }
 
-// NewMockSchemeFn returns a MockSchemeFn that returns the scheme
+// NewMockSchemeFn returns a MockSchemeFn that returns the scheme.
 func NewMockSchemeFn(scheme *runtime.Scheme) MockSchemeFn {
 	return func() *runtime.Scheme {
 		return scheme
+	}
+}
+
+// NewMockRESTMapperFn returns a MockRESTMapperFn that returns the RESTMapper.
+func NewMockRESTMapperFn(mapper meta.RESTMapper) MockRESTMapperFn {
+	return func() meta.RESTMapper {
+		return mapper
 	}
 }
 
@@ -257,6 +267,7 @@ type MockClient struct {
 	MockScheme              MockSchemeFn
 	MockGroupVersionKindFor MockGroupVersionKindForFn
 	MockIsObjectNamespaced  MockIsObjectNamespacedFn
+	MockRESTMapper          MockRESTMapperFn
 }
 
 // NewMockClient returns a MockClient that does nothing when its methods are
@@ -277,6 +288,7 @@ func NewMockClient() *MockClient {
 		MockScheme:              NewMockSchemeFn(nil),
 		MockGroupVersionKindFor: NewMockGroupVersionKindForFn(nil, schema.GroupVersionKind{}),
 		MockIsObjectNamespaced:  NewMockIsObjectNamespacedFn(nil, false),
+		MockRESTMapper:          NewMockRESTMapperFn(nil),
 	}
 }
 
@@ -336,7 +348,7 @@ func (c *MockClient) SubResource(_ string) client.SubResourceClient {
 
 // RESTMapper returns the REST mapper.
 func (c *MockClient) RESTMapper() meta.RESTMapper {
-	return nil
+	return c.MockRESTMapper()
 }
 
 // Scheme calls MockClient's MockScheme function


### PR DESCRIPTION
Add progress logs to the applicators:

- print creations
- print updates/patches with diff
- be silent on noop.

Based on https://github.com/crossplane/crossplane-runtime/pull/491

Signed-off-by: Dr. Stefan Schimanski <stefan.schimanski@upbound.io>