### PR TITLE
pkg/resource: add StoreCurrentRV

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -361,6 +361,16 @@ func AllowUpdateIf(fn func(current, desired runtime.Object) bool) ApplyOption {
 	}
 }
 
+// StoreCurrentRV stores the resource version of the current object in the
+// supplied string pointer. This is useful to detect whether the Apply call
+// was a no-op.
+func StoreCurrentRV(origRV *string) ApplyOption {
+	return func(_ context.Context, current, desired runtime.Object) error {
+		*origRV = current.(client.Object).GetResourceVersion()
+		return nil
+	}
+}
+
 // GetExternalTags returns the identifying tags to be used to tag the external
 // resource in provider API.
 func GetExternalTags(mg Managed) map[string]string {


### PR DESCRIPTION
### Description of your changes

To detect when an `Apply` is a no-op or not. Compare https://github.com/crossplane/crossplane/pull/4572.

```golang
origRV := ""
if err := r.client.Apply(ctx, crd, resource.MustBeControllableBy(d.GetUID()), resource.StoreCurrentRV(&origRV)); err != nil {
    return reconcile.Result{}, err
}
if crd.GetResourceVersion() != origRV {
    r.record.Event(d, event.Normal(reasonEstablishXR, fmt.Sprintf("Applied composite resource CustomResourceDefinition: %s", crd.GetName())))
}
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9