### PR TITLE
fix: ensure NewNameAsExternalName does not revert external-name to id

### DIFF
--- a/pkg/reconciler/managed/api.go
+++ b/pkg/reconciler/managed/api.go
@@ -67,10 +67,12 @@ func NewNameAsExternalName(c client.Client) *NameAsExternalName {
 
 // Initialize the given managed resource.
 func (a *NameAsExternalName) Initialize(ctx context.Context, mg resource.Managed) error {
-	if meta.GetExternalName(mg) != "" {
+	externalName := meta.GetExternalName(mg)
+	name := mg.GetName()
+	if externalName != "" && externalName == name {
 		return nil
 	}
-	meta.SetExternalName(mg, mg.GetName())
+	meta.SetExternalName(mg, name)
 	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add additional check to `NewNameAsExternalName.Initialize()` to ensure external-name annotation does not revert from `metadata.name` to an id.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #686

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Made the equivalent change locally while testing crossplane-contrib/provider-palette and verified that the MR's external-name annotation remained tied to `metadata.name`, rather than the underlying TF resource's id.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
