### PR TITLE
logging: add SetFilteredKlogLogger to show client-go throttling logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1
+	k8s.io/klog/v2 v2.110.1
 	sigs.k8s.io/controller-runtime v0.17.0
 	sigs.k8s.io/controller-tools v0.14.0
 	sigs.k8s.io/yaml v1.4.0
@@ -123,7 +124,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.29.1 // indirect
-	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/pkg/logging/klog.go
+++ b/pkg/logging/klog.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Upbound Inc.
+// All rights reserved
+
+package logging
+
+import (
+	"flag"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+)
+
+// SetFilteredKlogLogger sets log as the logger backend of klog, but filtering
+// aggressively to avoid noise.
+func SetFilteredKlogLogger(log logr.Logger) {
+	// initialize klog at verbosity level 3, dropping everything higher.
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(fs)
+	fs.Parse([]string{"--v=3"}) //nolint:errcheck // we couldn't do anything here anyway
+
+	klogr := logr.New(&requestThrottlingFilter{log.GetSink()})
+	klog.SetLogger(klogr)
+}
+
+// requestThrottlingFilter drops everything that is not a client-go throttling
+// message, compare:
+// https://github.com/kubernetes/client-go/blob/8c4efe8d079e405329f314fb789a41ac6af101dc/rest/request.go#L621
+type requestThrottlingFilter struct {
+	logr.LogSink
+}
+
+func (l *requestThrottlingFilter) Info(level int, msg string, keysAndValues ...interface{}) {
+	if !strings.Contains(msg, "Waited for ") || !strings.Contains(msg, "  request: ") {
+		return
+	}
+
+	l.LogSink.Info(l.klogToLogrLevel(level), msg, keysAndValues...)
+}
+
+func (l *requestThrottlingFilter) Enabled(level int) bool {
+	return l.LogSink.Enabled(l.klogToLogrLevel(level))
+}
+
+func (l *requestThrottlingFilter) klogToLogrLevel(klogLvl int) int {
+	// we want a default klog level of 3 for info, 4 for debug, corresponding to
+	// logr levels of 0 and 1.
+	if klogLvl >= 3 {
+		return klogLvl - 3
+	}
+	return 0
+}
+
+func (l *requestThrottlingFilter) WithCallDepth(depth int) logr.LogSink {
+	if delegate, ok := l.LogSink.(logr.CallDepthLogSink); ok {
+		return &requestThrottlingFilter{LogSink: delegate.WithCallDepth(depth)}
+	}
+
+	return l
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

It's hard to understand which component is causing slowness. This PR enables client throttling logging, both for server-side and client-side, i.e. these pass:

```golang
switch {
  case len(retryInfo) > 0:
    message = fmt.Sprintf("Waited for %v, %s - request: %s:%s", latency, retryInfo, r.verb, r.URL().String())
  default:
    message = fmt.Sprintf("Waited for %v due to client-side throttling, not priority and fairness, request: %s:%s", latency, r.verb, r.URL().String())
}
```

For example:

```
Waited for 1.033772408s due to client-side throttling, not priority and fairness, request: GET:https://api.example.org/apis/pkg.crossplane.io/v1?timeout=32s
Waited for 580ms, request: GET:https://api.example.org/apis/pkg.crossplane.io/v1?timeout=32s - retries: 1, retry-after: 1s - retry-reason: due to server-side throttling, FlowSchema UID: ""
```

This is just in Crossplane. It probably needs a log setup helper in controller-runtime and then vendored into providers.

Of course, this information could also be understood from metrics, but metrics are complicated, hard to discover and need tons of knowledge to understand right.

> Mr Prosser: But the plans were on display…
> Arthur: On display? I eventually had to go down to the cellar to find them.
> Mr Prosser: That’s the display department.
> Arthur: With a torch.
> Mr Prosser: The lights had probably gone out.
> Arthur: So had the stairs.
> Mr Prosser: But look, you found the notice, didn’t you?
> Arthur: Yes yes I did. It was on display at the bottom of a locked filing cabinet stuck in a disused lavatory with a sign on the door saying beware of the leopard.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in https://github.com/crossplane/crossplane/pull/5419.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9