### PR TITLE
Composite Receiver Functions for Conditions

### DIFF
--- a/apis/common/v1/condition.go
+++ b/apis/common/v1/condition.go
@@ -34,6 +34,17 @@ const (
 	// TypeSynced resources are believed to be in sync with the
 	// Kubernetes resources that manage their lifecycle.
 	TypeSynced ConditionType = "Synced"
+
+	// TypeHealthy resources are believed to be in a healthy state and to have all
+	// of their child resources in a healthy state. For example, a claim is
+	// healthy when the claim is synced and the underlying composite resource is
+	// both synced and healthy. A composite resource is healthy when the composite
+	// resource is synced and all composed resources are synced and, if
+	// applicable, healthy (e.g., the composed resource is a composite resource).
+	// TODO: This condition is not yet implemented. It is currently just reserved
+	// as a system condition. See the tracking issue for more details
+	// https://github.com/crossplane/crossplane/issues/5643.
+	TypeHealthy ConditionType = "Healthy"
 )
 
 // A ConditionReason represents the reason a resource is in a condition.
@@ -105,6 +116,16 @@ func (c Condition) WithMessage(msg string) Condition {
 func (c Condition) WithObservedGeneration(gen int64) Condition {
 	c.ObservedGeneration = gen
 	return c
+}
+
+// IsSystemConditionType returns true if the condition is owned by the
+// Crossplane system (e.g, Ready, Synced, Healthy).
+func IsSystemConditionType(t ConditionType) bool {
+	switch t {
+	case TypeReady, TypeSynced, TypeHealthy:
+		return true
+	}
+	return false
 }
 
 // NOTE(negz): Conditions are implemented as a slice rather than a map to comply

--- a/apis/common/v1/condition_test.go
+++ b/apis/common/v1/condition_test.go
@@ -257,3 +257,35 @@ func TestConditionWithObservedGeneration(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSystemConditionType(t *testing.T) {
+	cases := map[string]struct {
+		c    Condition
+		want bool
+	}{
+		"SystemReady": {
+			c:    Condition{Type: ConditionType("Ready")},
+			want: true,
+		},
+		"SystemSynced": {
+			c:    Condition{Type: ConditionType("Synced")},
+			want: true,
+		},
+		"SystemHealthy": {
+			c:    Condition{Type: ConditionType("Healthy")},
+			want: true,
+		},
+		"Custom": {
+			c:    Condition{Type: ConditionType("Custom")},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, IsSystemConditionType(tc.c.Type)); diff != "" {
+				t.Errorf("IsSystemConditionType(tc.c.Type): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 )
@@ -223,6 +224,14 @@ func (c *Unstructured) SetConditions(conditions ...xpv1.Condition) {
 	_ = fieldpath.Pave(c.Object).SetValue("status.conditions", conditioned.Conditions)
 }
 
+// GetConditions of this Composite resource.
+func (c *Unstructured) GetConditions() []xpv1.Condition {
+	conditioned := xpv1.ConditionedStatus{}
+	// The path is directly `status` because conditions are inline.
+	_ = fieldpath.Pave(c.Object).GetValueInto("status", &conditioned)
+	return conditioned.Conditions
+}
+
 // GetConnectionDetailsLastPublishedTime of this Composite resource.
 func (c *Unstructured) GetConnectionDetailsLastPublishedTime() *metav1.Time {
 	out := &metav1.Time{}
@@ -272,4 +281,34 @@ func (c *Unstructured) GetObservedGeneration() int64 {
 	status := &xpv1.ObservedStatus{}
 	_ = fieldpath.Pave(c.Object).GetValueInto("status", status)
 	return status.GetObservedGeneration()
+}
+
+// SetClaimConditionTypes of this Composite resource. You cannot set system
+// condition types such as Ready, Synced or Healthy as claim conditions.
+func (c *Unstructured) SetClaimConditionTypes(in ...xpv1.ConditionType) error {
+	ts := c.GetClaimConditionTypes()
+	m := make(map[xpv1.ConditionType]bool, len(ts))
+	for _, t := range ts {
+		m[t] = true
+	}
+
+	for _, t := range in {
+		if xpv1.IsSystemConditionType(t) {
+			return errors.Errorf("cannot set system condition %s as a claim condition", t)
+		}
+		if m[t] {
+			continue
+		}
+		m[t] = true
+		ts = append(ts, t)
+	}
+	_ = fieldpath.Pave(c.Object).SetValue("status.claimConditionTypes", ts)
+	return nil
+}
+
+// GetClaimConditionTypes of this Composite resource.
+func (c *Unstructured) GetClaimConditionTypes() []xpv1.ConditionType {
+	cs := []xpv1.ConditionType{}
+	_ = fieldpath.Pave(c.Object).GetValueInto("status.claimConditionTypes", &cs)
+	return cs
 }


### PR DESCRIPTION
### Description of your changes
Adds utilities for dealing with Composite Resources. Related to and needed for [Composition Function Events and Status Conditions](https://github.com/crossplane/crossplane/pull/5450).

Adds the following:
- GetConditions
- GetClaimConditions
- SetClaimConditions

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~