### PR TITLE
Add a nil case to the expandWildcards function

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -205,7 +205,7 @@ func expandWildcards(data any, segments Segments) ([]Segments, error) { //nolint
 					res = append(res, r...)
 				}
 			case nil:
-				return nil, errNotFound{errors.Errorf("%s: value of the field is nil", segments[:i])}
+				return nil, errNotFound{errors.Errorf("wildcard field %q is not found in the path", segments[:i])}
 			default:
 				return nil, errors.Errorf("%q: unexpected wildcard usage", segments[:i])
 			}

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -204,6 +204,8 @@ func expandWildcards(data any, segments Segments) ([]Segments, error) { //nolint
 					}
 					res = append(res, r...)
 				}
+			case nil:
+				return nil, errNotFound{errors.Errorf("%s: value of the field is nil", segments[:i])}
 			default:
 				return nil, errors.Errorf("%q: unexpected wildcard usage", segments[:i])
 			}

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -949,6 +949,14 @@ func TestExpandWildcards(t *testing.T) {
 				err: errors.Wrap(errors.New("unexpected ']' at position 5"), "cannot parse path \"spec[]\""),
 			},
 		},
+		"NilValue": {
+			reason: "Requesting a wildcard for an object that has nil value",
+			path:   "spec.containers[*].name",
+			data:   []byte(`{"spec":{"containers": null}}`),
+			want: want{
+				err: errors.Wrapf(errNotFound{errors.Errorf("wildcard field %q is not found in the path", "spec.containers")}, "cannot expand wildcards for segments: %q", "spec.containers[*].name"),
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes

This PR adds a nil case to the `expandWildcards` function to handle the case that the value of the segment is nil.

The issue was observed while testing the GCP `certificatemanager.Certificate` resource. While trying to get the connection details of this resource, we try to read the `self_managed[*].certificate_pem` attribute of this resource. If the `self_managed` object is nil, then we observe an error: 

`cannot get connection details: cannot get connection
        details: cannot expand wildcards: cannot expand wildcards for segments: "self_managed[*].certificate_pem":
        "self_managed": unexpected wildcard usage'`
        
If the value of this field is nil, then we do not want to return an error because there is nothing to read in the sensitive attribute. In this case, we want to handle this situation in Upjet as a specific case other than the different cases. So, by returning a specific error from the `nil` case, we can handle this in Upjet by ignoring this error type.

I observed a specific error type, `errNotFound` and used this for the `nil` case.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This was tested in the Upjet-based GCP provider. Resource: `certificatemanager.Certificate`

[contribution process]: https://git.io/fj2m9
