### PR TITLE
api: modern XRs do not have connection details

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -99,6 +99,7 @@ func (r *APIRecorder) Event(obj runtime.Object, e Event) {
 			return
 		}
 	}
+
 	r.kube.AnnotatedEventf(obj, r.annotations, string(e.Type), string(e.Reason), "%s", e.Message)
 }
 

--- a/pkg/reconciler/customresourcesgate/reconciler.go
+++ b/pkg/reconciler/customresourcesgate/reconciler.go
@@ -20,6 +20,7 @@ package customresourcesgate
 
 import (
 	"context"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/reconciler/customresourcesgate/reconciler_test.go
+++ b/pkg/reconciler/customresourcesgate/reconciler_test.go
@@ -287,6 +287,7 @@ func (m *MockGate) Set(gvk schema.GroupVersionKind, value bool) bool {
 
 		m.FalseCalls = append(m.FalseCalls, gvk)
 	}
+
 	return true
 }
 
@@ -538,6 +539,7 @@ func TestReconcile(t *testing.T) {
 				slices.SortFunc(tc.fields.gate.TrueCalls, func(a, b schema.GroupVersionKind) int {
 					return strings.Compare(a.Kind, b.Kind)
 				})
+
 				if diff := cmp.Diff(tc.want.trueCalls, tc.fields.gate.TrueCalls); diff != "" {
 					t.Errorf("\n%s\ngate.True calls: -want, +got:\n%s", tc.reason, diff)
 				}
@@ -548,6 +550,7 @@ func TestReconcile(t *testing.T) {
 				slices.SortFunc(tc.fields.gate.FalseCalls, func(a, b schema.GroupVersionKind) int {
 					return strings.Compare(a.Kind, b.Kind)
 				})
+
 				if diff := cmp.Diff(tc.want.falseCalls, tc.fields.gate.FalseCalls); diff != "" {
 					t.Errorf("\n%s\ngate.False calls: -want, +got:\n%s", tc.reason, diff)
 				}

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -888,7 +888,7 @@ func TestModernReconciler(t *testing.T) {
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
-								reason := "Successful managed resource creation should be reported as a conditioned status." //nolint:goconst // used only in tests
+								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
 							return nil
@@ -1246,7 +1246,7 @@ func TestModernReconciler(t *testing.T) {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
-								reason := "A successful managed resource update should be reported as a conditioned status." //nolint:goconst // used only in tests
+								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
 							return nil

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -358,13 +358,13 @@ func (c *Unstructured) GetConditions() []xpv1.Condition {
 
 // GetConnectionDetailsLastPublishedTime of this composite resource.
 func (c *Unstructured) GetConnectionDetailsLastPublishedTime() *metav1.Time {
-	path := "status.crossplane.connectionDetails.lastPublishedTime"
-	if c.Schema == SchemaLegacy {
-		path = "status.connectionDetails.lastPublishedTime"
+	// Only legacy XRs support connection details.
+	if c.Schema != SchemaLegacy {
+		return nil
 	}
 
 	out := &metav1.Time{}
-	if err := fieldpath.Pave(c.Object).GetValueInto(path, out); err != nil {
+	if err := fieldpath.Pave(c.Object).GetValueInto("status.connectionDetails.lastPublishedTime", out); err != nil {
 		return nil
 	}
 
@@ -373,12 +373,12 @@ func (c *Unstructured) GetConnectionDetailsLastPublishedTime() *metav1.Time {
 
 // SetConnectionDetailsLastPublishedTime of this composite resource.
 func (c *Unstructured) SetConnectionDetailsLastPublishedTime(t *metav1.Time) {
-	path := "status.crossplane.connectionDetails.lastPublishedTime"
-	if c.Schema == SchemaLegacy {
-		path = "status.connectionDetails.lastPublishedTime"
+	// Only legacy XRs support connection details.
+	if c.Schema != SchemaLegacy {
+		return
 	}
 
-	_ = fieldpath.Pave(c.Object).SetValue(path, t)
+	_ = fieldpath.Pave(c.Object).SetValue("status.connectionDetails.lastPublishedTime", t)
 }
 
 // SetObservedGeneration of this composite resource claim.

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -440,10 +440,15 @@ func TestConnectionDetailsLastPublishedTime(t *testing.T) {
 		set  *metav1.Time
 		want *metav1.Time
 	}{
-		"NewTime": {
-			u:    New(),
+		"NewTimeLegacy": {
+			u:    New(WithSchema(SchemaLegacy)),
 			set:  now,
 			want: lores(now),
+		},
+		"NewTimeModern": {
+			u:    New(WithSchema(SchemaModern)),
+			set:  now,
+			want: nil, // modern schema doesn't support connection details
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

https://github.com/crossplane/crossplane/pull/6655 removed `.status.crossplane.connectionDetails` from modern XR schema:

* https://github.com/crossplane/crossplane/pull/6655

This is a follow up PR in the crossplane-runtime unstructured resource helper functions to update the behavior of `[Get|Set]ConnectionDetailsLastPublishedTime()` to only do work on legacy XRs.

Looks like there were a few small formatting changes that also came in from running `earthly +reviewable`.

Related to https://github.com/crossplane/crossplane/issues/6652

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
