### PR TITLE
v2: add legacy and modern tracker interfaces for providerconfig usages

### DIFF
--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -126,6 +126,34 @@ func (fn TrackerFn) Track(ctx context.Context, mg Managed) error {
 	return fn(ctx, mg)
 }
 
+// A LegacyTracker tracks legacy managed resources.
+type LegacyTracker interface {
+	// Track the supplied legacy managed resource.
+	Track(ctx context.Context, mg LegacyManaged) error
+}
+
+// A LegacyTrackerFn is a function that tracks legacy managed resources.
+type LegacyTrackerFn func(ctx context.Context, mg LegacyManaged) error
+
+// Track the supplied legacy managed resource.
+func (fn LegacyTrackerFn) Track(ctx context.Context, mg LegacyManaged) error {
+	return fn(ctx, mg)
+}
+
+// A ModernTracker tracks modern managed resources.
+type ModernTracker interface {
+	// Track the supplied modern managed resource.
+	Track(ctx context.Context, mg ModernManaged) error
+}
+
+// A ModernTrackerFn is a function that tracks modern managed resources.
+type ModernTrackerFn func(ctx context.Context, mg ModernManaged) error
+
+// Track the supplied modern managed resource.
+func (fn ModernTrackerFn) Track(ctx context.Context, mg ModernManaged) error {
+	return fn(ctx, mg)
+}
+
 // A ProviderConfigUsageTracker tracks usages of a ProviderConfig by creating or
 // updating the appropriate ProviderConfigUsage.
 type ProviderConfigUsageTracker struct {


### PR DESCRIPTION
### Description of your changes

Adds `LegacyTracker` and `ModernTracker` interfaces for capturing new provider config usage pattern.
These would help also in testing.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet