### PR TITLE
Whitelist management policy Observe & Update

### DIFF
--- a/pkg/reconciler/managed/policies.go
+++ b/pkg/reconciler/managed/policies.go
@@ -85,6 +85,10 @@ func defaultSupportedManagementPolicies() []sets.Set[xpv1.ManagementAction] {
 		// Like ObserveOnly, but the external resource is deleted when the
 		// managed resource is deleted.
 		sets.New[xpv1.ManagementAction](xpv1.ManagementActionObserve, xpv1.ManagementActionDelete),
+		// No Crate and no Delete. Just update/patch the external resource.
+		// Useful when the same external resource is managed by multiple
+		// managed resources.
+		sets.New[xpv1.ManagementAction](xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate),
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

As initially requested in [this ticket](https://github.com/crossplane-contrib/provider-kubernetes/issues/115), we have valid use cases to set a management policy as "Observe & Update", at least with Provider Kubernetes.

This PR whitelisting this variant of management policies so that runtime will not fail early.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

With provider-kubernetes, `managementPolicies: ["Observe", "Update"]`.

[contribution process]: https://git.io/fj2m9
