### PR TITLE
Bump golangci-lint, copy config from c/c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.22.0'
-  GOLANGCI_VERSION: 'v1.55.2'
+  GOLANGCI_VERSION: 'v1.56.2'
 
 jobs:
   check-diff:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,102 @@ output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number
 
+linters:
+  enable-all: true
+  fast: false
+
+  disable:
+    # These linters are all deprecated. We disable them explicitly to avoid the
+    # linter logging deprecation warnings.
+    - deadcode
+    - varcheck
+    - scopelint
+    - structcheck
+    - interfacer
+    - exhaustivestruct
+    - ifshort
+    - golint
+    - maligned
+    - nosnakecase
+
+    # These are linters we'd like to enable, but that will be labor intensive to
+    # make existing code compliant.
+    - wrapcheck
+    - varnamelen
+    - testpackage
+    - paralleltest
+    - nilnil
+    - gomnd
+
+    # Below are linters that lint for things we don't value. Each entry below
+    # this line must have a comment explaining the rationale.
+
+    # These linters add whitespace in an attempt to make code more readable.
+    # This isn't a widely accepted Go best practice, and would be laborious to
+    # apply to existing code.
+    - wsl
+    - nlreturn
+
+    # Warns about uses of fmt.Sprintf that are less performant than alternatives
+    # such as string concatenation. We value readability more than performance
+    # unless performance is measured to be an issue.
+    - perfsprint
+
+    # This linter:
+    #
+    # 1. Requires errors.Is/errors.As to test equality.
+    # 2. Requires all errors be wrapped with fmt.Errorf specifically.
+    # 3. Disallows errors.New inline - requires package level errors.
+    #
+    # 1 is covered by other linters. 2 is covered by wrapcheck, which can also
+    # handle our use of crossplane-runtime's errors package. 3 is more strict
+    # than we need. Not every error needs to be tested for equality.
+    - goerr113
+
+    # These linters duplicate gocognit, but calculate complexity differently.
+    - gocyclo
+    - cyclop
+    - nestif
+    - funlen
+    - maintidx
+
+    # Enforces max line length. It's not idiomatic to enforce a strict limit on
+    # line length in Go. We'd prefer to lint for things that often cause long
+    # lines, like functions with too many parameters or long parameter names
+    # that duplicate their types.
+    - lll
+
+    # Warns about struct instantiations that don't specify every field. Could be
+    # useful in theory to catch fields that are accidentally omitted. Seems like
+    # it would have many more false positives than useful catches, though.
+    - exhaustruct
+
+    # Warns about TODO comments. The rationale being they should be issues
+    # instead. We're okay with using TODO to track minor cleanups for next time
+    # we touch a particular file.
+    - godox
+
+    # Warns about duplicated code blocks within the same file. Could be useful
+    # to prompt folks to think about whether code should be broken out into a
+    # function, but generally we're less worried about DRY and fine with a
+    # little copying. We don't want to give folks the impression that we require
+    # every duplicated code block to be factored out into a function.
+    - dupl
+
+    # Warns about returning interfaces rather than concrete types. We do think
+    # it's best to avoid returning interfaces where possible. However, at the
+    # time of writing enabling this linter would only catch the (many) cases
+    # where we must return an interface.
+    - ireturn
+
+    # Warns about returning named variables. We do think it's best to avoid
+    # returning named variables where possible. However, at the time of writing
+    # enabling this linter would only catch the (many) cases where returning
+    # named variables is useful to document what the variables are. For example
+    # we believe it makes sense to return (ready bool) rather than just (bool)
+    # to communicate what the bool means.
+    - nonamedreturns
+
 linters-settings:
   errcheck:
     # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
@@ -39,10 +135,6 @@ linters-settings:
       - prefix(github.com/crossplane/crossplane-runtime)
       - blank
       - dot
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
 
   maligned:
     # print struct with more effective memory layout or not, false by default
@@ -106,37 +198,27 @@ linters-settings:
     require-explanation: true
     require-specific: true
 
+  depguard:
+    rules:
+      no_third_party_test_libraries:
+        list-mode: lax
+        files:
+        - $test
+        deny:
+        - pkg: github.com/stretchr/testify
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
+        - pkg: github.com/onsi/ginkgo
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
+        - pkg: github.com/onsi/gomega
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
 
-linters:
-  enable:
-    - megacheck
-    - govet
-    - gocyclo
-    - gocritic
-    - goconst
-    - gci
-    - gofmt  # We enable this as well as goimports for its simplify mode.
-    - prealloc
-    - revive
-    - unconvert
-    - misspell
-    - nakedret
-    - nolintlint
-  
-  disable:
-    # These linters are all deprecated as of golangci-lint v1.49.0. We disable
-    # them explicitly to avoid the linter logging deprecation warnings.
-    - deadcode
-    - varcheck
-    - scopelint
-    - structcheck
-    - interfacer
+  interfacebloat:
+    max: 5
 
-  presets:
-    - bugs
-    - unused
-  fast: false
-
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
 
 issues:
   # Excluding configuration per-path and per-linter
@@ -144,20 +226,28 @@ issues:
     # Exclude some linters from running on tests files.
     - path: _test(ing)?\.go
       linters:
-        - gocyclo
+        - gocognit
         - errcheck
-        - dupl
         - gosec
         - scopelint
         - unparam
-        - contextcheck
-        - errchkjson
+        - gochecknoinits
+        - gochecknoglobals
+        - containedctx
+        - forcetypeassert
 
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer)"
       linters:
         - gocritic
+
+    # It's idiomatic to register Kubernetes types with a package scoped
+    # SchemeBuilder using an init function.
+    - path: apis/
+      linters:
+      - gochecknoinits
+      - gochecknoglobals
 
     # These are performance optimisations rather than style issues per se.
     # They warn when function arguments or range values copy a lot of memory
@@ -189,6 +279,11 @@ issues:
       linters:
       - gosec
       - gas
+
+    # Some k8s dependencies do not have JSON tags on all fields in structs.
+    - path: k8s.io/
+      linters:
+      - musttag
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO_SUBDIRS += pkg apis
 GO111MODULE = on
-GOLANGCILINT_VERSION = 1.55.2
+GOLANGCILINT_VERSION = 1.56.2
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/apis/common/v1/condition.go
+++ b/apis/common/v1/condition.go
@@ -117,7 +117,7 @@ func NewConditionedStatus(c ...Condition) *ConditionedStatus {
 }
 
 // GetCondition returns the condition for the given ConditionType if exists,
-// otherwise returns nil
+// otherwise returns nil.
 func (s *ConditionedStatus) GetCondition(ct ConditionType) Condition {
 	for _, c := range s.Conditions {
 		if c.Type == ct {

--- a/apis/common/v1/merge.go
+++ b/apis/common/v1/merge.go
@@ -20,7 +20,7 @@ import (
 	"dario.cat/mergo"
 )
 
-// MergeOptions Specifies merge options on a field path
+// MergeOptions Specifies merge options on a field path.
 type MergeOptions struct { // TODO(aru): add more options that control merging behavior
 	// Specifies that already existing values in a merged map should be preserved
 	// +optional
@@ -30,7 +30,7 @@ type MergeOptions struct { // TODO(aru): add more options that control merging b
 	AppendSlice *bool `json:"appendSlice,omitempty"`
 }
 
-// MergoConfiguration the default behavior is to replace maps and slices
+// MergoConfiguration the default behavior is to replace maps and slices.
 func (mo *MergeOptions) MergoConfiguration() []func(*mergo.Config) {
 	config := []func(*mergo.Config){mergo.WithOverride}
 	if mo == nil {
@@ -46,7 +46,7 @@ func (mo *MergeOptions) MergoConfiguration() []func(*mergo.Config) {
 	return config
 }
 
-// IsAppendSlice returns true if mo.AppendSlice is set to true
+// IsAppendSlice returns true if mo.AppendSlice is set to true.
 func (mo *MergeOptions) IsAppendSlice() bool {
 	return mo != nil && mo.AppendSlice != nil && *mo.AppendSlice
 }

--- a/apis/common/v1/merge_test.go
+++ b/apis/common/v1/merge_test.go
@@ -84,7 +84,6 @@ func TestMergoConfiguration(t *testing.T) {
 			if diff := cmp.Diff(tc.want.names(), mergoOptArr(tc.mo.MergoConfiguration()).names()); diff != "" {
 				t.Errorf("\nmo.MergoConfiguration(): -want, +got:\n %s", diff)
 			}
-
 		})
 	}
 }

--- a/apis/common/v1/resource.go
+++ b/apis/common/v1/resource.go
@@ -23,23 +23,23 @@ import (
 )
 
 const (
-	// ResourceCredentialsSecretEndpointKey is the key inside a connection secret for the connection endpoint
+	// ResourceCredentialsSecretEndpointKey is the key inside a connection secret for the connection endpoint.
 	ResourceCredentialsSecretEndpointKey = "endpoint"
-	// ResourceCredentialsSecretPortKey is the key inside a connection secret for the connection port
+	// ResourceCredentialsSecretPortKey is the key inside a connection secret for the connection port.
 	ResourceCredentialsSecretPortKey = "port"
-	// ResourceCredentialsSecretUserKey is the key inside a connection secret for the connection user
+	// ResourceCredentialsSecretUserKey is the key inside a connection secret for the connection user.
 	ResourceCredentialsSecretUserKey = "username"
-	// ResourceCredentialsSecretPasswordKey is the key inside a connection secret for the connection password
+	// ResourceCredentialsSecretPasswordKey is the key inside a connection secret for the connection password.
 	ResourceCredentialsSecretPasswordKey = "password"
-	// ResourceCredentialsSecretCAKey is the key inside a connection secret for the server CA certificate
+	// ResourceCredentialsSecretCAKey is the key inside a connection secret for the server CA certificate.
 	ResourceCredentialsSecretCAKey = "clusterCA"
-	// ResourceCredentialsSecretClientCertKey is the key inside a connection secret for the client certificate
+	// ResourceCredentialsSecretClientCertKey is the key inside a connection secret for the client certificate.
 	ResourceCredentialsSecretClientCertKey = "clientCert"
-	// ResourceCredentialsSecretClientKeyKey is the key inside a connection secret for the client key
+	// ResourceCredentialsSecretClientKeyKey is the key inside a connection secret for the client key.
 	ResourceCredentialsSecretClientKeyKey = "clientKey"
-	// ResourceCredentialsSecretTokenKey is the key inside a connection secret for the bearer token value
+	// ResourceCredentialsSecretTokenKey is the key inside a connection secret for the bearer token value.
 	ResourceCredentialsSecretTokenKey = "token"
-	// ResourceCredentialsSecretKubeconfigKey is the key inside a connection secret for the raw kubeconfig yaml
+	// ResourceCredentialsSecretKubeconfigKey is the key inside a connection secret for the raw kubeconfig yaml.
 	ResourceCredentialsSecretKubeconfigKey = "kubeconfig"
 )
 

--- a/pkg/connection/fake/mocks.go
+++ b/pkg/connection/fake/mocks.go
@@ -15,6 +15,8 @@
 */
 
 // Package fake implements a fake secret store.
+//
+//nolint:musttag // We only use JSON to round-trip convert these mocks.
 package fake
 
 import (
@@ -29,7 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection/store"
 )
 
-// SecretStore is a fake SecretStore
+// SecretStore is a fake SecretStore.
 type SecretStore struct {
 	ReadKeyValuesFn   func(ctx context.Context, n store.ScopedName, s *store.Secret) error
 	WriteKeyValuesFn  func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error)
@@ -52,14 +54,14 @@ func (ss *SecretStore) DeleteKeyValues(ctx context.Context, s *store.Secret, do 
 }
 
 // StoreConfig is a mock implementation of the StoreConfig interface.
-type StoreConfig struct { //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type StoreConfig struct {
 	metav1.ObjectMeta
 
 	Config v1.SecretStoreConfig
 	v1.ConditionedStatus
 }
 
-// GetStoreConfig returns SecretStoreConfig
+// GetStoreConfig returns SecretStoreConfig.
 func (s *StoreConfig) GetStoreConfig() v1.SecretStoreConfig {
 	return s.Config
 }
@@ -69,7 +71,7 @@ func (s *StoreConfig) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (s *StoreConfig) DeepCopyObject() runtime.Object {
 	out := &StoreConfig{}
 	j, err := json.Marshal(s)

--- a/pkg/connection/manager.go
+++ b/pkg/connection/manager.go
@@ -79,6 +79,7 @@ type DetailsManager struct {
 // NewDetailsManager returns a new connection DetailsManager.
 func NewDetailsManager(c client.Client, of schema.GroupVersionKind, o ...DetailsManagerOption) *DetailsManager {
 	nc := func() StoreConfig {
+		//nolint:forcetypeassert // If the supplied type isn't a StoreConfig it's a programming error. We want to panic.
 		return resource.MustCreateObject(of, c.Scheme()).(StoreConfig)
 	}
 

--- a/pkg/connection/manager_test.go
+++ b/pkg/connection/manager_test.go
@@ -74,7 +74,7 @@ func TestManagerConnectStore(t *testing.T) {
 			reason: "We should return a proper error if referenced StoreConfig does not exist.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
@@ -94,13 +94,13 @@ func TestManagerConnectStore(t *testing.T) {
 			reason: "We should return any error encountered while building the Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{}
 						return nil
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
-				sb: func(ctx context.Context, local client.Client, tCfg *tls.Config, cfg v1.SecretStoreConfig) (Store, error) {
+				sb: func(_ context.Context, _ client.Client, _ *tls.Config, _ v1.SecretStoreConfig) (Store, error) {
 					return nil, errors.New(errBuildStore)
 				},
 				p: &v1.PublishConnectionDetailsTo{
@@ -117,7 +117,7 @@ func TestManagerConnectStore(t *testing.T) {
 			reason: "We should not return an error when connected successfully.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -189,13 +189,13 @@ func TestManagerPublishConnection(t *testing.T) {
 			reason: "We should return any error encountered while connecting to Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, nil
 					},
 				}),
@@ -215,7 +215,7 @@ func TestManagerPublishConnection(t *testing.T) {
 			reason: "We should return a proper error when publish to secret store failed.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -229,7 +229,7 @@ func TestManagerPublishConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, errBoom
 					},
 				}),
@@ -249,7 +249,7 @@ func TestManagerPublishConnection(t *testing.T) {
 			reason: "We should return no error when published successfully.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -263,7 +263,7 @@ func TestManagerPublishConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, s *store.Secret, _ ...store.WriteOption) (bool, error) {
 						if diff := cmp.Diff(testUID, s.Metadata.GetOwnerUID()); diff != "" {
 							t.Errorf("\nReason: %s\nm.publishConnection(...): -want ownerUID, +got ownerUID:\n%s", testUID, diff)
 						}
@@ -336,13 +336,13 @@ func TestManagerUnpublishConnection(t *testing.T) {
 			reason: "We should return any error encountered while connecting to Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, nil
 					},
 				}),
@@ -362,7 +362,7 @@ func TestManagerUnpublishConnection(t *testing.T) {
 			reason: "We should return a proper error when delete from secret store failed.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -376,7 +376,7 @@ func TestManagerUnpublishConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					DeleteKeyValuesFn: func(ctx context.Context, s *store.Secret, do ...store.DeleteOption) error {
+					DeleteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.DeleteOption) error {
 						return errBoom
 					},
 				}),
@@ -396,7 +396,7 @@ func TestManagerUnpublishConnection(t *testing.T) {
 			reason: "We should return a proper error when attempted to unpublish a secret that is not owned.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -443,7 +443,7 @@ func TestManagerUnpublishConnection(t *testing.T) {
 			reason: "We should return no error when unpublished successfully.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -533,13 +533,13 @@ func TestManagerFetchConnection(t *testing.T) {
 			reason: "We should return any error encountered while connecting to Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, nil
 					},
 				}),
@@ -559,7 +559,7 @@ func TestManagerFetchConnection(t *testing.T) {
 			reason: "We should return a proper error when fetch from secret store failed.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -573,7 +573,7 @@ func TestManagerFetchConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, _ *store.Secret) error {
 						return errBoom
 					},
 				}),
