### PR TITLE
Update Managed reconciler to store observedGeneration in conditions

### DIFF
--- a/apis/common/v1/condition.go
+++ b/apis/common/v1/condition.go
@@ -96,12 +96,13 @@ type Condition struct {
 }
 
 // Equal returns true if the condition is identical to the supplied condition,
-// ignoring the LastTransitionTime and ObservedGeneration.
+// ignoring the LastTransitionTime.
 func (c Condition) Equal(other Condition) bool {
 	return c.Type == other.Type &&
 		c.Status == other.Status &&
 		c.Reason == other.Reason &&
-		c.Message == other.Message
+		c.Message == other.Message &&
+		c.ObservedGeneration == other.ObservedGeneration
 }
 
 // WithMessage returns a condition by adding the provided message to existing
@@ -167,28 +168,24 @@ func (s *ConditionedStatus) GetCondition(ct ConditionType) Condition {
 // SetConditions sets the supplied conditions, replacing any existing conditions
 // of the same type. This is a no-op if all supplied conditions are identical,
 // ignoring the last transition time, to those already set.
-// Observed generation is updated if higher than the existing one.
 func (s *ConditionedStatus) SetConditions(c ...Condition) {
-	for _, new := range c {
+	for _, cond := range c {
 		exists := false
 		for i, existing := range s.Conditions {
-			if existing.Type != new.Type {
+			if existing.Type != cond.Type {
 				continue
 			}
 
-			if existing.Equal(new) {
+			if existing.Equal(cond) {
 				exists = true
-				if existing.ObservedGeneration < new.ObservedGeneration {
-					existing.ObservedGeneration = new.ObservedGeneration
-				}
 				continue
 			}
 
-			s.Conditions[i] = new
+			s.Conditions[i] = cond
 			exists = true
 		}
 		if !exists {
-			s.Conditions = append(s.Conditions, new)
+			s.Conditions = append(s.Conditions, cond)
 		}
 	}
 }

--- a/apis/common/v1/condition_test.go
+++ b/apis/common/v1/condition_test.go
@@ -32,6 +32,25 @@ func TestConditionEqual(t *testing.T) {
 		b    Condition
 		want bool
 	}{
+		"Identical": {
+			a: Condition{
+				Type:               TypeReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             ReasonCreating,
+				Message:            "UnitTest",
+				ObservedGeneration: 1,
+			},
+			b: Condition{
+				Type:               TypeReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             ReasonCreating,
+				Message:            "UnitTest",
+				ObservedGeneration: 1,
+			},
+			want: true,
+		},
 		"IdenticalIgnoringTimestamp": {
 			a:    Condition{Type: TypeReady, LastTransitionTime: metav1.Now()},
 			b:    Condition{Type: TypeReady, LastTransitionTime: metav1.Now()},
@@ -55,6 +74,11 @@ func TestConditionEqual(t *testing.T) {
 		"DifferentMessage": {
 			a:    Condition{Message: "cool"},
 			b:    Condition{Message: "uncool"},
+			want: false,
+		},
+		"DifferentObservedGeneration": {
+			a:    Condition{ObservedGeneration: 1},
+			b:    Condition{},
 			want: false,
 		},
 		"CheckReconcilePaused": {
@@ -138,6 +162,11 @@ func TestSetConditions(t *testing.T) {
 			cs:   NewConditionedStatus(Available()),
 			c:    []Condition{Available()},
 			want: NewConditionedStatus(Available()),
+		},
+		"ObservedGenerationIsUpdated": {
+			cs:   NewConditionedStatus(Available().WithObservedGeneration(1)),
+			c:    []Condition{Available().WithObservedGeneration(2)},
+			want: NewConditionedStatus(Available().WithObservedGeneration(2)),
 		},
 		"TypeIsDifferent": {
 			cs:   NewConditionedStatus(Creating()),

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1107,9 +1107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 				log.Info(errRecordChangeLog, "error", err)
 			}
 			record.Event(managed, event.Normal(reasonDeleted, "Successfully requested deletion of external resource"))
-			managed.SetConditions(
-				xpv1.Deleting().WithObservedGeneration(managed.GetGeneration()),
-				xpv1.ReconcileSuccess().WithObservedGeneration(managed.GetGeneration()))
+			status.MarkConditions(xpv1.Deleting(), xpv1.ReconcileSuccess())
 			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 		if err := r.managed.UnpublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {
@@ -1305,7 +1303,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		// https://github.com/crossplane/crossplane/issues/289
 		reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
 		log.Debug("External resource is up to date", "requeue-after", time.Now().Add(reconcileAfter))
-		managed.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(managed.GetGeneration()))
+		status.MarkConditions(xpv1.ReconcileSuccess())
 		r.metricRecorder.recordFirstTimeReady(managed)
 
 		// record that we intentionally did not update the managed resource


### PR DESCRIPTION
### Description of your changes

Update `Managed` reconciler to store observedGeneration on conditions and also update that controllers unit tests.

This uses the new `conditions.Manager` to help propagate the `observedGeneration` to the changed conditions within the reconciler.

Relates to https://github.com/crossplane/crossplane/issues/6420
Superseedes https://github.com/crossplane/crossplane-runtime/pull/789
Depends on https://github.com/crossplane/crossplane-runtime/pull/831/

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
