### PR TITLE
chore: Renovate should run earthly commands for newer release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -103,8 +103,10 @@
       "matchDatasources": [
         "go"
       ],
-      // Currently we only have an Earthfile on main.
-      matchBaseBranches: ["main"],
+      // Currently we only have an Earthfile on main and some release branches, so we ignore the ones we know don't have it.
+      matchBaseBranches: [
+        '!/release-1\.16/',
+      ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -121,8 +123,10 @@
       "matchDatasources": [
         "go"
       ],
-      // Currently we only have an Earthfile on main.
-      matchBaseBranches: ["release-.+"],
+      // Currently we only have an Earthfile on main and some release branches, so we only run this on older release branches.
+      matchBaseBranches: [
+        'release-1.16',
+      ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -139,8 +143,10 @@
       "matchDepNames": [
         "golangci/golangci-lint"
       ],
-      // Currently we only have an Earthfile on main.
-      matchBaseBranches: ["main"],
+      // Currently we only have an Earthfile on main and some release branches, so we ignore the ones we know don't have it.
+      matchBaseBranches: [
+        '!/release-1\.16/',
+      ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -157,8 +163,10 @@
       "matchDepNames": [
         "golangci/golangci-lint"
       ],
-      // Currently we only have an Earthfile on main.
-      matchBaseBranches: ["release-.+"],
+      // Currently we only have an Earthfile on main and some release branches, so we only run this on older release branches.
+      matchBaseBranches: [
+        'release-1.16',
+      ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [


### PR DESCRIPTION
### Description of your changes

This PR updates the `matchBaseBranches` for `postUpgradeTasks` that renovate runs after updating dependencies. Earthly exists in every recent/supported branch except for `release-1.16`, so that is the only branch where `make` based commands should still be running.

These filters/comments were copied from core crossplane repo, i.e. https://github.com/crossplane/crossplane/pull/6199.

Partially addresses https://github.com/crossplane/crossplane/issues/6186, this does not address the fact that Renovate isn't allowed to run `make` based commands in [renovate.yaml](https://github.com/crossplane/crossplane-runtime/blob/main/.github/workflows/renovate.yml#L48) still - so Renovate PRs would still run into an issue for `release-1.16`.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
