### PR TITLE
Add a nil case to the `getValueFromInterface` function

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -142,7 +142,7 @@ func getValueFromInterface(it any, s Segments) (any, error) { //nolint:gocyclo /
 				}
 				it = object[current.Field]
 			case nil:
-				return nil, errNotFound{errors.Errorf("path %q is not found in the paved object", s[:i])}
+				return nil, errNotFound{errors.Errorf("%s: expected map, got nil", s[:i])}
 			default:
 				return nil, errors.Errorf("%s: not an object", s[:i])
 			}

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -142,7 +142,7 @@ func getValueFromInterface(it any, s Segments) (any, error) { //nolint:gocyclo /
 				}
 				it = object[current.Field]
 			case nil:
-				return nil, errNotFound{errors.Errorf("field %q is not found in the path", s[:i])}
+				return nil, errNotFound{errors.Errorf("path %q is not found in the paved object", s[:i])}
 			default:
 				return nil, errors.Errorf("%s: not an object", s[:i])
 			}

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -161,12 +161,12 @@ func TestGetValue(t *testing.T) {
 				err: errors.Wrap(errors.New("unexpected ']' at position 5"), "cannot parse path \"spec[]\""),
 			},
 		},
-		"NilValue": {
-			reason: "Requesting for an object that has nil value",
+		"NilParent": {
+			reason: "Request for a path with a nil parent value",
 			path:   "spec.containers[*].name",
 			data:   []byte(`{"spec":{"containers": null}}`),
 			want: want{
-				err: errNotFound{errors.Errorf("field %q is not found in the path", "spec.containers")},
+				err: errNotFound{errors.Errorf("path %q is not found in the paved object", "spec.containers")},
 			},
 		},
 	}

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -161,6 +161,14 @@ func TestGetValue(t *testing.T) {
 				err: errors.Wrap(errors.New("unexpected ']' at position 5"), "cannot parse path \"spec[]\""),
 			},
 		},
+		"NilValue": {
+			reason: "Requesting for an object that has nil value",
+			path:   "spec.containers[*].name",
+			data:   []byte(`{"spec":{"containers": null}}`),
+			want: want{
+				err: errNotFound{errors.Errorf("field %q is not found in the path", "spec.containers")},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -166,7 +166,7 @@ func TestGetValue(t *testing.T) {
 			path:   "spec.containers[*].name",
 			data:   []byte(`{"spec":{"containers": null}}`),
 			want: want{
-				err: errNotFound{errors.Errorf("path %q is not found in the paved object", "spec.containers")},
+				err: errNotFound{errors.Errorf("%s: expected map, got nil", "spec.containers")},
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

This PR adds a nil case to the `getValueFromInterface` function to handle the case that the value of the segment is nil. This [issue](https://github.com/upbound/provider-aws/pull/1118#issuecomment-1922017676) was observed while testing the conversion functions in provider-aws.

This PR addresses the same issue as [here](https://github.com/crossplane/crossplane-runtime/pull/627), but for a different function.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally for the observed case.

[contribution process]: https://git.io/fj2m9
