### PR TITLE
feat: enable namespaced reference resolution

### DIFF
--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -286,6 +286,30 @@ func TestResolve(t *testing.T) {
 				},
 			},
 		},
+		"SuccessfulResolveNamespaced": {
+			reason: "Resolve should be successful when a namespace is given",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					meta.SetExternalName(obj.(metav1.Object), value)
+					return nil
+				}),
+			},
+			from: &fake.Managed{},
+			args: args{
+				req: ResolutionRequest{
+					Reference: ref,
+					To:        To{Managed: &fake.Managed{}},
+					Extract:   ExternalName(),
+					Namespace: "cool-ns",
+				},
+			},
+			want: want{
+				rsp: ResolutionResponse{
+					ResolvedValue:     value,
+					ResolvedReference: ref,
+				},
+			},
+		},
 		"OptionalReference": {
 			reason: "No error should be returned when the resolution policy is Optional",
 			c: &test.MockClient{
@@ -374,6 +398,33 @@ func TestResolve(t *testing.T) {
 						controlled,      // A resource with a matching controller reference.
 					}}},
 					Extract: ExternalName(),
+				},
+			},
+			want: want{
+				rsp: ResolutionResponse{
+					ResolvedValue:     value,
+					ResolvedReference: &xpv1.Reference{Name: value},
+				},
+				err: nil,
+			},
+		},
+		"SuccessfulSelectNamespaced": {
+			reason: "Resolve should be successful when a namespace is given",
+			c: &test.MockClient{
+				MockList: test.NewMockListFn(nil),
+			},
+			from: controlled,
+			args: args{
+				req: ResolutionRequest{
+					Selector: &xpv1.Selector{
+						MatchControllerRef: func() *bool { t := true; return &t }(),
+					},
+					To: To{List: &FakeManagedList{Items: []resource.Managed{
+						&fake.Managed{}, // A resource that does not match.
+						controlled,      // A resource with a matching controller reference.
+					}}},
+					Extract:   ExternalName(),
+					Namespace: "cool-ns",
 				},
 			},
 			want: want{
@@ -609,6 +660,30 @@ func TestResolveMultiple(t *testing.T) {
 				},
 			},
 		},
+		"SuccessfulResolveNamespaced": {
+			reason: "Resolve should be successful when a namespace is given",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					meta.SetExternalName(obj.(metav1.Object), value)
+					return nil
+				}),
+			},
+			from: &fake.Managed{},
+			args: args{
+				req: MultiResolutionRequest{
+					References: []xpv1.Reference{ref},
+					To:         To{Managed: &fake.Managed{}},
+					Extract:    ExternalName(),
+					Namespace:  "cool-ns",
+				},
+			},
+			want: want{
+				rsp: MultiResolutionResponse{
+					ResolvedValues:     []string{value},
+					ResolvedReferences: []xpv1.Reference{ref},
+				},
+			},
+		},
 		"OptionalReference": {
 			reason: "No error should be returned when the resolution policy is Optional",
 			c: &test.MockClient{
@@ -698,6 +773,33 @@ func TestResolveMultiple(t *testing.T) {
 						controlled,      // A resource with a matching controller reference.
 					}}},
 					Extract: ExternalName(),
+				},
+			},
+			want: want{
+				rsp: MultiResolutionResponse{
+					ResolvedValues:     []string{value},
+					ResolvedReferences: []xpv1.Reference{{Name: value}},
+				},
+				err: nil,
+			},
+		},
+		"SuccessfulSelectNamespaced": {
+			reason: "Resolve should be successful when a namespace is given",
+			c: &test.MockClient{
+				MockList: test.NewMockListFn(nil),
+			},
+			from: controlled,
+			args: args{
+				req: MultiResolutionRequest{
+					Selector: &xpv1.Selector{
+						MatchControllerRef: func() *bool { t := true; return &t }(),
+					},
+					To: To{List: &FakeManagedList{Items: []resource.Managed{
+						&fake.Managed{}, // A resource that does not match.
+						controlled,      // A resource with a matching controller reference.
+					}}},
+					Extract:   ExternalName(),
+					Namespace: "cool-ns",
 				},
 			},
 			want: want{


### PR DESCRIPTION
### Description of your changes

This PR updates the Resolve methods to take into a namespace when resolving references. This is needed for v2 compatible providers that have namespaced managed resources.

I considered updating [`ResolutionRequest.Reference`](https://github.com/crossplane/crossplane-runtime/blob/main/pkg/reference/reference.go#L187) itself to become a reference type that includes a namespace field, but I decided against that for the following reasons:

* it's not needed - cluster scoped legacy MRs refer to other cluster scoped MRs and don't need to specify a namespace in the reference itself. namespaced MRs refer to other namespaced MRs and don't need to specify a namespace in the reference either - it's inferred from the namespace of the MR.
* it would be a (semi) breaking change to add a new field to that type that is used all over the crossplane ecosystem

This PR is against `main` since Crossplane core development has moved onto v2 now.

Part of https://github.com/crossplane/crossplane/issues/6381

Related PR: https://github.com/crossplane/crossplane-tools/pull/110 

These changes have been tested as demonstrated in this demo repo: https://github.com/jbw976/demo-upjet-namespaced-refs

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
