### PR TITLE
Delay external delete call when other finalizers exist

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1163,6 +1163,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	if meta.WasDeleted(managed) {
 		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
 
+		if len(managed.GetFinalizers()) > 1 {
+			// There are other controllers monitoring this resource so preserve the external instance
+			// until all other finalizers have been removed
+			log.Debug("Delay external deletion until all finalizers have been removed")
+			return reconcile.Result{Requeue: true}, nil
+		}
+
 		if observation.ResourceExists && policy.ShouldDelete() {
 			deletion, err := external.Delete(externalCtx, managed)
 			if err != nil {

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -208,27 +208,17 @@ func TestReconciler(t *testing.T) {
 				m: &fake.Manager{
 					Client: &test.MockClient{
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-							mg :=
-								asManaged(obj, 42)
+							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetDeletionPolicy(xpv1.DeletionDelete)
 							mg.SetFinalizers([]string{FinalizerName, "finalizer2"})
 							return nil
 						}),
-						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, _ client.Object,
-							_ ...client.SubResourceUpdateOption) error {
-							want :=
-								newManaged(42)
-							want.SetDeletionTimestamp(&now)
-							want.SetDeletionPolicy(xpv1.DeletionDelete)
-							want.SetFinalizers([]string{FinalizerName, "finalizer2"})
-							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
-							return nil
-						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					Scheme: fake.SchemeWith(&fake.Managed{}),
+					Scheme: fake.SchemeWith(&fake.LegacyManaged{}),
 				},
-				mg: resource.ManagedKind(fake.GVK(&fake.Managed{})),
+				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
 				o: []ReconcilerOption{
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
@@ -246,7 +236,8 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
-		}, "ExternalCreatePending": {
+		},
+		"ExternalCreatePending": {
 			reason: "We should return early if the managed resource appears to be pending creation. We might have leaked a resource and don't want to create another.",
 			args: args{
 				m: &fake.Manager{

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -207,6 +207,40 @@ func TestModernReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
+		"ExtraFinalizersDelayDelete": {
+			reason: "The existence of multiple finalizers should trigger a requeue after a short wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asModernManaged(obj, 42)
+							mg.SetDeletionTimestamp(&now)
+							mg.SetFinalizers([]string{FinalizerName, "finalizer2"})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
+					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: true}, nil
+							},
+							DisconnectFn: func(_ context.Context) error {
+								return nil
+							},
+						}
+						return c, nil
+					})),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
 		"ExternalCreatePending": {
 			reason: "We should return early if the managed resource appears to be pending creation. We might have leaked a resource and don't want to create another.",
 			args: args{


### PR DESCRIPTION
### Description of your changes
Delay the external.Delete() call on a Managed Resource if there are extra finalizers in addition to the one that Crossplane uses.  This will allow external controllers to complete their deletion handling before the external resource is deleted.

One example could be a database backup Operation Function that needs to execute when a Database MR is marked as deleted but before the actual external database is removed by the provider.

Additional testing is needed but I wanted to get the review started for any feedback.

Fixes #851 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
