### PR TITLE
Update status readiness #583

### DIFF
--- a/apis/common/v1/condition.go
+++ b/apis/common/v1/condition.go
@@ -44,6 +44,7 @@ const (
 	ReasonAvailable   ConditionReason = "Available"
 	ReasonUnavailable ConditionReason = "Unavailable"
 	ReasonCreating    ConditionReason = "Creating"
+	ReasonUpdating    ConditionReason = "Updating"
 	ReasonDeleting    ConditionReason = "Deleting"
 )
 
@@ -191,6 +192,17 @@ func Creating() Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonCreating,
+	}
+}
+
+// Updating returns a condition that indicates the resource is currently
+// being updated.
+func Updating() Condition {
+	return Condition{
+		Type:               TypeReady,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonUpdating,
 	}
 }
 

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1142,23 +1142,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		}
 	}
 
-	if observation.ResourceUpToDate {
-		// We did not need to create, update, or delete our external resource.
-		// Per the below issue nothing will notify us if and when the external
-		// resource we manage changes, so we requeue a speculative reconcile
-		// after the specified poll interval in order to observe it and react
-		// accordingly.
-		// https://github.com/crossplane/crossplane/issues/289
-		reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
-		log.Debug("External resource is up to date", "requeue-after", time.Now().Add(reconcileAfter))
-		managed.SetConditions(xpv1.ReconcileSuccess())
-		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
-	}
-
-	if observation.Diff != "" {
-		log.Debug("External resource differs from desired state", "diff", observation.Diff)
-	}
-
 	// skip the update if the management policy is set to ignore updates
 	if !policy.ShouldUpdate() {
 		reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
@@ -1167,37 +1150,52 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
-	update, err := external.Update(externalCtx, managed)
-	if err != nil {
-		// We'll hit this condition if we can't update our external resource,
-		// for example if our provider credentials don't have access to update
-		// it. If this is the first time we encounter this issue we'll be
-		// requeued implicitly when we update our status with the new error
-		// condition. If not, we requeue explicitly, which will trigger backoff.
-		log.Debug("Cannot update external resource")
-		record.Event(managed, event.Warning(reasonCannotUpdate, err))
-		managed.SetConditions(xpv1.ReconcileError(errors.Wrap(err, errReconcileUpdate)))
+	if observation.Diff != "" {
+		log.Debug("External resource differs from desired state", "diff", observation.Diff)
+	}
+
+	if !observation.ResourceUpToDate && policy.ShouldUpdate() {
+		update, err := external.Update(externalCtx, managed)
+		if err != nil {
+			// We'll hit this condition if we can't update our external resource,
+			// for example if our provider credentials don't have access to update
+			// it. If this is the first time we encounter this issue we'll be
+			// requeued implicitly when we update our status with the new error
+			// condition. If not, we requeue explicitly, which will trigger backoff.
+			log.Debug("Cannot update external resource")
+			record.Event(managed, event.Warning(reasonCannotUpdate, err))
+			managed.SetConditions(xpv1.Updating(), xpv1.ReconcileError(errors.Wrap(err, errReconcileUpdate)))
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		}
+
+		if _, err := r.managed.PublishConnection(ctx, managed, update.ConnectionDetails); err != nil {
+			// If this is the first time we encounter this issue we'll be requeued
+			// implicitly when we update our status with the new error condition. If
+			// not, we requeue explicitly, which will trigger backoff.
+			log.Debug("Cannot publish connection details", "error", err)
+			record.Event(managed, event.Warning(reasonCannotPublish, err))
+			managed.SetConditions(xpv1.Updating(), xpv1.ReconcileError(err))
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+		}
+
+		// We've successfully updated our external resource. In many cases the
+		// updating process takes a little time to finish. We requeue explicitly
+		// order to observe the external resource to determine whether it's
+		// ready for use.
+		log.Debug("Successfully requested update of external resource")
+		record.Event(managed, event.Normal(reasonUpdated, "Successfully requested update of external resource"))
+		managed.SetConditions(xpv1.Updating(), xpv1.ReconcileSuccess())
 		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
-	if _, err := r.managed.PublishConnection(ctx, managed, update.ConnectionDetails); err != nil {
-		// If this is the first time we encounter this issue we'll be requeued
-		// implicitly when we update our status with the new error condition. If
-		// not, we requeue explicitly, which will trigger backoff.
-		log.Debug("Cannot publish connection details", "error", err)
-		record.Event(managed, event.Warning(reasonCannotPublish, err))
-		managed.SetConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
-	}
-
-	// We've successfully updated our external resource. Per the below issue
-	// nothing will notify us if and when the external resource we manage
-	// changes, so we requeue a speculative reconcile after the specified poll
-	// interval in order to observe it and react accordingly.
+	// We did not need to create, update, or delete our external resource.
+	// Per the below issue nothing will notify us if and when the external
+	// resource we manage changes, so we requeue a speculative reconcile
+	// after the specified poll interval in order to observe it and react
+	// accordingly.
 	// https://github.com/crossplane/crossplane/issues/289
 	reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
-	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(reconcileAfter))
-	record.Event(managed, event.Normal(reasonUpdated, "Successfully requested update of external resource"))
+	log.Debug("External resource is up to date", "requeue-after", time.Now().Add(reconcileAfter))
 	managed.SetConditions(xpv1.ReconcileSuccess())
 	return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 }

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -1075,6 +1075,7 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := &fake.Managed{}
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileUpdate)))
+							want.SetConditions(xpv1.Updating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors while updating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1114,6 +1115,7 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := &fake.Managed{}
 							want.SetConditions(xpv1.ReconcileError(errBoom))
+							want.SetConditions(xpv1.Updating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after an update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1156,7 +1158,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"UpdateSuccessful": {
-			reason: "A successful managed resource update should trigger a requeue after a long wait.",
+			reason: "A successful managed resource update should trigger a requeue after a short wait",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -1164,6 +1166,7 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := &fake.Managed{}
 							want.SetConditions(xpv1.ReconcileSuccess())
+							want.SetConditions(xpv1.Updating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1192,7 +1195,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ReconciliationPausedSuccessful": {
 			reason: `If a managed resource has the pause annotation with value "true", there should be no further requeue requests.`,
@@ -1662,7 +1665,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ManagementPolicyAllUpdateSuccessful": {
-			reason: "A successful managed resource update using management policies should trigger a requeue after a long wait.",
+			reason: "A successful managed resource update using management policies should trigger a requeue after a short wait.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -1675,6 +1678,7 @@ func TestReconciler(t *testing.T) {
 							want := &fake.Managed{}
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess())
+							want.SetConditions(xpv1.Updating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1704,10 +1708,10 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ManagementPolicyUpdateUpdateSuccessful": {
-			reason: "A successful managed resource update using management policies should trigger a requeue after a long wait.",
+			reason: "A successful managed resource update using management policies should trigger a requeue after a short wait.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -1720,6 +1724,7 @@ func TestReconciler(t *testing.T) {
 							want := &fake.Managed{}
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess())
+							want.SetConditions(xpv1.Updating())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
@@ -1749,7 +1754,7 @@ func TestReconciler(t *testing.T) {
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+			want: want{result: reconcile.Result{Requeue: true}},
 		},
 		"ManagementPolicySkipLateInitialize": {
 			reason: "Should skip updating a managed resource to persist late initialized fields and should trigger a requeue after a long wait.",


### PR DESCRIPTION
### Description of your changes

This PR aims to align the behavior of the reconciler for `Update` operations with that of `Create` operations.

It achieves this by rewriting some of the `Reconcile` function to not use the call to `external.Update` as a last resort, but instead evaluate if it is needed based on the returned `observation.ResourceUpToDate` and `policy.ShouldUpdate`.

Fixes #584 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

We have updated all tests related to the `Update` functionality, so they now test if the `xpv1.Updating()` condition is there and that it returns the updated `reconcile.Result{Requeue: true}` struct.
No tests have been added, but we are not sure if it is needed.
