### PR TITLE
errors: add SilentlyRequeueOnConflicts

### DIFF
--- a/pkg/errors/reconcile.go
+++ b/pkg/errors/reconcile.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"context"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SilentlyRequeueOnConflict returns a requeue result and silently drops the
+// error if it is a Kubernetes conflict error from the optimistic concurrency
+// protocol.
+func SilentlyRequeueOnConflict(result reconcile.Result, err error) (reconcile.Result, error) {
+	if kerrors.IsConflict(Cause(err)) {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	return result, err
+}
+
+// WithSilentRequeueOnConflict wraps a Reconciler and silently drops conflict
+// errors and requeues instead.
+func WithSilentRequeueOnConflict(r reconcile.Reconciler) reconcile.Reconciler {
+	return &silentlyRequeueOnConflict{Reconciler: r}
+}
+
+type silentlyRequeueOnConflict struct {
+	reconcile.Reconciler
+}
+
+func (r *silentlyRequeueOnConflict) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	result, err := r.Reconciler.Reconcile(ctx, req)
+	return SilentlyRequeueOnConflict(result, err)
+}

--- a/pkg/errors/reconcile_test.go
+++ b/pkg/errors/reconcile_test.go
@@ -1,5 +1,18 @@
-// Copyright 2023 Upbound Inc.
-// All rights reserved
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package errors
 

--- a/pkg/errors/reconcile_test.go
+++ b/pkg/errors/reconcile_test.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Upbound Inc.
+// All rights reserved
+
+package errors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestSilentlyRequeueOnConflict(t *testing.T) {
+	type args struct {
+		result reconcile.Result
+		err    error
+	}
+	type want struct {
+		result reconcile.Result
+		err    error
+	}
+	tests := []struct {
+		reason string
+		args   args
+		want   want
+	}{
+		{
+			reason: "nil error",
+			args: args{
+				result: reconcile.Result{RequeueAfter: time.Second},
+			},
+			want: want{
+				result: reconcile.Result{RequeueAfter: time.Second},
+			},
+		},
+		{
+			reason: "other error",
+			args: args{
+				result: reconcile.Result{RequeueAfter: time.Second},
+				err:    New("some other error"),
+			},
+			want: want{
+				result: reconcile.Result{RequeueAfter: time.Second},
+				err:    New("some other error"),
+			},
+		},
+		{
+			reason: "conflict error",
+			args: args{
+				result: reconcile.Result{RequeueAfter: time.Second},
+				err:    kerrors.NewConflict(schema.GroupResource{Group: "nature", Resource: "stones"}, "foo", New("nested error")),
+			},
+			want: want{
+				result: reconcile.Result{Requeue: true},
+			},
+		},
+		{
+			reason: "nested conflict error",
+			args: args{
+				result: reconcile.Result{RequeueAfter: time.Second},
+				err: Wrap(
+					kerrors.NewConflict(schema.GroupResource{Group: "nature", Resource: "stones"}, "foo", New("nested error")),
+					"outer error"),
+			},
+			want: want{
+				result: reconcile.Result{Requeue: true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			got, err := SilentlyRequeueOnConflict(tt.args.result, tt.args.err)
+			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nIgnoreConflict(...): -want error, +got error:\n%s", tt.reason, diff)
+			}
+			if diff := cmp.Diff(tt.want.result, got); diff != "" {
+				t.Errorf("\n%s\nIgnoreConflict(...): -want result, +got result:\n%s", tt.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Example:
```golang
func Reconcile(...) (reconcile.Result, error) {
    ...

    return errors.SilentlyRequeueOnConflict(reconcile.Result{}, r.hcClient.Patch(ctx, obj, client.MergeFrom(orig)))
}
```

If the returned error is a (possibly wrapped) Kube conflict error, it is dropped (replaced with `nil`) and the result is replaced with an immediate requeue.

This way, the conflict errors, which are part of the Kube's optimistic concurrency protocol and not actual errors, do not show up as ugly backtrace in the logs.

Alternative way to use:
```golang
errors.WithSilentRequeueOnConflict(NewReconciler())
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tested.

[contribution process]: https://git.io/fj2m9