### PR TITLE
controller/engine: sync informers on controller start

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -147,8 +147,8 @@ func (c *GVKRoutedCache) Start(_ context.Context) error {
 	return nil
 }
 
-// WaitForCacheSync for a GVKRoutedCache waits for all delegates to sync, and
-// returns false if any of them fails to sync.
+// WaitForCacheSync for a GVKRoutedCache waits for all delegates and the
+// fallback to sync, and returns false if any of them fails to sync.
 func (c *GVKRoutedCache) WaitForCacheSync(ctx context.Context) bool {
 	c.lock.RLock()
 	syncedCh := make(chan bool, len(c.delegates)+1)
@@ -186,7 +186,7 @@ func (c *GVKRoutedCache) WaitForCacheSync(ctx context.Context) bool {
 		}
 	}
 
-	return true
+	return c.fallback.WaitForCacheSync(ctx)
 }
 
 // IndexField adds an index with the given field name on the given object type

--- a/pkg/controller/engine.go
+++ b/pkg/controller/engine.go
@@ -271,6 +271,10 @@ func (c *namedController) Start(ctx context.Context) error {
 	}()
 	go func() {
 		<-c.e.mgr.Elected()
+		if synced := c.ca.WaitForCacheSync(ctx); !synced {
+			c.e.done(c.name, errors.New(errCrashCache))
+			return
+		}
 		c.e.done(c.name, errors.Wrap(c.ctrl.Start(ctx), errCrashController))
 	}()
 

--- a/pkg/controller/engine_test.go
+++ b/pkg/controller/engine_test.go
@@ -47,6 +47,10 @@ func (c *MockCache) Start(stop context.Context) error {
 	return c.MockStart(stop)
 }
 
+func (c *MockCache) WaitForCacheSync(_ context.Context) bool {
+	return true
+}
+
 type MockController struct {
 	controller.Controller
 


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes crossplane/crossplane#5151.

Before this, there was no wait for informers when starting the XR controller. This PR is supposed to ensure that all informers are in sync before XRs are reconciled.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Mostly by reading the code carefully. Waiting for feedback from https://github.com/crossplane/crossplane/issues/5151.

[contribution process]: https://git.io/fj2m9