### PR TITLE
reconciler/managed: make more resilient to error conditions

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -212,7 +212,9 @@ func NewRetryingCriticalAnnotationUpdater(c client.Client) *RetryingCriticalAnno
 // case of a conflict error.
 func (u *RetryingCriticalAnnotationUpdater) UpdateCriticalAnnotations(ctx context.Context, o client.Object) error {
 	a := o.GetAnnotations()
-	err := retry.OnError(retry.DefaultRetry, resource.IsAPIError, func() error {
+	err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return !errors.Is(err, context.Canceled)
+	}, func() error {
 		err := u.client.Update(ctx, o)
 		if kerrors.IsConflict(err) {
 			if getErr := u.client.Get(ctx, client.ObjectKeyFromObject(o), o); getErr != nil {

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1051,10 +1051,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 			// issue we'll be requeued implicitly when we update our status with
 			// the new error condition. If not, we requeue explicitly, which will trigger backoff.
 			log.Debug("Cannot create external resource", "error", err)
-			if kerrors.IsConflict(err) {
-				return reconcile.Result{Requeue: true}, nil
+			if !kerrors.IsConflict(err) {
+				record.Event(managed, event.Warning(reasonCannotCreate, err))
 			}
-			record.Event(managed, event.Warning(reasonCannotCreate, err))
 
 			// We handle annotations specially here because it's
 			// critical that they are persisted to the API server.


### PR DESCRIPTION
### Description of your changes

Two cases where the manager reconciler bricked an object forever:

1. when `external.Create` returned a conflict error. This was an oversight in https://github.com/crossplane/crossplane-runtime/pull/540 when introducing less noisy conflict handling.
2. on non-API errors when the critical failed/succeeded annotations were applied. Think of network issues. These are not API errors and hence they stopped the retry loop.

There is still a risk that an object becomes bricked, e.g.:
- when the ctx is cancelled after some timeout (30s or so per reconcile?). I.e. if the error persists for long enough.
- when the controller crashes before apply the critical annotations.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Careful code reading and review. This is hard to test other than under real-life condition under heavy load.