### PR TITLE
feat(managed): Add generic interfaces for external types

### DIFF
--- a/pkg/reconciler/managed/reconciler_typed.go
+++ b/pkg/reconciler/managed/reconciler_typed.go
@@ -1,0 +1,73 @@
+package managed
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+)
+
+const errFmtUnexpectedObjectType = "unexpected object type %T"
+
+// typedExternalConnectDisconnecterWrapper wraps a TypedExternalConnecter to a
+// common ExternalConnector.
+type typedExternalConnectDisconnecterWrapper[managed resource.Managed] struct {
+	c TypedExternalConnectDisconnecter[managed]
+}
+
+func (c *typedExternalConnectDisconnecterWrapper[managed]) Connect(ctx context.Context, mg resource.Managed) (ExternalClient, error) {
+	cr, ok := mg.(managed)
+	if !ok {
+		return nil, errors.Errorf(errFmtUnexpectedObjectType, mg)
+	}
+	external, err := c.c.Connect(ctx, cr)
+	if err != nil {
+		return nil, err
+	}
+	return &typedExternalClientWrapper[managed]{c: external}, nil
+}
+
+func (c *typedExternalConnectDisconnecterWrapper[managed]) Disconnect(ctx context.Context) error {
+	return c.c.Disconnect(ctx)
+}
+
+// typedExternalClientWrapper wraps a TypedExternalClient to a common
+// ExternalClient.
+type typedExternalClientWrapper[managed resource.Managed] struct {
+	c TypedExternalClient[managed]
+}
+
+func (c *typedExternalClientWrapper[managed]) Observe(ctx context.Context, mg resource.Managed) (ExternalObservation, error) {
+	cr, ok := mg.(managed)
+	if !ok {
+		return ExternalObservation{}, errors.Errorf(errFmtUnexpectedObjectType, mg)
+	}
+	return c.c.Observe(ctx, cr)
+}
+
+func (c *typedExternalClientWrapper[managed]) Create(ctx context.Context, mg resource.Managed) (ExternalCreation, error) {
+	cr, ok := mg.(managed)
+	if !ok {
+		return ExternalCreation{}, errors.Errorf(errFmtUnexpectedObjectType, mg)
+	}
+	return c.c.Create(ctx, cr)
+}
+func (c *typedExternalClientWrapper[managed]) Update(ctx context.Context, mg resource.Managed) (ExternalUpdate, error) {
+	cr, ok := mg.(managed)
+	if !ok {
+		return ExternalUpdate{}, errors.Errorf(errFmtUnexpectedObjectType, mg)
+	}
+	return c.c.Update(ctx, cr)
+}
+
+func (c *typedExternalClientWrapper[managed]) Delete(ctx context.Context, mg resource.Managed) (ExternalDelete, error) {
+	cr, ok := mg.(managed)
+	if !ok {
+		return ExternalDelete{}, errors.Errorf(errFmtUnexpectedObjectType, mg)
+	}
+	return c.c.Delete(ctx, cr)
+}
+
+func (c *typedExternalClientWrapper[managed]) Disconnect(ctx context.Context) error {
+	return c.c.Disconnect(ctx)
+}


### PR DESCRIPTION
### Description of your changes

Add a wrapper for typed external clients that take over the conversion from resource.Managed to the actual Go struct that is always necessary in every controller. It does not reduce complexity as a whole but allows controllers to save some LoCs and focus on the important things.

Keep the previous types as type aliases to avoid any breaking changes.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
