### PR TITLE
Fix retry in update critical annotations after a confict

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -177,7 +177,9 @@ func (u *RetryingCriticalAnnotationUpdater) UpdateCriticalAnnotations(ctx contex
 	err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
 		err := u.client.Update(ctx, o)
 		if kerrors.IsConflict(err) {
-			err = u.client.Get(ctx, types.NamespacedName{Name: o.GetName()}, o)
+			if getErr := u.client.Get(ctx, types.NamespacedName{Name: o.GetName()}, o); getErr != nil {
+				return getErr
+			}
 			meta.AddAnnotations(o, a)
 		}
 		return err


### PR DESCRIPTION
### Description of your changes

This PR fixes retry in updating critical annotations under a specific circumstance where the Update attempt returns a conflict. Presumably introduced with [this PR](https://github.com/crossplane/crossplane-runtime/pull/526), we hide the conflict error when we have a successful get afterward, which causes not retrying to persist critical annotations.

Related issue: https://github.com/upbound/provider-azure/issues/577

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Added unit test to catch the specific scenario.

Also tested with `ResourceGroup` with provider-azure `v0.38.0`. The resource becomes ready/synced with this PR, even though it throws that event* 2 times before the retries doing its job and eventually persisting the `crossplane.io/external-create-succeeded` annotation. The question of why we try to reconcile two times before the first reconciliation returns is another question that needs to be investigated separately - I'll create a ticket to follow up.


\* `cannot determine creation result - remove the crossplane.io/external-create-pending annotation if it is safe to proceed`


[contribution process]: https://git.io/fj2m9
