### PR TITLE
Use server-side apply patch to update the resolved cross-resource references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	dario.cat/mergo v1.0.0
 	github.com/bufbuild/buf v1.28.1
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/go-logr/logr v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/spf13/afero v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxER
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes to use [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) patch operations in [managed.APISimpleReferenceResolver](https://github.com/crossplane/crossplane-runtime/blob/53f2f2d472847b7d04f9fbcbb6d64f78327ba135/pkg/reconciler/managed/api.go#L122) when updating the resolved cross-resource references. This will enable us to address the issue reported in https://github.com/upbound/provider-aws/issues/975 by specifying the SSA merge strategy for the object list `spec.forProvider.vpcConfig` and with the root cause described in detail [here](https://github.com/crossplane/crossplane/issues/3335).

An example patch document computed while updating the resolved VPC ID for the following manifests:
```yaml
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
metadata:
  name: sample-vpc-alper-1
  labels:
    app: test
spec:
  initProvider:
    cidrBlock: 172.16.0.0/16
    tags:
      a: b
  forProvider:
    region: us-west-1
    tags:
      Name: DemoVpc

---

apiVersion: ec2.aws.upbound.io/v1beta1
kind: Subnet
metadata:
  name: sample-subnet-alper-1
spec:
  forProvider:
    region: us-west-1
    availabilityZone: us-west-1b
    cidrBlock: 172.16.10.0/24
    vpcIdSelector:
      matchLabels:
        app: test
```

is:

```json
{
  "apiVersion": "ec2.aws.upbound.io/v1beta1",
  "kind": "Subnet",
  "spec": {
    "forProvider": {
      "vpcId": "vpc-08f590a352d767c2f",
      "vpcIdRef": {
        "name": "sample-vpc-alper-1"
      }
    }
  }
}
```

And the resulting managed field object is:
```json
{
    "apiVersion": "ec2.aws.upbound.io/v1beta1",
    "fieldsType": "FieldsV1",
    "fieldsV1": {
      "f:spec": {
        "f:forProvider": {
          "f:vpcId": {},
          "f:vpcIdRef": {
            "f:name": {}
          }
        }
      }
    },
    "manager": "managed.crossplane.io/api-simple-reference-resolver",
    "operation": "Apply",
    "time": "2023-12-07T14:51:26Z"
  }
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via a custom build of `upbound/provider-aws` with the above manifests and also with the configuration packages `upbound/configuration-aws-eks` and `upbound/configuration-aws-network` in the context of https://github.com/upbound/provider-aws/issues/975. The AWS family provider packages used in these tests are `index.docker.io/ulucinar/provider-aws-{ec2, iam, eks}:v0.45.0-c914fe18a92011992e32630ca4d0dba4a8f36242` and the configuration packages are `index.docker.io/ulucinar/configuration-aws-{network, eks}:v0.45.0-c914fe18a92011992e32630ca4d0dba4a8f36242`. 

[contribution process]: https://git.io/fj2m9
