### PR TITLE
Add `paved.GetFloat()` function

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -263,6 +263,20 @@ func (p *Paved) GetString(path string) (string, error) {
 	return s, nil
 }
 
+// GetFloat value of the supplied field path.
+func (p *Paved) GetFloat(path string) (float64, error) {
+	v, err := p.GetValue(path)
+	if err != nil {
+		return 0, err
+	}
+
+	f, ok := v.(float64)
+	if !ok {
+		return 0, errors.Errorf("%s: not a number", path)
+	}
+	return f, nil
+}
+
 // GetStringArray value of the supplied field path.
 func (p *Paved) GetStringArray(path string) ([]string, error) {
 	v, err := p.GetValue(path)


### PR DESCRIPTION
This adds `paved.GetFloat()` function similar to `paved.GetString()` and `paved.GetInteger()` but returning a `float64`.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
