### PR TITLE
reconciler/managed: fix RetryingCriticalAnnotationUpdater to support namespaces

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -215,7 +215,7 @@ func (u *RetryingCriticalAnnotationUpdater) UpdateCriticalAnnotations(ctx contex
 	err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
 		err := u.client.Update(ctx, o)
 		if kerrors.IsConflict(err) {
-			if getErr := u.client.Get(ctx, types.NamespacedName{Name: o.GetName()}, o); getErr != nil {
+			if getErr := u.client.Get(ctx, client.ObjectKeyFromObject(o), o); getErr != nil {
 				return getErr
 			}
 			meta.AddAnnotations(o, a)


### PR DESCRIPTION
### Description of your changes

In the managed reconciler with the external client, the `RetryingCriticalAnnotationUpdater` didn't support namespaces. This PR adds that trivially.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Nothing changes for existing cluster-scoped use-cases because then namespace is empty. Tested in internal project that uses the code for namespaced objects.

[contribution process]: https://git.io/fj2m9