@@ -593,7 +593,7 @@ func TestManagerFetchConnection(t *testing.T) {
 			reason: "We should return no error when fetched successfully.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -607,7 +607,7 @@ func TestManagerFetchConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Data = store.KeyValues{
 							"key1": []byte("val1"),
 						}
@@ -693,13 +693,13 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return any error encountered while connecting to Source Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, nil
 					},
 				}),
@@ -720,7 +720,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return a proper error when fetch from secret store failed.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -734,7 +734,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, _ *store.Secret) error {
 						return errBoom
 					},
 				}),
@@ -773,7 +773,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{}
 						return nil
 					},
@@ -823,7 +823,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: "00000000-1111-2222-3333-444444444444",
@@ -877,7 +877,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -913,7 +913,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return any error encountered while publishing to Destination Store.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -927,7 +927,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -935,7 +935,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 						}
 						return nil
 					},
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return false, errBoom
 					},
 				}),
@@ -965,7 +965,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return a proper error if destination secret cannot be owned by destination resource.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -979,7 +979,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -989,7 +989,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					},
 					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
 						for _, o := range wo {
-							if err := o(context.Background(), &store.Secret{
+							if err := o(ctx, &store.Secret{
 								Metadata: &v1.ConnectionSecretMetadata{
 									Labels: map[string]string{
 										v1.LabelKeyOwnerUID: "00000000-1111-2222-3333-444444444444",
@@ -1031,7 +1031,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return no error when propagated successfully.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -1045,7 +1045,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -1053,7 +1053,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 						}
 						return nil
 					},
-					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
+					WriteKeyValuesFn: func(_ context.Context, _ *store.Secret, _ ...store.WriteOption) (bool, error) {
 						return true, nil
 					},
 				}),
@@ -1083,7 +1083,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return a proper error when attempted to update an unowned secret.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -1097,7 +1097,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -1107,7 +1107,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					},
 					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
 						for _, o := range wo {
-							if err := o(context.Background(), &store.Secret{
+							if err := o(ctx, &store.Secret{
 								Data: map[string][]byte{
 									"some-key": []byte("some-val"),
 								},
@@ -1145,7 +1145,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 			reason: "We should return no error when propagated successfully by updating an already owned secret.",
 			args: args{
 				c: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*fake.StoreConfig) = fake.StoreConfig{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: fakeConfig,
@@ -1159,7 +1159,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					MockScheme: test.NewMockSchemeFn(resourcefake.SchemeWith(&fake.StoreConfig{})),
 				},
 				sb: fakeStoreBuilderFn(fake.SecretStore{
-					ReadKeyValuesFn: func(ctx context.Context, n store.ScopedName, s *store.Secret) error {
+					ReadKeyValuesFn: func(_ context.Context, _ store.ScopedName, s *store.Secret) error {
 						s.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
 								v1.LabelKeyOwnerUID: testUID,
@@ -1169,7 +1169,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 					},
 					WriteKeyValuesFn: func(ctx context.Context, s *store.Secret, wo ...store.WriteOption) (bool, error) {
 						for _, o := range wo {
-							if err := o(context.Background(), &store.Secret{
+							if err := o(ctx, &store.Secret{
 								Metadata: &v1.ConnectionSecretMetadata{
 									Labels: map[string]string{
 										v1.LabelKeyOwnerUID: testUID,
@@ -1227,7 +1227,7 @@ func TestManagerPropagateConnection(t *testing.T) {
 }
 
 func fakeStoreBuilderFn(ss fake.SecretStore) StoreBuilderFn {
-	return func(_ context.Context, _ client.Client, tcfg *tls.Config, cfg v1.SecretStoreConfig) (Store, error) {
+	return func(_ context.Context, _ client.Client, _ *tls.Config, cfg v1.SecretStoreConfig) (Store, error) {
 		if *cfg.Type == fakeStore {
 			return &ss, nil
 		}

--- a/pkg/connection/store/kubernetes/store.go
+++ b/pkg/connection/store/kubernetes/store.go
@@ -128,7 +128,7 @@ func (ss *SecretStore) WriteKeyValues(ctx context.Context, s *store.Secret, wo .
 	ao = append(ao, resource.AllowUpdateIf(func(current, desired runtime.Object) bool {
 		// We consider the update to be a no-op and don't allow it if the
 		// current and existing secret data are identical.
-		return !cmp.Equal(current.(*corev1.Secret).Data, desired.(*corev1.Secret).Data, cmpopts.EquateEmpty())
+		return !cmp.Equal(current.(*corev1.Secret).Data, desired.(*corev1.Secret).Data, cmpopts.EquateEmpty()) //nolint:forcetypeassert // Will always be a secret.
 	}))
 
 	err := ss.client.Apply(ctx, ks, ao...)
@@ -197,8 +197,8 @@ func applyOptions(wo ...store.WriteOption) []resource.ApplyOption {
 	for i := range wo {
 		o := wo[i]
 		ao[i] = func(ctx context.Context, current, desired runtime.Object) error {
-			currentSecret := current.(*corev1.Secret)
-			desiredSecret := desired.(*corev1.Secret)
+			currentSecret := current.(*corev1.Secret) //nolint:forcetypeassert // Will always be a secret.
+			desiredSecret := desired.(*corev1.Secret) //nolint:forcetypeassert // Will always be a secret.
 
 			cs := &store.Secret{
 				ScopedName: store.ScopedName{

--- a/pkg/connection/store/kubernetes/store_test.go
+++ b/pkg/connection/store/kubernetes/store_test.go
@@ -102,7 +102,7 @@ func TestSecretStoreReadKeyValues(t *testing.T) {
 			args: args{
 				client: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 							if key.Name != fakeSecretName || key.Namespace != fakeSecretNamespace {
 								return errors.New("unexpected secret name or namespace to get the secret")
 							}
@@ -179,7 +179,7 @@ func TestSecretStoreWriteKeyValues(t *testing.T) {
 			reason: "Should return a proper error when cannot apply.",
 			args: args{
 				client: resource.ClientApplicator{
-					Applicator: resource.ApplyFn(func(ctx context.Context, obj client.Object, option ...resource.ApplyOption) error {
+					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
 						return errBoom
 					}),
 				},
@@ -216,7 +216,7 @@ func TestSecretStoreWriteKeyValues(t *testing.T) {
 					Data: store.KeyValues(fakeKV()),
 				},
 				wo: []store.WriteOption{
-					func(ctx context.Context, current, desired *store.Secret) error {
+					func(_ context.Context, _, _ *store.Secret) error {
 						return errBoom
 					},
 				},
@@ -246,7 +246,7 @@ func TestSecretStoreWriteKeyValues(t *testing.T) {
 					Data: store.KeyValues(fakeKV()),
 				},
 				wo: []store.WriteOption{
-					func(ctx context.Context, current, desired *store.Secret) error {
+					func(_ context.Context, _, desired *store.Secret) error {
 						desired.Data["customkey"] = []byte("customval")
 						desired.Metadata = &v1.ConnectionSecretMetadata{
 							Labels: map[string]string{
@@ -346,7 +346,7 @@ func TestSecretStoreWriteKeyValues(t *testing.T) {
 						"existing-key": []byte("new-value"),
 					}),
 				},
-				wo: []store.WriteOption{func(ctx context.Context, current, desired *store.Secret) error {
+				wo: []store.WriteOption{func(_ context.Context, current, _ *store.Secret) error {
 					if current.Metadata == nil || current.Metadata.GetOwnerUID() != fakeOwnerID {
 						return errors.Errorf("secret not owned by %s", fakeOwnerID)
 					}
@@ -524,7 +524,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 							*obj.(*corev1.Secret) = *fakeConnectionSecret(withData(fakeKV()))
 							return nil
 						}),
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							if diff := cmp.Diff(fakeConnectionSecret(withData(map[string][]byte{"key3": []byte("value3")})), obj.(*corev1.Secret)); diff != "" {
 								t.Errorf("r: -want, +got:\n%s", diff)
 							}
@@ -575,7 +575,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 			args: args{
 				client: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						MockGet: test.NewMockGetFn(nil, func(_ client.Object) error {
 							return kerrors.NewNotFound(schema.GroupResource{}, "")
 						}),
 					},
@@ -600,7 +600,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 							*obj.(*corev1.Secret) = *fakeConnectionSecret(withData(fakeKV()))
 							return nil
 						}),
-						MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
 							return nil
 						},
 					},
@@ -612,7 +612,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 					},
 				},
 				do: []store.DeleteOption{
-					func(ctx context.Context, secret *store.Secret) error {
+					func(_ context.Context, _ *store.Secret) error {
 						return errBoom
 					},
 				},
@@ -630,7 +630,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 							*obj.(*corev1.Secret) = *fakeConnectionSecret(withData(fakeKV()))
 							return nil
 						}),
-						MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+						MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
 							return nil
 						},
 					},
@@ -642,7 +642,7 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 					},
 				},
 				do: []store.DeleteOption{
-					func(ctx context.Context, secret *store.Secret) error {
+					func(_ context.Context, _ *store.Secret) error {
 						return nil
 					},
 				},
@@ -698,7 +698,7 @@ func TestNewSecretStore(t *testing.T) {
 			args: args{
 				client: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						MockGet: test.NewMockGetFn(nil, func(_ client.Object) error {
 							return kerrors.NewNotFound(schema.GroupResource{}, "kube-conn")
 						}),
 					},

--- a/pkg/connection/store/plugin/store_test.go
+++ b/pkg/connection/store/plugin/store_test.go
@@ -37,9 +37,7 @@ const (
 	secretName = "ess-test-secret"
 )
 
-var (
-	errBoom = errors.New("boom")
-)
+var errBoom = errors.New("boom")
 
 func TestReadKeyValues(t *testing.T) {
 	type args struct {
@@ -59,7 +57,7 @@ func TestReadKeyValues(t *testing.T) {
 			reason: "Should return a proper error if secret cannot be obtained",
 			args: args{
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					GetSecretFn: func(ctx context.Context, req *ess.GetSecretRequest, opts ...grpc.CallOption) (*ess.GetSecretResponse, error) {
+					GetSecretFn: func(_ context.Context, _ *ess.GetSecretRequest, _ ...grpc.CallOption) (*ess.GetSecretResponse, error) {
 						return nil, errBoom
 					},
 				},
@@ -77,7 +75,7 @@ func TestReadKeyValues(t *testing.T) {
 					Scope: parentPath,
 				},
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					GetSecretFn: func(ctx context.Context, req *ess.GetSecretRequest, opts ...grpc.CallOption) (*ess.GetSecretResponse, error) {
+					GetSecretFn: func(_ context.Context, req *ess.GetSecretRequest, _ ...grpc.CallOption) (*ess.GetSecretResponse, error) {
 						if diff := cmp.Diff(filepath.Join(parentPath, secretName), req.GetSecret().GetScopedName()); diff != "" {
 							t.Errorf("r: -want, +got:\n%s", diff)
 						}
@@ -164,7 +162,7 @@ func TestWriteKeyValues(t *testing.T) {
 			reason: "Should return a proper error if secret cannot be applied",
 			args: args{
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					ApplySecretFn: func(ctx context.Context, req *ess.ApplySecretRequest, opts ...grpc.CallOption) (*ess.ApplySecretResponse, error) {
+					ApplySecretFn: func(_ context.Context, _ *ess.ApplySecretRequest, _ ...grpc.CallOption) (*ess.ApplySecretResponse, error) {
 						return nil, errBoom
 					},
 				},
@@ -178,7 +176,7 @@ func TestWriteKeyValues(t *testing.T) {
 			reason: "Should return isChanged true",
 			args: args{
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					ApplySecretFn: func(ctx context.Context, req *ess.ApplySecretRequest, opts ...grpc.CallOption) (*ess.ApplySecretResponse, error) {
+					ApplySecretFn: func(_ context.Context, _ *ess.ApplySecretRequest, _ ...grpc.CallOption) (*ess.ApplySecretResponse, error) {
 						resp := &ess.ApplySecretResponse{
 							Changed: true,
 						}
@@ -235,9 +233,10 @@ func TestDeleteKeyValues(t *testing.T) {
 			reason: "Should return a proper error if key values cannot be deleted",
 			args: args{
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					DeleteKeysFn: func(ctx context.Context, req *ess.DeleteKeysRequest, opts ...grpc.CallOption) (*ess.DeleteKeysResponse, error) {
+					DeleteKeysFn: func(_ context.Context, _ *ess.DeleteKeysRequest, _ ...grpc.CallOption) (*ess.DeleteKeysResponse, error) {
 						return nil, errBoom
-					}},
+					},
+				},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errDelete),
@@ -247,7 +246,7 @@ func TestDeleteKeyValues(t *testing.T) {
 			reason: "Should not return error",
 			args: args{
 				client: &fake.ExternalSecretStorePluginServiceClient{
-					DeleteKeysFn: func(ctx context.Context, req *ess.DeleteKeysRequest, opts ...grpc.CallOption) (*ess.DeleteKeysResponse, error) {
+					DeleteKeysFn: func(_ context.Context, _ *ess.DeleteKeysRequest, _ ...grpc.CallOption) (*ess.DeleteKeysResponse, error) {
 						return nil, nil
 					},
 				},

--- a/pkg/controller/engine.go
+++ b/pkg/controller/engine.go
@@ -34,7 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 )
 
-// Error strings
+// Error strings.
 const (
 	errCreateCache      = "cannot create new cache"
 	errCreateController = "cannot create new controller"
@@ -50,6 +50,8 @@ type NewCacheFn func(cfg *rest.Config, o cache.Options) (cache.Cache, error)
 type NewControllerFn func(name string, m manager.Manager, o controller.Options) (controller.Controller, error)
 
 // The default new cache and new controller functions.
+//
+//nolint:gochecknoglobals // We treat these as constants.
 var (
 	DefaultNewCacheFn      NewCacheFn      = cache.New
 	DefaultNewControllerFn NewControllerFn = controller.NewUnmanaged

--- a/pkg/controller/engine_test.go
+++ b/pkg/controller/engine_test.go
@@ -161,11 +161,11 @@ func TestEngine(t *testing.T) {
 			reason: "Errors starting or running a cache should be returned",
 			e: NewEngine(&fake.Manager{},
 				WithNewCacheFn(func(*rest.Config, cache.Options) (cache.Cache, error) {
-					c := &MockCache{MockStart: func(stop context.Context) error { return errBoom }}
+					c := &MockCache{MockStart: func(_ context.Context) error { return errBoom }}
 					return c, nil
 				}),
 				WithNewControllerFn(func(string, manager.Manager, controller.Options) (controller.Controller, error) {
-					c := &MockController{MockStart: func(stop context.Context) error {
+					c := &MockController{MockStart: func(_ context.Context) error {
 						return nil
 					}}
 					return c, nil
@@ -182,13 +182,13 @@ func TestEngine(t *testing.T) {
 			reason: "Errors starting or running a controller should be returned",
 			e: NewEngine(&fake.Manager{},
 				WithNewCacheFn(func(*rest.Config, cache.Options) (cache.Cache, error) {
-					c := &MockCache{MockStart: func(stop context.Context) error {
+					c := &MockCache{MockStart: func(_ context.Context) error {
 						return nil
 					}}
 					return c, nil
 				}),
 				WithNewControllerFn(func(string, manager.Manager, controller.Options) (controller.Controller, error) {
-					c := &MockController{MockStart: func(stop context.Context) error {
+					c := &MockController{MockStart: func(_ context.Context) error {
 						return errBoom
 					}}
 					return c, nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -102,7 +102,7 @@ func Wrap(err error, message string) error {
 	return WithMessage(err, message)
 }
 
-// Wrapf is an alias for WithMessagef
+// Wrapf is an alias for WithMessagef.
 func Wrapf(err error, format string, args ...any) error {
 	return WithMessagef(err, format, args...)
 }
@@ -116,7 +116,6 @@ func Cause(err error) error {
 	}
 
 	for err != nil {
-		//nolint:errorlint // We actually do want to check the outermost error.
 		w, ok := err.(wrapped)
 		if !ok {
 			return err
@@ -157,6 +156,7 @@ type multiError struct {
 func (m multiError) Error() string {
 	return m.aggregate.Error()
 }
+
 func (m multiError) Unwrap() []error {
 	return m.aggregate.Errors()
 }

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -27,7 +27,7 @@ type Type string
 
 // Event types. See below for valid types.
 // https://godoc.org/k8s.io/client-go/tools/record#EventRecorder
-var (
+const (
 	TypeNormal  Type = "Normal"
 	TypeWarning Type = "Warning"
 )

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestSliceMap(t *testing.T) {
-
 	type args struct {
 		from []string
 		to   map[string]string
@@ -86,5 +85,4 @@ func TestSliceMap(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/fieldpath/fieldpath_test.go
+++ b/pkg/fieldpath/fieldpath_test.go
@@ -72,7 +72,6 @@ func TestSegments(t *testing.T) {
 			if diff := cmp.Diff(tc.want, tc.s.String()); diff != "" {
 				t.Errorf("s.String(): -want, +got:\n %s", diff)
 			}
-
 		})
 	}
 }

--- a/pkg/fieldpath/merge.go
+++ b/pkg/fieldpath/merge.go
@@ -30,7 +30,7 @@ const (
 )
 
 // MergeValue of the receiver p at the specified field path with the supplied
-// value according to supplied merge options
+// value according to supplied merge options.
 func (p *Paved) MergeValue(path string, value any, mo *xpv1.MergeOptions) error {
 	dst, err := p.GetValue(path)
 	if IsNotFound(err) || mo == nil {

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -41,7 +41,7 @@ func (e errNotFound) IsNotFound() bool {
 // index was out of bounds in an array.
 func IsNotFound(err error) bool {
 	cause := errors.Cause(err)
-	_, ok := cause.(interface { //nolint: errorlint // Skip errorlint for interface type
+	_, ok := cause.(interface {
 		IsNotFound() bool
 	})
 	return ok
@@ -112,9 +112,7 @@ func (p *Paved) getValue(s Segments) (any, error) {
 	return getValueFromInterface(p.object, s)
 }
 
-func getValueFromInterface(it any, s Segments) (any, error) { //nolint:gocyclo // See note below.
-	// Although the complexity of the function may seem high, in fact the same
-	// operation is performed in different cases.
+func getValueFromInterface(it any, s Segments) (any, error) {
 	for i, current := range s {
 		final := i == len(s)-1
 		switch current.Type {
@@ -161,7 +159,7 @@ func getValueFromInterface(it any, s Segments) (any, error) { //nolint:gocyclo /
 //
 // For a Paved object with the following data: []byte(`{"spec":{"containers":[{"name":"cool", "image": "latest", "args": ["start", "now", "debug"]}]}}`),
 // ExpandWildcards("spec.containers[*].args[*]") returns:
-// []string{"spec.containers[0].args[0]", "spec.containers[0].args[1]", "spec.containers[0].args[2]"},
+// []string{"spec.containers[0].args[0]", "spec.containers[0].args[1]", "spec.containers[0].args[2]"},.
 func (p *Paved) ExpandWildcards(path string) ([]string, error) {
 	segments, err := Parse(path)
 	if err != nil {
@@ -178,7 +176,7 @@ func (p *Paved) ExpandWildcards(path string) ([]string, error) {
 	return paths, nil
 }
 
-func expandWildcards(data any, segments Segments) ([]Segments, error) { //nolint:gocyclo // See note below.
+func expandWildcards(data any, segments Segments) ([]Segments, error) { //nolint:gocognit // See note below.
 	// Even complexity turns out to be high, it is mostly because we have duplicate
 	// logic for arrays and maps and a couple of error handling.
 	var res []Segments
@@ -308,7 +306,6 @@ func (p *Paved) GetStringObject(path string) (map[string]string, error) {
 			return nil, errors.Errorf("%s: not an object with string field values", path)
 		}
 		so[k] = s
-
 	}
 
 	return so, nil
@@ -517,7 +514,7 @@ func (p *Paved) DeleteField(path string) error {
 	return p.delete(segments)
 }
 
-func (p *Paved) delete(segments Segments) error { //nolint:gocyclo // See note below.
+func (p *Paved) delete(segments Segments) error { //nolint:gocognit // See note below.
 	// NOTE(muvaf): I could not reduce the cyclomatic complexity
 	// more than that without disturbing the reading flow.
 	if len(segments) == 1 {
@@ -525,7 +522,7 @@ func (p *Paved) delete(segments Segments) error { //nolint:gocyclo // See note b
 		if err != nil {
 			return errors.Wrapf(err, "cannot delete %s", segments)
 		}
-		p.object = o.(map[string]any)
+		p.object = o.(map[string]any) //nolint:forcetypeassert // We're deleting from the root of the paved object, which is always a map[string]any.
 		return nil
 	}
 	var in any = p.object

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -703,7 +703,8 @@ func TestSetValue(t *testing.T) {
 			},
 			want: want{
 				object: map[string]any{
-					"data": []any{"a"}},
+					"data": []any{"a"},
+				},
 				err: errors.Errorf("index %v is greater than max allowed index %v",
 					DefaultMaxFieldPathIndex+1, DefaultMaxFieldPathIndex),
 			},
@@ -723,7 +724,8 @@ func TestSetValue(t *testing.T) {
 						res[0] = "a"
 						res[DefaultMaxFieldPathIndex+1] = "c"
 						return res
-					}()},
+					}(),
+				},
 			},
 		},
 		"MapStringString": {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -825,6 +825,7 @@ func TestWasDeleted(t *testing.T) {
 		})
 	}
 }
+
 func TestWasCreated(t *testing.T) {
 	now := metav1.Now()
 	zero := metav1.Time{}
@@ -1111,7 +1112,6 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 }
 
 func TestExternalCreateIncomplete(t *testing.T) {
-
 	now := time.Now().Format(time.RFC3339)
 	earlier := time.Now().Add(-1 * time.Second).Format(time.RFC3339)
 	evenEarlier := time.Now().Add(-1 * time.Minute).Format(time.RFC3339)

--- a/pkg/parser/fsreader.go
+++ b/pkg/parser/fsreader.go
@@ -51,14 +51,14 @@ type FilterFn func(path string, info os.FileInfo) (bool, error)
 
 // SkipPath skips files at a certain path.
 func SkipPath(pattern string) FilterFn {
-	return func(path string, info os.FileInfo) (bool, error) {
+	return func(path string, _ os.FileInfo) (bool, error) {
 		return filepath.Match(pattern, path)
 	}
 }
 
 // SkipDirs skips directories.
 func SkipDirs() FilterFn {
-	return func(path string, info os.FileInfo) (bool, error) {
+	return func(_ string, info os.FileInfo) (bool, error) {
 		if info.IsDir() {
 			return true, nil
 		}
@@ -68,14 +68,14 @@ func SkipDirs() FilterFn {
 
 // SkipEmpty skips empty files.
 func SkipEmpty() FilterFn {
-	return func(path string, info os.FileInfo) (bool, error) {
+	return func(_ string, info os.FileInfo) (bool, error) {
 		return info.Size() == 0, nil
 	}
 }
 
 // SkipNotYAML skips files that do not have YAML extension.
 func SkipNotYAML() FilterFn {
-	return func(path string, info os.FileInfo) (bool, error) {
+	return func(path string, _ os.FileInfo) (bool, error) {
 		if filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml" {
 			return true, nil
 		}

--- a/pkg/parser/fuzz_test.go
+++ b/pkg/parser/fuzz_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func FuzzParse(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		objScheme := runtime.NewScheme()
 		metaScheme := runtime.NewScheme()
 		p := New(metaScheme, objScheme)

--- a/pkg/parser/linter.go
+++ b/pkg/parser/linter.go
@@ -32,7 +32,7 @@ const (
 
 // A Linter lints packages.
 type Linter interface {
-	Lint(Lintable) error
+	Lint(l Lintable) error
 }
 
 // PackageLinterFn lints an entire package. If function applies a check for

--- a/pkg/parser/linter_test.go
+++ b/pkg/parser/linter_test.go
@@ -31,16 +31,16 @@ var _ Linter = &PackageLinter{}
 var (
 	errBoom = errors.New("boom")
 
-	pkgPass = func(lin Lintable) error {
+	pkgPass = func(_ Lintable) error {
 		return nil
 	}
-	pkgFail = func(lin Lintable) error {
+	pkgFail = func(_ Lintable) error {
 		return errBoom
 	}
-	objPass = func(o runtime.Object) error {
+	objPass = func(_ runtime.Object) error {
 		return nil
 	}
-	objFail = func(o runtime.Object) error {
+	objFail = func(_ runtime.Object) error {
 		return errBoom
 	}
 )

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -79,7 +79,7 @@ func (p *Package) GetObjects() []runtime.Object {
 
 // Parser is a package parser.
 type Parser interface {
-	Parse(context.Context, io.ReadCloser) (*Package, error)
+	Parse(ctx context.Context, rc io.ReadCloser) (*Package, error)
 }
 
 // PackageParser is a Parser implementation for parsing packages.
@@ -168,7 +168,7 @@ type BackendOption func(Backend)
 
 // Backend provides a source for a parser.
 type Backend interface {
-	Init(context.Context, ...BackendOption) (io.ReadCloser, error)
+	Init(ctx context.Context, o ...BackendOption) (io.ReadCloser, error)
 }
 
 // PodLogBackend is a parser backend that uses Kubernetes pod logs as source.

--- a/pkg/password/password.go
+++ b/pkg/password/password.go
@@ -32,6 +32,8 @@ type Settings struct {
 }
 
 // Default password generation settings.
+//
+//nolint:gochecknoglobals // We treat this as a constant.
 var Default = Settings{
 	CharacterSet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
 	Length:       27,

--- a/pkg/ratelimiter/reconciler_test.go
+++ b/pkg/ratelimiter/reconciler_test.go
@@ -56,7 +56,7 @@ func TestReconcile(t *testing.T) {
 		"NotRateLimited": {
 			reason: "Requests that are not rate limited should be passed to the inner Reconciler.",
 			r: NewReconciler("test",
-				reconcile.Func(func(c context.Context, r reconcile.Request) (reconcile.Result, error) {
+				reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 					return reconcile.Result{Requeue: true}, nil
 				}),
 				&predictableRateLimiter{}),
@@ -76,7 +76,7 @@ func TestReconcile(t *testing.T) {
 		"Returning": {
 			reason: "Returning requests that were previously rate limited should be allowed through without further rate limiting.",
 			r: func() reconcile.Reconciler {
-				inner := reconcile.Func(func(c context.Context, r reconcile.Request) (reconcile.Result, error) {
+				inner := reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 					return reconcile.Result{Requeue: true}, nil
 				})
 
@@ -84,7 +84,6 @@ func TestReconcile(t *testing.T) {
 				r := NewReconciler("test", inner, &predictableRateLimiter{d: 8 * time.Second})
 				r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "limited"}})
 				return r
-
 			}(),
 			args: args{
 				ctx: context.Background(),

--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -108,6 +108,7 @@ func (a *APISecretPublisher) PublishConnection(ctx context.Context, o resource.C
 		resource.AllowUpdateIf(func(current, desired runtime.Object) bool {
 			// We consider the update to be a no-op and don't allow it if the
 			// current and existing secret data are identical.
+			//nolint:forcetypeassert // Will always be a secret.
 			return !cmp.Equal(current.(*corev1.Secret).Data, desired.(*corev1.Secret).Data, cmpopts.EquateEmpty())
 		}),
 	)
@@ -168,7 +169,7 @@ func prepareJSONMerge(existing, resolved runtime.Object) ([]byte, error) {
 // ResolveReferences method, if any.
 func (a *APISimpleReferenceResolver) ResolveReferences(ctx context.Context, mg resource.Managed) error {
 	rr, ok := mg.(interface {
-		ResolveReferences(context.Context, client.Reader) error
+		ResolveReferences(ctx context.Context, r client.Reader) error
 	})
 	if !ok {
 		// This managed resource doesn't have any references to resolve.

--- a/pkg/reconciler/managed/api_test.go
+++ b/pkg/reconciler/managed/api_test.go
@@ -35,9 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
-var (
-	_ Initializer = &NameAsExternalName{}
-)
+var _ Initializer = &NameAsExternalName{}
 
 func TestNameAsExternalName(t *testing.T) {
 	type args struct {
@@ -176,11 +174,11 @@ func TestAPISecretPublisher(t *testing.T) {
 		"AlreadyPublished": {
 			reason: "An up to date connection secret should result in no error and not being published",
 			fields: fields{
-				secret: resource.ApplyFn(func(_ context.Context, o client.Object, ao ...resource.ApplyOption) error {
+				secret: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
 					want := resource.ConnectionSecretFor(mg, fake.GVK(mg))
 					want.Data = cd
 					for _, fn := range ao {
-						if err := fn(context.Background(), o, want); err != nil {
+						if err := fn(ctx, o, want); err != nil {
 							return err
 						}
 					}
@@ -379,7 +377,8 @@ func TestPrepareJSONMerge(t *testing.T) {
 				resolved: &fake.Managed{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resolved",
-					}},
+					},
+				},
 			},
 			want: want{
 				patch: `{"name":"resolved"}`,

--- a/pkg/reconciler/managed/policies.go
+++ b/pkg/reconciler/managed/policies.go
@@ -131,7 +131,7 @@ func (m *ManagementPoliciesResolver) Validate() error {
 }
 
 // IsPaused returns true if the management policy is empty and the
-// management policies feature is enabled
+// management policies feature is enabled.
 func (m *ManagementPoliciesResolver) IsPaused() bool {
 	if !m.enabled {
 		return false

--- a/pkg/reconciler/managed/publisher.go
+++ b/pkg/reconciler/managed/publisher.go
@@ -57,8 +57,7 @@ func (pc PublisherChain) UnpublishConnection(ctx context.Context, o resource.Con
 
 // DisabledSecretStoreManager is a connection details manager that returns a proper
 // error when API used but feature not enabled.
-type DisabledSecretStoreManager struct {
-}
+type DisabledSecretStoreManager struct{}
 
 // PublishConnection returns a proper error when API used but the feature was
 // not enabled.

--- a/pkg/reconciler/managed/publisher_test.go
+++ b/pkg/reconciler/managed/publisher_test.go
@@ -64,10 +64,10 @@ func TestPublisherChain(t *testing.T) {
 		"SuccessfulPublisher": {
 			p: PublisherChain{
 				ConnectionPublisherFns{
-					PublishConnectionFn: func(_ context.Context, o resource.ConnectionSecretOwner, c ConnectionDetails) (bool, error) {
+					PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) (bool, error) {
 						return true, nil
 					},
-					UnpublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c ConnectionDetails) error {
+					UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return nil
 					},
 				},
@@ -84,10 +84,10 @@ func TestPublisherChain(t *testing.T) {
 		"PublisherReturnsError": {
 			p: PublisherChain{
 				ConnectionPublisherFns{
-					PublishConnectionFn: func(_ context.Context, o resource.ConnectionSecretOwner, c ConnectionDetails) (bool, error) {
+					PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) (bool, error) {
 						return false, errBoom
 					},
-					UnpublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c ConnectionDetails) error {
+					UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ ConnectionDetails) error {
 						return nil
 					},
 				},

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -196,7 +196,7 @@ func TestReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
-					WithInitializers(InitializerFn(func(_ context.Context, mg resource.Managed) error {
+					WithInitializers(InitializerFn(func(_ context.Context, _ resource.Managed) error {
 						return errBoom
 					})),
 				},
@@ -227,7 +227,7 @@ func TestReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
-					WithInitializers(InitializerFn(func(_ context.Context, mg resource.Managed) error { return nil })),
+					WithInitializers(InitializerFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
@@ -253,7 +253,7 @@ func TestReconciler(t *testing.T) {
 				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
 					WithInitializers(),
-					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, res resource.Managed) error {
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error {
 						return errBoom
 					})),
 				},
@@ -281,7 +281,7 @@ func TestReconciler(t *testing.T) {
 				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
 					WithInitializers(),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						return nil, errBoom
 					})),
 				},
@@ -311,7 +311,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnectDisconnecter(ExternalConnectDisconnecterFns{
-						ConnectFn: func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						ConnectFn: func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 							c := &ExternalClientFns{
 								ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 									return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -348,7 +348,7 @@ func TestReconciler(t *testing.T) {
 				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
 				o: []ReconcilerOption{
 					WithInitializers(),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{}, errBoom
@@ -376,7 +376,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithCreationGracePeriod(1 * time.Minute),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -418,7 +418,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true}, nil
@@ -463,7 +463,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true}, nil
@@ -508,7 +508,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -553,7 +553,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -585,7 +585,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -684,7 +684,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -727,7 +727,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -740,7 +740,7 @@ func TestReconciler(t *testing.T) {
 					})),
 					// We simulate our critical annotation update failing too here.
 					// This is mostly just to exercise the code, which just creates a log and an event.
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return errBoom })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return errBoom })),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
@@ -773,7 +773,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -785,7 +785,7 @@ func TestReconciler(t *testing.T) {
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return errBoom })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return errBoom })),
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
@@ -816,7 +816,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -828,7 +828,7 @@ func TestReconciler(t *testing.T) {
 						}
 						return c, nil
 					})),
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return nil })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
 					WithConnectionPublishers(ConnectionPublisherFns{
 						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, cd ConnectionDetails) (bool, error) {
 							// We're called after observe, create, and update
@@ -872,7 +872,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnecter(&NopConnecter{}),
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return nil })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
@@ -902,7 +902,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: true}, nil
@@ -938,7 +938,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -968,7 +968,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -1008,7 +1008,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -1018,7 +1018,7 @@ func TestReconciler(t *testing.T) {
 					})),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
-					WithPollIntervalHook(func(managed resource.Managed, pollInterval time.Duration) time.Duration {
+					WithPollIntervalHook(func(_ resource.Managed, pollInterval time.Duration) time.Duration {
 						return 2 * pollInterval
 					}),
 				},
@@ -1043,7 +1043,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -1054,10 +1054,10 @@ func TestReconciler(t *testing.T) {
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 					WithPollJitterHook(time.Second),
-					WithPollIntervalHook(func(managed resource.Managed, pollInterval time.Duration) time.Duration {
+					WithPollIntervalHook(func(_ resource.Managed, pollInterval time.Duration) time.Duration {
 						return 2 * pollInterval
 					}),
-					WithPollIntervalHook(func(managed resource.Managed, pollInterval time.Duration) time.Duration {
+					WithPollIntervalHook(func(_ resource.Managed, pollInterval time.Duration) time.Duration {
 						return 3 * pollInterval
 					}),
 				},
@@ -1088,7 +1088,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1127,7 +1127,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1177,7 +1177,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1283,7 +1283,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnectDisconnecter(ExternalConnectDisconnecterFns{
-						ConnectFn: func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+						ConnectFn: func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 							c := &ExternalClientFns{
 								ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 									return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
@@ -1309,7 +1309,7 @@ func TestReconciler(t *testing.T) {
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 							return nil
 						}),
-						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
 							return errBoom
 						}),
 					},
@@ -1434,7 +1434,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithManagementPolicies(),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: false}, nil
@@ -1473,7 +1473,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithManagementPolicies(),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true}, nil
@@ -1517,7 +1517,7 @@ func TestReconciler(t *testing.T) {
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithManagementPolicies(),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true}, nil
@@ -1568,7 +1568,7 @@ func TestReconciler(t *testing.T) {
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnecter(&NopConnecter{}),
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return nil })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
@@ -1608,7 +1608,7 @@ func TestReconciler(t *testing.T) {
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnecter(&NopConnecter{}),
-					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(ctx context.Context, o client.Object) error { return nil })),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
 					WithConnectionPublishers(),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
@@ -1644,7 +1644,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1689,7 +1689,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1734,7 +1734,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
@@ -1780,7 +1780,7 @@ func TestReconciler(t *testing.T) {
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
-					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, mg resource.Managed) (ExternalClient, error) {
+					WithExternalConnecter(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
 							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
 								return ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: true}, nil

--- a/pkg/reconciler/providerconfig/reconciler.go
+++ b/pkg/reconciler/providerconfig/reconciler.go
@@ -111,9 +111,11 @@ func WithRecorder(er event.Recorder) ReconcilerOption {
 // NewReconciler returns a Reconciler of ProviderConfigs.
 func NewReconciler(m manager.Manager, of resource.ProviderConfigKinds, o ...ReconcilerOption) *Reconciler {
 	nc := func() resource.ProviderConfig {
+		//nolint:forcetypeassert // If this isn't a ProviderConfig it's a programming error and we want to panic.
 		return resource.MustCreateObject(of.Config, m.GetScheme()).(resource.ProviderConfig)
 	}
 	nul := func() resource.ProviderConfigUsageList {
+		//nolint:forcetypeassert // If this isn't a ProviderConfigUsage it's a programming error and we want to panic.
 		return resource.MustCreateObject(of.UsageList, m.GetScheme()).(resource.ProviderConfigUsageList)
 	}
 

--- a/pkg/reconciler/providerconfig/reconciler_test.go
+++ b/pkg/reconciler/providerconfig/reconciler_test.go
@@ -39,7 +39,7 @@ import (
 
 // This can't live in fake, because it would cause an import cycle due to
 // GetItems returning managed.ProviderConfigUsage.
-type ProviderConfigUsageList struct { //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type ProviderConfigUsageList struct {
 	client.ObjectList
 	Items []resource.ProviderConfigUsage
 }
@@ -50,11 +50,11 @@ func (p *ProviderConfigUsageList) GetObjectKind() schema.ObjectKind {
 
 func (p *ProviderConfigUsageList) DeepCopyObject() runtime.Object {
 	out := &ProviderConfigUsageList{}
-	j, err := json.Marshal(p)
+	j, err := json.Marshal(p) //nolint:musttag // We're just using this to round-trip convert.
 	if err != nil {
 		panic(err)
 	}
-	_ = json.Unmarshal(j, out)
+	_ = json.Unmarshal(j, out) //nolint:musttag // We're just using this to round-trip convert.
 	return out
 }
 

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -104,9 +104,9 @@ func ToIntPtrValue(v string) *int64 {
 // NOTE: Do not use this utility function unless you have to.
 // Using pointer slices does not adhere to our current API practices.
 // The current use case is where generated code creates reference-able fields in a provider which are
-// string pointers and need to be resolved as part of `ResolveMultiple`
+// string pointers and need to be resolved as part of `ResolveMultiple`.
 func FromPtrValues(v []*string) []string {
-	var res = make([]string, len(v))
+	res := make([]string, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = FromPtrValue(v[i])
 	}
@@ -115,7 +115,7 @@ func FromPtrValues(v []*string) []string {
 
 // FromFloatPtrValues adapts a slice of float64 pointer fields for use as CurrentValues.
 func FromFloatPtrValues(v []*float64) []string {
-	var res = make([]string, len(v))
+	res := make([]string, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = FromFloatPtrValue(v[i])
 	}
@@ -124,7 +124,7 @@ func FromFloatPtrValues(v []*float64) []string {
 
 // FromIntPtrValues adapts a slice of int64 pointer fields for use as CurrentValues.
 func FromIntPtrValues(v []*int64) []string {
-	var res = make([]string, len(v))
+	res := make([]string, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = FromIntPtrValue(v[i])
 	}
@@ -135,9 +135,9 @@ func FromIntPtrValues(v []*int64) []string {
 // NOTE: Do not use this utility function unless you have to.
 // Using pointer slices does not adhere to our current API practices.
 // The current use case is where generated code creates reference-able fields in a provider which are
-// string pointers and need to be resolved as part of `ResolveMultiple`
+// string pointers and need to be resolved as part of `ResolveMultiple`.
 func ToPtrValues(v []string) []*string {
-	var res = make([]*string, len(v))
+	res := make([]*string, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = ToPtrValue(v[i])
 	}
@@ -146,7 +146,7 @@ func ToPtrValues(v []string) []*string {
 
 // ToFloatPtrValues adapts ResolvedValues for use as a slice of float64 pointer fields.
 func ToFloatPtrValues(v []string) []*float64 {
-	var res = make([]*float64, len(v))
+	res := make([]*float64, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = ToFloatPtrValue(v[i])
 	}
@@ -155,7 +155,7 @@ func ToFloatPtrValues(v []string) []*float64 {
 
 // ToIntPtrValues adapts ResolvedValues for use as a slice of int64 pointer fields.
 func ToIntPtrValues(v []string) []*int64 {
-	var res = make([]*int64, len(v))
+	res := make([]*int64, len(v))
 	for i := 0; i < len(v); i++ {
 		res[i] = ToIntPtrValue(v[i])
 	}
@@ -350,7 +350,6 @@ func (r *APIResolver) Resolve(ctx context.Context, req ResolutionRequest) (Resol
 
 	// We couldn't resolve anything.
 	return ResolutionResponse{}, getResolutionError(req.Selector.Policy, errors.New(errNoMatches))
-
 }
 
 // ResolveMultiple resolves the supplied MultiResolutionRequest. The returned

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -59,10 +59,8 @@ func TestToAndFromPtr(t *testing.T) {
 			got := FromPtrValue(ToPtrValue(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromPtrValue(ToPtrValue(%s): -want, +got: %s", tc.want, diff)
-
 			}
 		})
-
 	}
 }
 
@@ -78,10 +76,8 @@ func TestToAndFromFloatPtr(t *testing.T) {
 			got := FromFloatPtrValue(ToFloatPtrValue(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromPtrValue(ToPtrValue(%s): -want, +got: %s", tc.want, diff)
-
 			}
 		})
-
 	}
 }
 
@@ -99,7 +95,6 @@ func TestToAndFromPtrValues(t *testing.T) {
 			got := FromPtrValues(ToPtrValues(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromPtrValues(ToPtrValues(%s): -want, +got: %s", tc.want, diff)
-
 			}
 		})
 	}
@@ -119,7 +114,6 @@ func TestToAndFromFloatPtrValues(t *testing.T) {
 			got := FromFloatPtrValues(ToFloatPtrValues(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromPtrValues(ToPtrValues(%s): -want, +got: %s", tc.want, diff)
-
 			}
 		})
 	}
@@ -139,7 +133,6 @@ func TestToAndFromIntPtrValues(t *testing.T) {
 			got := FromIntPtrValues(ToIntPtrValues(tc.want))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("FromIntPtrValues(ToIntPtrValues(%s): -want, +got: %s", tc.want, diff)
-
 			}
 		})
 	}
@@ -460,6 +453,7 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
 func TestResolveMultiple(t *testing.T) {
 	errBoom := errors.New("boom")
 	now := metav1.Now()

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -110,6 +110,7 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o client.Object, ao .
 		return errors.Wrap(a.client.Create(ctx, o), "cannot create object")
 	}
 
+	//nolint:forcetypeassert // Will always be a client.Object.
 	current := o.DeepCopyObject().(client.Object)
 
 	err := a.client.Get(ctx, types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}, current)
@@ -129,7 +130,7 @@ func (a *APIUpdatingApplicator) Apply(ctx context.Context, o client.Object, ao .
 
 	// NOTE(hasheddan): we must set the resource version of the desired object
 	// to that of the current or the update will always fail.
-	m.SetResourceVersion(current.(metav1.Object).GetResourceVersion())
+	m.SetResourceVersion(current.GetResourceVersion())
 	return errors.Wrap(a.client.Update(ctx, m), "cannot update object")
 }
 
@@ -147,6 +148,7 @@ type nopFinalizer struct{}
 func (f nopFinalizer) AddFinalizer(_ context.Context, _ Object) error {
 	return nil
 }
+
 func (f nopFinalizer) RemoveFinalizer(_ context.Context, _ Object) error {
 	return nil
 }

--- a/pkg/resource/enqueue_handlers_test.go
+++ b/pkg/resource/enqueue_handlers_test.go
@@ -29,9 +29,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 )
 
-var (
-	_ handler.EventHandler = &EnqueueRequestForProviderConfig{}
-)
+var _ handler.EventHandler = &EnqueueRequestForProviderConfig{}
 
 type addFn func(item any)
 

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 // Package fake provides fake Crossplane resources for use in tests.
+//
+//nolint:musttag // We only use JSON to round-trip convert these mocks.
 package fake
 
 import (
@@ -66,7 +68,7 @@ func (m *ManagedResourceReferencer) SetResourceReference(r *corev1.ObjectReferen
 func (m *ManagedResourceReferencer) GetResourceReference() *corev1.ObjectReference { return m.Ref }
 
 // ProviderConfigReferencer is a mock that implements ProviderConfigReferencer interface.
-type ProviderConfigReferencer struct{ Ref *xpv1.Reference } //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type ProviderConfigReferencer struct{ Ref *xpv1.Reference }
 
 // SetProviderConfigReference sets the ProviderConfigReference.
 func (m *ProviderConfigReferencer) SetProviderConfigReference(p *xpv1.Reference) { m.Ref = p }
@@ -76,7 +78,7 @@ func (m *ProviderConfigReferencer) GetProviderConfigReference() *xpv1.Reference 
 
 // RequiredProviderConfigReferencer is a mock that implements the
 // RequiredProviderConfigReferencer interface.
-type RequiredProviderConfigReferencer struct{ Ref xpv1.Reference } //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type RequiredProviderConfigReferencer struct{ Ref xpv1.Reference }
 
 // SetProviderConfigReference sets the ProviderConfigReference.
 func (m *RequiredProviderConfigReferencer) SetProviderConfigReference(p xpv1.Reference) {
@@ -118,7 +120,7 @@ func (m *LocalConnectionSecretWriterTo) GetWriteConnectionSecretToReference() *x
 }
 
 // ConnectionSecretWriterTo is a mock that implements ConnectionSecretWriterTo interface.
-type ConnectionSecretWriterTo struct{ Ref *xpv1.SecretReference } //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type ConnectionSecretWriterTo struct{ Ref *xpv1.SecretReference }
 
 // SetWriteConnectionSecretToReference sets the WriteConnectionSecretToReference.
 func (m *ConnectionSecretWriterTo) SetWriteConnectionSecretToReference(r *xpv1.SecretReference) {
@@ -173,7 +175,7 @@ func (m *CompositionReferencer) SetCompositionReference(r *corev1.ObjectReferenc
 func (m *CompositionReferencer) GetCompositionReference() *corev1.ObjectReference { return m.Ref }
 
 // CompositionSelector is a mock that implements CompositionSelector interface.
-type CompositionSelector struct{ Sel *metav1.LabelSelector } //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type CompositionSelector struct{ Sel *metav1.LabelSelector }
 
 // SetCompositionSelector sets the CompositionSelector.
 func (m *CompositionSelector) SetCompositionSelector(s *metav1.LabelSelector) { m.Sel = s }
@@ -287,7 +289,7 @@ func (c *ConnectionDetailsLastPublishedTimer) GetConnectionDetailsLastPublishedT
 
 // UserCounter is a mock that satisfies UserCounter
 // interface.
-type UserCounter struct{ Users int64 } //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type UserCounter struct{ Users int64 }
 
 // SetUsers sets the count of users.
 func (m *UserCounter) SetUsers(i int64) {
@@ -310,7 +312,7 @@ func (o *Object) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (o *Object) DeepCopyObject() runtime.Object {
 	out := &Object{}
 	j, err := json.Marshal(o)
@@ -337,7 +339,7 @@ func (m *Managed) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *Managed) DeepCopyObject() runtime.Object {
 	out := &Managed{}
 	j, err := json.Marshal(m)
@@ -371,7 +373,7 @@ func (m *Composite) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *Composite) DeepCopyObject() runtime.Object {
 	out := &Composite{}
 	j, err := json.Marshal(m)
@@ -395,7 +397,7 @@ func (m *Composed) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *Composed) DeepCopyObject() runtime.Object {
 	out := &Composed{}
 	j, err := json.Marshal(m)
@@ -428,7 +430,7 @@ func (m *CompositeClaim) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *CompositeClaim) DeepCopyObject() runtime.Object {
 	out := &CompositeClaim{}
 	j, err := json.Marshal(m)
@@ -477,7 +479,7 @@ func (m *Manager) GetRESTMapper() meta.RESTMapper { return m.RESTMapper }
 func (m *Manager) GetLogger() logr.Logger { return m.Logger }
 
 // GV returns a mock schema.GroupVersion.
-var GV = schema.GroupVersion{Group: "g", Version: "v"}
+var GV = schema.GroupVersion{Group: "g", Version: "v"} //nolint:gochecknoglobals // We treat this as a constant.
 
 // GVK returns the mock GVK of the given object.
 func GVK(o runtime.Object) schema.GroupVersionKind {
@@ -493,7 +495,7 @@ func SchemeWith(o ...runtime.Object) *runtime.Scheme {
 
 // MockConnectionSecretOwner is a mock object that satisfies ConnectionSecretOwner
 // interface.
-type MockConnectionSecretOwner struct { //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type MockConnectionSecretOwner struct {
 	runtime.Object
 	metav1.ObjectMeta
 
@@ -526,7 +528,7 @@ func (m *MockConnectionSecretOwner) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *MockConnectionSecretOwner) DeepCopyObject() runtime.Object {
 	out := &MockConnectionSecretOwner{}
 	j, err := json.Marshal(m)
@@ -539,7 +541,7 @@ func (m *MockConnectionSecretOwner) DeepCopyObject() runtime.Object {
 
 // MockLocalConnectionSecretOwner is a mock object that satisfies LocalConnectionSecretOwner
 // interface.
-type MockLocalConnectionSecretOwner struct { //nolint:musttag // This is a fake implementation to be used in unit tests only.
+type MockLocalConnectionSecretOwner struct {
 	runtime.Object
 	metav1.ObjectMeta
 
@@ -557,7 +559,7 @@ func (m *MockLocalConnectionSecretOwner) SetWriteConnectionSecretToReference(r *
 	m.Ref = r
 }
 
-// SetPublishConnectionDetailsTo sets the publish connectionDetails to
+// SetPublishConnectionDetailsTo sets the publish connectionDetails to.
 func (m *MockLocalConnectionSecretOwner) SetPublishConnectionDetailsTo(r *xpv1.PublishConnectionDetailsTo) {
 	m.To = r
 }
@@ -572,7 +574,7 @@ func (m *MockLocalConnectionSecretOwner) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (m *MockLocalConnectionSecretOwner) DeepCopyObject() runtime.Object {
 	out := &MockLocalConnectionSecretOwner{}
 	j, err := json.Marshal(m)
@@ -596,7 +598,7 @@ func (p *ProviderConfig) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (p *ProviderConfig) DeepCopyObject() runtime.Object {
 	out := &ProviderConfig{}
 	j, err := json.Marshal(p)
@@ -621,7 +623,7 @@ func (p *ProviderConfigUsage) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-// DeepCopyObject returns a copy of the object as runtime.Object
+// DeepCopyObject returns a copy of the object as runtime.Object.
 func (p *ProviderConfigUsage) DeepCopyObject() runtime.Object {
 	out := &ProviderConfigUsage{}
 	j, err := json.Marshal(p)

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -32,7 +32,7 @@ import (
 // indicate the status of both a resource and its reconciliation process.
 type Conditioned interface {
 	SetConditions(c ...xpv1.Condition)
-	GetCondition(xpv1.ConditionType) xpv1.Condition
+	GetCondition(ct xpv1.ConditionType) xpv1.Condition
 }
 
 // A ClaimReferencer may reference a resource claim.
@@ -62,7 +62,7 @@ type ConnectionSecretWriterTo interface {
 }
 
 // A ConnectionDetailsPublisherTo may write a connection details secret to a
-// secret store
+// secret store.
 type ConnectionDetailsPublisherTo interface {
 	SetPublishConnectionDetailsTo(r *xpv1.PublishConnectionDetailsTo)
 	GetPublishConnectionDetailsTo() *xpv1.PublishConnectionDetailsTo
@@ -107,20 +107,20 @@ type Finalizer interface {
 
 // A CompositionSelector may select a composition of resources.
 type CompositionSelector interface {
-	SetCompositionSelector(*metav1.LabelSelector)
+	SetCompositionSelector(s *metav1.LabelSelector)
 	GetCompositionSelector() *metav1.LabelSelector
 }
 
 // A CompositionReferencer may reference a composition of resources.
 type CompositionReferencer interface {
-	SetCompositionReference(*corev1.ObjectReference)
+	SetCompositionReference(ref *corev1.ObjectReference)
 	GetCompositionReference() *corev1.ObjectReference
 }
 
 // A CompositionRevisionReferencer may reference a specific revision of a
 // composition of resources.
 type CompositionRevisionReferencer interface {
-	SetCompositionRevisionReference(*corev1.ObjectReference)
+	SetCompositionRevisionReference(ref *corev1.ObjectReference)
 	GetCompositionRevisionReference() *corev1.ObjectReference
 }
 
@@ -134,7 +134,7 @@ type CompositionRevisionSelector interface {
 // A CompositionUpdater uses a composition, and may update which revision of
 // that composition it uses.
 type CompositionUpdater interface {
-	SetCompositionUpdatePolicy(*xpv1.UpdatePolicy)
+	SetCompositionUpdatePolicy(p *xpv1.UpdatePolicy)
 	GetCompositionUpdatePolicy() *xpv1.UpdatePolicy
 }
 
@@ -147,7 +147,7 @@ type CompositeResourceDeleter interface {
 
 // A ComposedResourcesReferencer may reference the resources it composes.
 type ComposedResourcesReferencer interface {
-	SetResourceReferences([]corev1.ObjectReference)
+	SetResourceReferences(refs []corev1.ObjectReference)
 	GetResourceReferences() []corev1.ObjectReference
 }
 
@@ -159,7 +159,7 @@ type CompositeResourceReferencer interface {
 
 // An EnvironmentConfigReferencer references a list of EnvironmentConfigs.
 type EnvironmentConfigReferencer interface {
-	SetEnvironmentConfigReferences([]corev1.ObjectReference)
+	SetEnvironmentConfigReferences(refs []corev1.ObjectReference)
 	GetEnvironmentConfigReferences() []corev1.ObjectReference
 }
 
@@ -184,7 +184,7 @@ type Object interface {
 
 // A Managed is a Kubernetes object representing a concrete managed
 // resource (e.g. a CloudSQL instance).
-type Managed interface {
+type Managed interface { //nolint:interfacebloat // This interface has to be big.
 	Object
 
 	ProviderConfigReferencer
@@ -229,7 +229,7 @@ type ProviderConfigUsageList interface {
 }
 
 // A Composite resource composes one or more Composed resources.
-type Composite interface {
+type Composite interface { //nolint:interfacebloat // This interface has to be big.
 	Object
 
 	CompositionSelector
@@ -257,7 +257,7 @@ type Composed interface {
 }
 
 // A CompositeClaim for a Composite resource.
-type CompositeClaim interface {
+type CompositeClaim interface { //nolint:interfacebloat // This interface has to be big.
 	Object
 
 	CompositionSelector

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -47,7 +47,7 @@ func NewPredicates(fn PredicateFn) predicate.Funcs {
 // To be more specific, it accepts update events that have changes in one of the followings:
 // - `metadata.annotations` (except for certain annotations)
 // - `metadata.labels`
-// - `spec`
+// - `spec`.
 func DesiredStateChanged() predicate.Predicate {
 	return predicate.Or(
 		AnnotationChangedPredicate{

--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -49,7 +49,7 @@ func (m errMissingRef) MissingReference() bool { return true }
 // IsMissingReference returns true if an error indicates that a managed
 // resource is missing a required reference..
 func IsMissingReference(err error) bool {
-	_, ok := err.(interface { //nolint: errorlint // Skip errorlint for interface type
+	_, ok := err.(interface {
 		MissingReference() bool
 	})
 	return ok
@@ -138,6 +138,7 @@ func NewProviderConfigUsageTracker(c client.Client, of ProviderConfigUsage) *Pro
 // managed resource's usage is updated if the managed resource is updated to
 // reference a misconfigured ProviderConfig.
 func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg Managed) error {
+	//nolint:forcetypeassert // Will always be a PCU.
 	pcu := u.of.DeepCopyObject().(ProviderConfigUsage)
 	gvk := mg.GetObjectKind().GroupVersionKind()
 	ref := mg.GetProviderConfigReference()
@@ -158,6 +159,7 @@ func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg Managed) erro
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),
 		AllowUpdateIf(func(current, _ runtime.Object) bool {
+			//nolint:forcetypeassert // Will always be a PCU.
 			return current.(ProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference()
 		}),
 	)

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -266,7 +266,7 @@ func TestTrack(t *testing.T) {
 		"NopUpdate": {
 			reason: "No error should be returned if the apply fails because it would be a no-op",
 			fields: fields{
-				c: ApplyFn(func(c context.Context, r client.Object, ao ...ApplyOption) error {
+				c: ApplyFn(func(ctx context.Context, _ client.Object, ao ...ApplyOption) error {
 					for _, fn := range ao {
 						// Exercise the MustBeControllableBy and AllowUpdateIf
 						// ApplyOptions. The former should pass because the
@@ -279,7 +279,7 @@ func TestTrack(t *testing.T) {
 								Ref: xpv1.Reference{Name: name},
 							},
 						}
-						if err := fn(context.TODO(), current, nil); err != nil {
+						if err := fn(ctx, current, nil); err != nil {
 							return err
 						}
 					}
@@ -299,7 +299,7 @@ func TestTrack(t *testing.T) {
 		"ApplyError": {
 			reason: "Errors applying the ProviderConfigUsage should be returned",
 			fields: fields{
-				c: ApplyFn(func(c context.Context, r client.Object, ao ...ApplyOption) error {
+				c: ApplyFn(func(_ context.Context, _ client.Object, _ ...ApplyOption) error {
 					return errBoom
 				}),
 				of: &fake.ProviderConfigUsage{},

--- a/pkg/resource/reference.go
+++ b/pkg/resource/reference.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReferenceStatusType is an enum type for the possible values for a Reference Status
+// ReferenceStatusType is an enum type for the possible values for a Reference Status.
 type ReferenceStatusType int
 
 // Reference statuses.
@@ -39,7 +39,7 @@ func (t ReferenceStatusType) String() string {
 	return []string{"Unknown", "NotFound", "NotReady", "Ready"}[t]
 }
 
-// ReferenceStatus has the name and status of a reference
+// ReferenceStatus has the name and status of a reference.
 type ReferenceStatus struct {
 	Name   string
 	Status ReferenceStatusType
@@ -56,7 +56,7 @@ type CanReference runtime.Object
 
 // An AttributeReferencer resolves cross-resource attribute references. See
 // https://github.com/crossplane/crossplane/blob/master/design/one-pager-cross-resource-referencing.md
-// for more information
+// for more information.
 type AttributeReferencer interface {
 	// GetStatus retries the referenced resource, as well as other non-managed
 	// resources (like a `Provider`) and reports their readiness for use as a

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -249,6 +249,7 @@ func TestGetKind(t *testing.T) {
 		})
 	}
 }
+
 func TestMustCreateObject(t *testing.T) {
 	type args struct {
 		kind schema.GroupVersionKind
@@ -290,14 +291,14 @@ func TestIgnore(t *testing.T) {
 	}{
 		"IgnoreError": {
 			args: args{
-				is:  func(err error) bool { return true },
+				is:  func(_ error) bool { return true },
 				err: errBoom,
 			},
 			want: nil,
 		},
 		"PropagateError": {
 			args: args{
-				is:  func(err error) bool { return false },
+				is:  func(_ error) bool { return false },
 				err: errBoom,
 			},
 			want: errBoom,
@@ -327,7 +328,7 @@ func TestIgnoreAny(t *testing.T) {
 	}{
 		"IgnoreError": {
 			args: args{
-				is:  []ErrorIs{func(err error) bool { return true }},
+				is:  []ErrorIs{func(_ error) bool { return true }},
 				err: errBoom,
 			},
 			want: nil,
@@ -335,8 +336,8 @@ func TestIgnoreAny(t *testing.T) {
 		"IgnoreErrorArr": {
 			args: args{
 				is: []ErrorIs{
-					func(err error) bool { return true },
-					func(err error) bool { return false },
+					func(_ error) bool { return true },
+					func(_ error) bool { return false },
 				},
 				err: errBoom,
 			},
@@ -344,7 +345,7 @@ func TestIgnoreAny(t *testing.T) {
 		},
 		"PropagateError": {
 			args: args{
-				is:  []ErrorIs{func(err error) bool { return false }},
+				is:  []ErrorIs{func(_ error) bool { return false }},
 				err: errBoom,
 			},
 			want: errBoom,
@@ -434,7 +435,6 @@ func TestIsNotControllable(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestMustBeControllableBy(t *testing.T) {
@@ -582,14 +582,14 @@ func TestAllowUpdateIf(t *testing.T) {
 	}{
 		"Allowed": {
 			reason: "No error should be returned when the supplied function returns true",
-			fn:     func(current, desired runtime.Object) bool { return true },
+			fn:     func(_, _ runtime.Object) bool { return true },
 			args: args{
 				current: &object{},
 			},
 		},
 		"NotAllowed": {
 			reason: "An error that satisfies IsNotAllowed should be returned when the supplied function returns false",
-			fn:     func(current, desired runtime.Object) bool { return false },
+			fn:     func(_, _ runtime.Object) bool { return false },
 			args: args{
 				current: &object{},
 			},
@@ -616,9 +616,10 @@ func TestGetExternalTags(t *testing.T) {
 		want map[string]string
 	}{
 		"SuccessfulWithProviderConfig": {
-			o: &fake.Managed{ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
+			o: &fake.Managed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
 				ProviderConfigReferencer: fake.ProviderConfigReferencer{Ref: &xpv1.Reference{Name: provName}},
 			},
 			want: map[string]string{
@@ -639,7 +640,7 @@ func TestGetExternalTags(t *testing.T) {
 	}
 }
 
-// single test case => not using tables
+// single test case => not using tables.
 func Test_errNotControllable_NotControllable(t *testing.T) {
 	err := errNotControllable{
 		errors.New("test-error"),
@@ -650,7 +651,7 @@ func Test_errNotControllable_NotControllable(t *testing.T) {
 	}
 }
 
-// single test case => not using tables
+// single test case => not using tables.
 func Test_errNotAllowed_NotAllowed(t *testing.T) {
 	err := errNotAllowed{
 		errors.New("test-error"),
@@ -834,11 +835,12 @@ func TestUpdate(t *testing.T) {
 		want runtime.Object
 	}{
 		"Update": {
-			args: args{fn: func(current, desired runtime.Object) {
-				c, d := current.(*corev1.Secret), desired.(*corev1.Secret)
+			args: args{
+				fn: func(current, desired runtime.Object) {
+					c, d := current.(*corev1.Secret), desired.(*corev1.Secret)
 
-				c.StringData = d.StringData
-			},
+					c.StringData = d.StringData
+				},
 				current: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "current",
@@ -893,7 +895,7 @@ func TestFirstNAndSomeMore(t *testing.T) {
 		{args: args{n: 3, names: []string{"a"}}, want: "a"},
 		{args: args{n: 3, names: []string{}}, want: ""},
 		{args: args{n: 3, names: []string{"a", "c", "e", "b", "d"}}, want: "a, c, e, and 2 more"},
-		{args: args{n: 3, names: []string{"a", "b", "b", "b", "d"}}, want: "a, b, b, and 2 more"},
+		{args: args{n: 3, names: []string{"a", "b", "b", "b", "d"}}, want: "a, b, b, and 2 more"}, //nolint:dupword // Intentional.
 		{args: args{n: 2, names: []string{"a", "c", "e", "b", "d"}}, want: "a, c, and 3 more"},
 		{args: args{n: 0, names: []string{"a", "c", "e", "b", "d"}}, want: "5"},
 		{args: args{n: -7, names: []string{"a", "c", "e", "b", "d"}}, want: "5"},

--- a/pkg/resource/unstructured/claim/claim.go
+++ b/pkg/resource/unstructured/claim/claim.go
@@ -63,7 +63,7 @@ type Unstructured struct {
 	unstructured.Unstructured
 }
 
-// Reference to a claim
+// Reference to a claim.
 type Reference struct {
 	// APIVersion of the referenced claim.
 	APIVersion string `json:"apiVersion"`
@@ -183,7 +183,7 @@ func (c *Unstructured) SetResourceReference(ref *corev1.ObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.resourceRef", ref)
 }
 
-// GetReference returns reference to this claim
+// GetReference returns reference to this claim.
 func (c *Unstructured) GetReference() *Reference {
 	return &Reference{
 		APIVersion: c.GetAPIVersion(),

--- a/pkg/resource/unstructured/claim/claim_test.go
+++ b/pkg/resource/unstructured/claim/claim_test.go
@@ -31,9 +31,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-var (
-	_ client.Object = &Unstructured{}
-)
+var _ client.Object = &Unstructured{}
 
 func TestWithGroupVersionKind(t *testing.T) {
 	gvk := schema.GroupVersionKind{
@@ -47,12 +45,13 @@ func TestWithGroupVersionKind(t *testing.T) {
 	}{
 		"New": {
 			gvk: gvk,
-			want: &Unstructured{Unstructured: unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "g/v1",
-					"kind":       "k",
+			want: &Unstructured{
+				Unstructured: unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "g/v1",
+						"kind":       "k",
+					},
 				},
-			},
 			},
 		},
 	}
@@ -146,6 +145,7 @@ func TestCompositionSelector(t *testing.T) {
 		})
 	}
 }
+
 func TestCompositionReference(t *testing.T) {
 	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
 	cases := map[string]struct {
@@ -341,7 +341,7 @@ func TestConnectionDetailsLastPublishedTime(t *testing.T) {
 	// encoding.
 	lores := func(t *metav1.Time) *metav1.Time {
 		out := &metav1.Time{}
-		j, _ := json.Marshal(t)
+		j, _ := json.Marshal(t) //nolint:errchkjson // No encoding issue in practice.
 		_ = json.Unmarshal(j, out)
 		return out
 	}

--- a/pkg/resource/unstructured/composed/composed.go
+++ b/pkg/resource/unstructured/composed/composed.go
@@ -117,7 +117,7 @@ func (cr *Unstructured) SetPublishConnectionDetailsTo(ref *xpv1.PublishConnectio
 	_ = fieldpath.Pave(cr.Object).SetValue("spec.publishConnectionDetailsTo", ref)
 }
 
-// OwnedBy returns true if the supplied UID is an owner of the composed
+// OwnedBy returns true if the supplied UID is an owner of the composed.
 func (cr *Unstructured) OwnedBy(u types.UID) bool {
 	for _, owner := range cr.GetOwnerReferences() {
 		if owner.UID == u {
@@ -127,7 +127,7 @@ func (cr *Unstructured) OwnedBy(u types.UID) bool {
 	return false
 }
 
-// RemoveOwnerRef removes the supplied UID from the composed resource's owner
+// RemoveOwnerRef removes the supplied UID from the composed resource's owner.
 func (cr *Unstructured) RemoveOwnerRef(u types.UID) {
 	refs := cr.GetOwnerReferences()
 	for i := range refs {

--- a/pkg/resource/unstructured/composed/composed_test.go
+++ b/pkg/resource/unstructured/composed/composed_test.go
@@ -27,9 +27,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-var (
-	_ client.Object = &Unstructured{}
-)
+var _ client.Object = &Unstructured{}
 
 func TestFromReference(t *testing.T) {
 	ref := corev1.ObjectReference{
@@ -44,16 +42,17 @@ func TestFromReference(t *testing.T) {
 	}{
 		"New": {
 			ref: ref,
-			want: &Unstructured{Unstructured: unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "a/v1",
-					"kind":       "k",
-					"metadata": map[string]any{
-						"name":      "name",
-						"namespace": "ns",
+			want: &Unstructured{
+				Unstructured: unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "a/v1",
+						"kind":       "k",
+						"metadata": map[string]any{
+							"name":      "name",
+							"namespace": "ns",
+						},
 					},
 				},
-			},
 			},
 		},
 	}

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -32,9 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 )
 
-var (
-	_ client.Object = &Unstructured{}
-)
+var _ client.Object = &Unstructured{}
 
 func TestWithGroupVersionKind(t *testing.T) {
 	gvk := schema.GroupVersionKind{
@@ -48,12 +46,13 @@ func TestWithGroupVersionKind(t *testing.T) {
 	}{
 		"New": {
 			gvk: gvk,
-			want: &Unstructured{Unstructured: unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "g/v1",
-					"kind":       "k",
+			want: &Unstructured{
+				Unstructured: unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "g/v1",
+						"kind":       "k",
+					},
 				},
-			},
 			},
 		},
 	}
@@ -122,6 +121,7 @@ func TestConditions(t *testing.T) {
 		})
 	}
 }
+
 func TestCompositionSelector(t *testing.T) {
 	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"cool": "very"}}
 	cases := map[string]struct {
@@ -146,6 +146,7 @@ func TestCompositionSelector(t *testing.T) {
 		})
 	}
 }
+
 func TestCompositionReference(t *testing.T) {
 	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
 	cases := map[string]struct {
@@ -328,7 +329,7 @@ func TestConnectionDetailsLastPublishedTime(t *testing.T) {
 	// encoding.
 	lores := func(t *metav1.Time) *metav1.Time {
 		out := &metav1.Time{}
-		j, _ := json.Marshal(t)
+		j, _ := json.Marshal(t) //nolint:errchkjson // No encoding error in practice.
 		_ = json.Unmarshal(j, out)
 		return out
 	}

--- a/pkg/test/fake.go
+++ b/pkg/test/fake.go
@@ -107,7 +107,7 @@ func NewMockListFn(err error, ofn ...ObjectListFn) MockListFn {
 
 // NewMockCreateFn returns a MockCreateFn that returns the supplied error.
 func NewMockCreateFn(err error, ofn ...ObjectFn) MockCreateFn {
-	return func(_ context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
 		for _, fn := range ofn {
 			if err := fn(obj); err != nil {
 				return err
@@ -167,7 +167,7 @@ func NewMockPatchFn(err error, ofn ...ObjectFn) MockPatchFn {
 
 // NewMockSubResourceCreateFn returns a MockSubResourceCreateFn that returns the supplied error.
 func NewMockSubResourceCreateFn(err error, ofn ...ObjectFn) MockSubResourceCreateFn {
-	return func(_ context.Context, obj, subResource client.Object, _ ...client.SubResourceCreateOption) error {
+	return func(_ context.Context, obj, _ client.Object, _ ...client.SubResourceCreateOption) error {
 		for _, fn := range ofn {
 			if err := fn(obj); err != nil {
 				return err
@@ -201,7 +201,7 @@ func NewMockSubResourcePatchFn(err error, ofn ...ObjectFn) MockSubResourcePatchF
 	}
 }
 
-// NewMockSchemeFn returns a MockSchemeFn that returns the scheme
+// NewMockSchemeFn returns a MockSchemeFn that returns the scheme.
 func NewMockSchemeFn(scheme *runtime.Scheme) MockSchemeFn {
 	return func() *runtime.Scheme {
 		return scheme
@@ -315,7 +315,7 @@ func (c *MockClient) Patch(ctx context.Context, obj client.Object, patch client.
 	return c.MockPatch(ctx, obj, patch, opts...)
 }
 
-// Status returns status writer for status sub-resource
+// Status returns status writer for status sub-resource.
 func (c *MockClient) Status() client.SubResourceWriter {
 	return &MockSubResourceClient{
 		MockCreate: c.MockStatusCreate,
@@ -339,22 +339,22 @@ func (c *MockClient) RESTMapper() meta.RESTMapper {
 	return nil
 }
 
-// Scheme calls MockClient's MockScheme function
+// Scheme calls MockClient's MockScheme function.
 func (c *MockClient) Scheme() *runtime.Scheme {
 	return c.MockScheme()
 }
 
-// GroupVersionKindFor calls MockClient's MockGroupVersionKindFor function
+// GroupVersionKindFor calls MockClient's MockGroupVersionKindFor function.
 func (c *MockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
 	return c.MockGroupVersionKindFor(obj)
 }
 
-// IsObjectNamespaced calls MockClient's MockIsObjectNamespaced function
+// IsObjectNamespaced calls MockClient's MockIsObjectNamespaced function.
 func (c *MockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
 	return c.MockIsObjectNamespaced(obj)
 }
 
-// MockSubResourceClient provides mock functionality for status sub-resource
+// MockSubResourceClient provides mock functionality for status sub-resource.
 type MockSubResourceClient struct {
 	MockGet    MockSubResourceGetFn
 	MockCreate MockSubResourceCreateFn
@@ -362,22 +362,22 @@ type MockSubResourceClient struct {
 	MockPatch  MockSubResourcePatchFn
 }
 
-// Get a sub-resource
+// Get a sub-resource.
 func (m *MockSubResourceClient) Get(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
 	return m.MockGet(ctx, obj, subResource, opts...)
 }
 
-// Create a sub-resource
+// Create a sub-resource.
 func (m *MockSubResourceClient) Create(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {
 	return m.MockCreate(ctx, obj, subResource, opts...)
 }
 
-// Update a sub-resource
+// Update a sub-resource.
 func (m *MockSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 	return m.MockUpdate(ctx, obj, opts...)
 }
 
-// Patch a sub-resource
+// Patch a sub-resource.
 func (m *MockSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 	return m.MockPatch(ctx, obj, patch, opts...)
 }

--- a/pkg/test/retry.go
+++ b/pkg/test/retry.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// DefaultRetry is the recommended retry parameters for unit testing scenarios where a condition is being
-// tested multiple times before it is expected to succeed.
+// DefaultRetry is the recommended retry parameters for unit testing scenarios
+// where a condition is being tested multiple times before it is expected to
+// succeed.
+//
+//nolint:gochecknoglobals // We treat this as a constant.
 var DefaultRetry = wait.Backoff{
 	Steps:    500,
 	Duration: 10 * time.Millisecond,

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -34,8 +34,10 @@ import (
 // controller-runtime Manager.
 var _ webhook.CustomValidator = &Validator{}
 
-var errBoom = errors.New("boom")
-var warnings = []string{"warning"}
+var (
+	errBoom  = errors.New("boom")
+	warnings = []string{"warning"}
+)
 
 func TestValidateCreate(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
This copies the latest config from c/c and addresses all the linter errors that config produces.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Closes https://github.com/crossplane/crossplane-runtime/pull/669

See https://github.com/crossplane/crossplane/pull/5445. This brings this repo into line with c/c's config.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Just unit tests.
