### PR TITLE
Allow Renovate to run Earthly

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+curl -fsSLo /usr/local/bin/earthly https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64
+chmod +x /usr/local/bin/earthly
+/usr/local/bin/earthly bootstrap
+
+runuser -u ubuntu renovate

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,10 +99,12 @@
   // be at the beginning, high priority at the end
   "packageRules": [
     {
-      "description": "Generate code after upgrading go dependencies",
+      "description": "Generate code after upgrading go dependencies (master)",
       "matchDatasources": [
         "go"
       ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["master"],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -115,10 +117,30 @@
       },
     },
     {
-      "description": "Lint code after upgrading golangci-lint",
+      "description": "Generate code after upgrading go dependencies (release branch)",
+      "matchDatasources": [
+        "go"
+      ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["release-.+"],
+      postUpgradeTasks: {
+        // Post-upgrade tasks that are executed before a commit is made by Renovate.
+        "commands": [
+          "make go.generate",
+        ],
+        fileFilters: [
+          "**/*"
+        ],
+        executionMode: "update",
+      },
+    },
+    {
+      "description": "Lint code after upgrading golangci-lint (master)",
       "matchDepNames": [
         "golangci/golangci-lint"
       ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["master"],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -131,13 +153,22 @@
       },
     },
     {
-      "matchManagers": [
-        "crossplane"
+      "description": "Lint code after upgrading golangci-lint (release branch)",
+      "matchDepNames": [
+        "golangci/golangci-lint"
       ],
-      "matchFileNames": [
-        "test/e2e/**"
-      ],
-      "groupName": "e2e-manifests",
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["release-.+"],
+      postUpgradeTasks: {
+        // Post-upgrade tasks that are executed before a commit is made by Renovate.
+        "commands": [
+          "make go.lint",
+        ],
+        fileFilters: [
+          "**/*"
+        ],
+        executionMode: "update",
+      },
     },
     {
       "description": "Ignore non-security related updates to release branches",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Setup Earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ env.EARTHLY_VERSION }}
-
       # Don't waste time starting Renovate if JSON is invalid
       - name: Validate Renovate JSON
         run:  npx --yes --package renovate -- renovate-config-validator
@@ -55,3 +49,6 @@ jobs:
         with:
           configurationFile: .github/renovate.json5
           token: '${{ steps.get-github-app-token.outputs.token }}'
+          mount-docker-socket: true
+          docker-user: root
+          docker-cmd-file: .github/renovate-entrypoint.sh


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Actually install it in the Renovate container, not the runner environment.

Also, run make rather than earthly on release branches.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
