### PR TITLE
fix lint issue on deprecated interfaces

### DIFF
--- a/pkg/reconciler/managed/reconciler_deprecated.go
+++ b/pkg/reconciler/managed/reconciler_deprecated.go
@@ -36,6 +36,8 @@ type TypedExternalConnecter[managed resource.Managed] interface {
 //
 // Deprecated: Please use Disconnect() on the ExternalClient for disconnecting
 // from the provider.
+//
+//nolint:iface // We know it is a redundant interface.
 type ExternalDisconnector interface {
 	// Disconnect from the provider and close the ExternalClient.
 	Disconnect(ctx context.Context) error
@@ -45,6 +47,8 @@ type ExternalDisconnector interface {
 //
 // Deprecated: Please use Disconnect() on the ExternalClient for disconnecting
 // from the provider.
+//
+//nolint:iface // We know it is a redundant interface
 type ExternalDisconnecter interface {
 	ExternalDisconnector
 }

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -107,7 +107,7 @@ func ToIntPtrValue(v string) *int64 {
 // string pointers and need to be resolved as part of `ResolveMultiple`.
 func FromPtrValues(v []*string) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromPtrValue(v[i])
 	}
 	return res
@@ -116,7 +116,7 @@ func FromPtrValues(v []*string) []string {
 // FromFloatPtrValues adapts a slice of float64 pointer fields for use as CurrentValues.
 func FromFloatPtrValues(v []*float64) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromFloatPtrValue(v[i])
 	}
 	return res
@@ -125,7 +125,7 @@ func FromFloatPtrValues(v []*float64) []string {
 // FromIntPtrValues adapts a slice of int64 pointer fields for use as CurrentValues.
 func FromIntPtrValues(v []*int64) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromIntPtrValue(v[i])
 	}
 	return res
@@ -138,7 +138,7 @@ func FromIntPtrValues(v []*int64) []string {
 // string pointers and need to be resolved as part of `ResolveMultiple`.
 func ToPtrValues(v []string) []*string {
 	res := make([]*string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToPtrValue(v[i])
 	}
 	return res
@@ -147,7 +147,7 @@ func ToPtrValues(v []string) []*string {
 // ToFloatPtrValues adapts ResolvedValues for use as a slice of float64 pointer fields.
 func ToFloatPtrValues(v []string) []*float64 {
 	res := make([]*float64, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToFloatPtrValue(v[i])
 	}
 	return res
@@ -156,7 +156,7 @@ func ToFloatPtrValues(v []string) []*float64 {
 // ToIntPtrValues adapts ResolvedValues for use as a slice of int64 pointer fields.
 func ToIntPtrValues(v []string) []*int64 {
 	res := make([]*int64, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToIntPtrValue(v[i])
 	}
 	return res


### PR DESCRIPTION
### Description of your changes

Noticed the build started failing after https://github.com/crossplane/crossplane-runtime/pull/835 was merged. SORRY!! Here is a fix to ignore the linting error. Not sure why it was not caught in the normal CI? 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
