### PR TITLE
resource: use Patch in APIFinalizer

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -161,8 +161,9 @@ func (a *APIFinalizer) AddFinalizer(ctx context.Context, obj Object) error {
 	if meta.FinalizerExists(obj, a.finalizer) {
 		return nil
 	}
+	orig := obj.DeepCopyObject().(Object)
 	meta.AddFinalizer(obj, a.finalizer)
-	return errors.Wrap(a.client.Update(ctx, obj), errUpdateObject)
+	return errors.Wrap(a.client.Patch(ctx, obj, client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{})), errUpdateObject)
 }
 
 // RemoveFinalizer from the supplied Managed resource.
@@ -170,8 +171,9 @@ func (a *APIFinalizer) RemoveFinalizer(ctx context.Context, obj Object) error {
 	if !meta.FinalizerExists(obj, a.finalizer) {
 		return nil
 	}
+	orig := obj.DeepCopyObject().(Object)
 	meta.RemoveFinalizer(obj, a.finalizer)
-	return errors.Wrap(IgnoreNotFound(a.client.Update(ctx, obj)), errUpdateObject)
+	return errors.Wrap(IgnoreNotFound(a.client.Patch(ctx, obj, client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}))), errUpdateObject)
 }
 
 // A FinalizerFns satisfy the Finalizer interface.

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -302,7 +302,7 @@ func TestManagedRemoveFinalizer(t *testing.T) {
 		want   want
 	}{
 		"UpdateError": {
-			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
+			client: &test.MockClient{MockPatch: test.NewMockPatchFn(errBoom)},
 			args: args{
 				ctx: context.Background(),
 				obj: &fake.Object{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{finalizer}}},
@@ -313,7 +313,7 @@ func TestManagedRemoveFinalizer(t *testing.T) {
 			},
 		},
 		"Successful": {
-			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			client: &test.MockClient{MockPatch: test.NewMockPatchFn(nil)},
 			args: args{
 				ctx: context.Background(),
 				obj: &fake.Object{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{finalizer}}},
@@ -360,7 +360,7 @@ func TestAPIFinalizerAdder(t *testing.T) {
 		want   want
 	}{
 		"UpdateError": {
-			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
+			client: &test.MockClient{MockPatch: test.NewMockPatchFn(errBoom)},
 			args: args{
 				ctx: context.Background(),
 				obj: &fake.Object{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}}},
@@ -371,7 +371,7 @@ func TestAPIFinalizerAdder(t *testing.T) {
 			},
 		},
 		"Successful": {
-			client: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			client: &test.MockClient{MockPatch: test.NewMockPatchFn(nil)},
 			args: args{
 				ctx: context.Background(),
 				obj: &fake.Object{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}}},


### PR DESCRIPTION
### Description of your changes

Calling `Update` on a non-unstructured object will potentially lead to data-loss because it is not guaranteed that the object is a complete representation of all the fields stored in the apiserver, e.g. because of version skew between client and Crossplane.

I have:

- [ ] is that type cast safe?
- [ ] do we have enough test coverage to confirm the safety of this change?
- [ ] maybe run proof PR in crossplane
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Via Crossplane test suite, aka unit tests and e2e tests.

[contribution process]: https://git.io/fj2m9