### PR TITLE
Remove references to controller-runtime/pkg/ratelimiter

### DIFF
--- a/pkg/ratelimiter/default.go
+++ b/pkg/ratelimiter/default.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/time/rate"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 )
 
 // NewGlobal returns a token bucket rate limiter meant for limiting the number
@@ -36,7 +35,7 @@ func NewGlobal(rps int) *workqueue.BucketRateLimiter {
 // NewController returns a rate limiter that takes the maximum delay between the
 // passed rate limiter and a per-item exponential backoff limiter. The
 // exponential backoff limiter has a base delay of 1s and a maximum of 60s.
-func NewController() ratelimiter.RateLimiter {
+func NewController() workqueue.RateLimiter {
 	return workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 60*time.Second)
 }
 

--- a/pkg/ratelimiter/reconciler.go
+++ b/pkg/ratelimiter/reconciler.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -31,7 +31,7 @@ import (
 type Reconciler struct {
 	name  string
 	inner reconcile.Reconciler
-	limit ratelimiter.RateLimiter
+	limit workqueue.RateLimiter
 
 	limited  map[string]struct{}
 	limitedL sync.RWMutex
@@ -40,7 +40,7 @@ type Reconciler struct {
 // NewReconciler wraps the supplied Reconciler, ensuring requests are passed to
 // it no more frequently than the supplied RateLimiter allows. Multiple uniquely
 // named Reconcilers can share the same RateLimiter.
-func NewReconciler(name string, r reconcile.Reconciler, l ratelimiter.RateLimiter) *Reconciler {
+func NewReconciler(name string, r reconcile.Reconciler, l workqueue.RateLimiter) *Reconciler {
 	return &Reconciler{name: name, inner: r, limit: l, limited: make(map[string]struct{})}
 }
 

--- a/pkg/ratelimiter/reconciler_test.go
+++ b/pkg/ratelimiter/reconciler_test.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
-var _ ratelimiter.RateLimiter = &predictableRateLimiter{}
+var _ workqueue.RateLimiter = &predictableRateLimiter{}
 
 type predictableRateLimiter struct{ d time.Duration }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
As part of https://github.com/kubernetes-sigs/controller-runtime/pull/2799, the `ratelimiter` package was removed from controller-runtime [here](https://github.com/kubernetes-sigs/controller-runtime/pull/2799/files#diff-762512571c906b1acdc870c6fd9bc7b2b289b19d973a0f41183bf873a7ebc9ee).

Anything project pulling in crossplane-runtime and referencing the ratelimiter package will run into problems as they go to upgrade to more recent versions.

This changeset gets in front of this a little by directly referencing the RateLimiter interface from client-go, which was copied into controller-runtime.

>NOTE: We do not upgrade controller-runtime and friends at this time.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.~
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
