### PR TITLE
chore: bump renovate base branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,10 +13,10 @@
   // The branches renovate should target
   // PLEASE UPDATE THIS WHEN RELEASING.
   "baseBranches": [
-    "main",
-    "release-1.14",
-    "release-1.15",
-    "release-1.16"
+    'main',
+    'release-1.16',
+    'release-1.17',
+    'release-1.18',
   ],
   "ignorePaths": [
     "design/**",


### PR DESCRIPTION
### Description of your changes

Looks like the renovate config for `baseBranches` has fallen behind, I noticed this when Renovate was opening PRs for old release branches today. This gets the config back inline with the currently supported releases. This change was made by basically copying the config from core crossplane, which has been kept up to date: https://github.com/crossplane/crossplane/blob/main/.github/renovate.json5#L15-L20 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
