### PR TITLE
build: remove release-1.17 from renovate baseBranches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
   // PLEASE UPDATE THIS WHEN RELEASING.
   "baseBranches": [
     'main',
-    'release-1.17',
     'release-1.18',
     'release-1.19',
     'release-1.20',


### PR DESCRIPTION
### Description of your changes

This PR removes release-1.17 from renovate baseBranches, as v1.17 is now EOL.

Part of https://github.com/crossplane/release/issues/43

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
