### PR TITLE
Enable Namespace as an optional field in TypedReference

### DIFF
--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -122,9 +122,9 @@ type Reference struct {
 	Policy *Policy `json:"policy,omitempty"`
 }
 
-// A TypedReference refers to an object by Name, Kind, and APIVersion. It is
-// commonly used to reference cluster-scoped objects or objects where the
-// namespace is already known.
+// A TypedReference refers to an object by Name, Namespace, Kind, and
+// APIVersion. It is commonly used to reference cluster-scoped objects
+// and can also be used for namespace-scoped objects.
 type TypedReference struct {
 	// APIVersion of the referenced object.
 	APIVersion string `json:"apiVersion"`
@@ -134,6 +134,10 @@ type TypedReference struct {
 
 	// Name of the referenced object.
 	Name string `json:"name"`
+
+	// Namespace of the referenced object.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 
 	// UID of the referenced object.
 	// +optional

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -87,6 +87,7 @@ func TypedReferenceTo(o metav1.Object, of schema.GroupVersionKind) *xpv1.TypedRe
 		APIVersion: v,
 		Kind:       k,
 		Name:       o.GetName(),
+		Namespace:  o.GetNamespace(),
 		UID:        o.GetUID(),
 	}
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -112,6 +112,7 @@ func TestTypedReferenceTo(t *testing.T) {
 			want: &xpv1.TypedReference{
 				APIVersion: groupVersion,
 				Kind:       kind,
+				Namespace:  namespace,
 				Name:       name,
 				UID:        uid,
 			},


### PR DESCRIPTION
### Description of your changes

Added support for namespace scoped objects in TypedReference, so we can introduce general namespace scoped resource in the resources list of composition. This change is backward compatible with existing implementation and does not require any updates from existing providers.

This also requires some changes in the main Crossplane repo after the runtime is updated. I have created a corresponding draft PR to demonstrate the idea:

https://github.com/crossplane/crossplane/pull/4606

Fixes #251 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Some manually testing with namespace scoped objects like ConfigMap.

For example, a Composition like below will help to update a namespace scoped ConfigMap with a redisHost URL from the status of certain CompositeResources. This will then enable workloads (like Deployments/StatefulSets) under the same namespace to consume the data from ConfigMap.

```
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
...
spec:
...
  resources:
  - name: configmap
    base:
      apiVersion: v1
      kind: ConfigMap
      metadata:
        namespace: "some-namespace"
    patches:
    - type: FromCompositeFieldPath
      fromFieldPath: status.redisHost
      toFieldPath: data.redisHost
```

