### PR TITLE
Do not modify the informer cache objects in resource.AnnotationChangedPredicate.Update

### DIFF
--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -75,6 +75,14 @@ type AnnotationChangedPredicate struct {
 	ignored []string
 }
 
+func copyAnnotations(an map[string]string) map[string]string {
+	r := make(map[string]string, len(an))
+	for k, v := range an {
+		r[k] = v
+	}
+	return r
+}
+
 // Update implements default UpdateEvent filter for validating annotation change.
 func (a AnnotationChangedPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
@@ -86,8 +94,8 @@ func (a AnnotationChangedPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	na := e.ObjectNew.GetAnnotations()
-	oa := e.ObjectOld.GetAnnotations()
+	na := copyAnnotations(e.ObjectNew.GetAnnotations())
+	oa := copyAnnotations(e.ObjectOld.GetAnnotations())
 
 	for _, k := range a.ignored {
 		delete(na, k)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #560

This PR proposes a change in the implementation of the `resource.AnnotationChangedPredicate.Update` function so that we no longer modify the `metadata.annotations` of the underlying informer cache object when the predicate is run. There's a race between this predicate and the managed reconciler when the managed reconciler tries to fetch the object from the informer cache.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
We have built an AWS provider image by updating the crossplane-runtime module dependency:
`index.docker.io/ulucinar/provider-aws-iam:v0.40.0-2f7af2124115916c53aa5f3df8c3ac53e28702fa`,
and we have not been able to reproduce the data race on `metadata.annotations` with the packages containing this fix.

[contribution process]: https://git.io/fj2m9
