### PR TITLE
Treat all maps & slices of zero-length equal whether they are nil or not in managed.APISimpleReferenceResolver

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -146,7 +146,7 @@ func (a *APISimpleReferenceResolver) ResolveReferences(ctx context.Context, mg r
 		return errors.Wrap(err, errResolveReferences)
 	}
 
-	if cmp.Equal(existing, mg) {
+	if cmp.Equal(existing, mg, cmpopts.EquateEmpty()) {
 		// The resource didn't change during reference resolution.
 		return nil
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #617 

This PR passes the `cmpopts.EquateEmpty()` option when the `managed.APISimpleReferenceResolver` is checking whether any reference fields (`Ref` fields if a label selector is specified and the reference target fields) have been set by the downstream`ResolveReferences` call, so that all maps & slices of zero-length will be considered as equal whether they are nil or empty.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with a custom build of `upbound/provider-aws`.

[contribution process]: https://git.io/fj2m9
