### PR TITLE
Add [Observe, Delete] as a supported management policy

### DIFF
--- a/pkg/reconciler/managed/policies.go
+++ b/pkg/reconciler/managed/policies.go
@@ -82,6 +82,9 @@ func defaultSupportedManagementPolicies() []sets.Set[xpv1.ManagementAction] {
 		// is not deleted when the managed resource is deleted and the
 		// spec.forProvider is not late initialized.
 		sets.New[xpv1.ManagementAction](xpv1.ManagementActionObserve, xpv1.ManagementActionCreate),
+		// Like ObserveOnly, but the external resource is deleted when the
+		// managed resource is deleted.
+		sets.New[xpv1.ManagementAction](xpv1.ManagementActionObserve, xpv1.ManagementActionDelete),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

[provider-kubernetes ](https://github.com/crossplane-contrib/provider-kubernetes)uses its native ManagementPolicy of which one is ObserveDelete which would translate into ["Observe", "Delete"]. We are in the [process](https://github.com/crossplane-contrib/provider-kubernetes/pull/163) of migrating that to Crossplane core ManagementPolicies so I noticed that ["Observe", "Delete"] is not supported. TBH I dont see a reason why not to add it to supported policies. 

So this PR adds ["Observe", "Delete"] to the list of supported polices. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable test` . 
+
Did a manual test with provider-kubernetes and an Object observing configmap. Deleting the MR, deleted the configmap.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
