### PR TITLE
Add support for Orphan management policy

### DIFF
--- a/apis/common/policies.go
+++ b/apis/common/policies.go
@@ -49,6 +49,10 @@ const (
 	// ManagementActionAll means that all of the above actions will be taken
 	// by the Crossplane controllers.
 	ManagementActionAll ManagementAction = "*"
+
+	// ManagementActionOrphan means that all actions except Delete will be taken
+	// by the Crossplane controllers.
+	ManagementActionOrphan ManagementAction = "Orphan"
 )
 
 // A DeletionPolicy determines what should happen to the underlying external

--- a/apis/common/v1/policies.go
+++ b/apis/common/v1/policies.go
@@ -52,6 +52,10 @@ const (
 	// ManagementActionAll means that all of the above actions will be taken
 	// by the Crossplane controllers.
 	ManagementActionAll = common.ManagementActionAll
+
+	// ManagementActionOrphan means that all actions except Delete will be taken
+	// by the Crossplane controllers.
+	ManagementActionOrphan ManagementAction = common.ManagementActionOrphan
 )
 
 // A DeletionPolicy determines what should happen to the underlying external

--- a/pkg/reconciler/managed/policies.go
+++ b/pkg/reconciler/managed/policies.go
@@ -106,6 +106,8 @@ func defaultSupportedManagementPolicies() []sets.Set[xpv1.ManagementAction] {
 		// Useful when external resource lifecycle is managed elsewhere but you want
 		// to allow Crossplane to make updates and discover state changes.
 		sets.New[xpv1.ManagementAction](xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate, xpv1.ManagementActionLateInitialize),
+		// Orphan allows all actions except Delete.
+		sets.New[xpv1.ManagementAction](xpv1.ManagementActionOrphan),
 	}
 }
 
@@ -187,7 +189,7 @@ func (m *ManagementPoliciesResolver) ShouldCreate() bool {
 		return true
 	}
 
-	return m.managementPolicies.HasAny(xpv1.ManagementActionCreate, xpv1.ManagementActionAll)
+	return m.managementPolicies.HasAny(xpv1.ManagementActionCreate, xpv1.ManagementActionAll, xpv1.ManagementActionOrphan)
 }
 
 // ShouldUpdate returns true if the Update action is allowed.
@@ -197,7 +199,7 @@ func (m *ManagementPoliciesResolver) ShouldUpdate() bool {
 		return true
 	}
 
-	return m.managementPolicies.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll)
+	return m.managementPolicies.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll, xpv1.ManagementActionOrphan)
 }
 
 // ShouldLateInitialize returns true if the LateInitialize action is allowed.
@@ -207,7 +209,7 @@ func (m *ManagementPoliciesResolver) ShouldLateInitialize() bool {
 		return true
 	}
 
-	return m.managementPolicies.HasAny(xpv1.ManagementActionLateInitialize, xpv1.ManagementActionAll)
+	return m.managementPolicies.HasAny(xpv1.ManagementActionLateInitialize, xpv1.ManagementActionAll, xpv1.ManagementActionOrphan)
 }
 
 // ShouldOnlyObserve returns true if the Observe action is allowed and all

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -86,7 +86,7 @@ func TestReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{}},
 		},
-		"UnpublishConnectionDetailsDeletionPolicyDeleteOrpahn": {
+		"UnpublishConnectionDetailsDeletionPolicyDeleteOrphan": {
 			reason: "Errors unpublishing connection details should trigger a requeue after a short wait.",
 			args: args{
 				m: &fake.Manager{
@@ -1735,6 +1735,45 @@ func TestReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
+		"ManagementPolicyOrphanCreateSuccessful": {
+			reason: "Successful managed resource creation using management policy Orphan should trigger a requeue after a short wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asLegacyManaged(obj, 42)
+							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newLegacyManaged(42)
+							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							meta.SetExternalCreatePending(want, time.Now())
+							meta.SetExternalCreateSucceeded(want, time.Now())
+							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+								reason := "Successful managed resource creation should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.LegacyManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(&NopConnector{}),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
 		"ManagementPolicyCreateCreateSuccessful": {
 			reason: "Successful managed resource creation using management policy Create should trigger a requeue after a short wait.",
 			args: args{
@@ -1835,6 +1874,53 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "A successful managed resource update should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.LegacyManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+							},
+							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
+								return ExternalUpdate{}, nil
+							},
+							DisconnectFn: func(_ context.Context) error {
+								return nil
+							},
+						}
+						return c, nil
+					})),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+		},
+		"ManagementPolicyOrphanUpdateSuccessful": {
+			reason: "A successful managed resource update using management policies should trigger a requeue after a long wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asLegacyManaged(obj, 42)
+							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							return nil
+						}),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newLegacyManaged(42)
+							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
@@ -2175,6 +2261,14 @@ func TestLegacyManagementPoliciesResolverShouldCreate(t *testing.T) {
 			},
 			want: true,
 		},
+		"ManagementPoliciesEnabledHasCreateOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
+		},
 		"ManagementPoliciesEnabledActionNotAllowed": {
 			reason: "Should return false if management policies are enabled and managementPolicies does not have Create",
 			args: args{
@@ -2236,6 +2330,14 @@ func TestLegacyManagementPoliciesResolverShouldUpdate(t *testing.T) {
 			},
 			want: false,
 		},
+		"ManagementPoliciesEnabledHasUpdateOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -2288,6 +2390,14 @@ func TestLegacyManagementPoliciesResolverShouldLateInitialize(t *testing.T) {
 				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionObserve},
 			},
 			want: false,
+		},
+		"ManagementPoliciesEnabledHasLateInitializeOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
 		},
 	}
 	for name, tc := range cases {
@@ -2454,6 +2564,33 @@ func TestLegacyShouldDelete(t *testing.T) {
 					},
 					Manageable: fake.Manageable{
 						Policy: xpv1.ManagementPolicies{xpv1.ManagementActionObserve},
+					},
+				},
+			},
+			want: want{delete: false},
+		},
+		"DeletionDeleteManagementActionOrphan": {
+			reason: "Should orphan if management policies are enabled and deletion policy is set to Delete and management policy does not have action Delete.",
+			args: args{
+				managementPoliciesEnabled: true,
+				managed: &fake.LegacyManaged{
+					Orphanable: fake.Orphanable{
+						Policy: xpv1.DeletionDelete,
+					},
+					Manageable: fake.Manageable{
+						Policy: xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+					},
+				},
+			},
+			want: want{delete: false},
+		},
+		"DeletionManagementActionOrphan": {
+			reason: "Should orphan if management policies are enabled and deletion policy is not set and management policy does not have action Delete.",
+			args: args{
+				managementPoliciesEnabled: true,
+				managed: &fake.LegacyManaged{
+					Manageable: fake.Manageable{
+						Policy: xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
 					},
 				},
 			},

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -1741,6 +1741,45 @@ func TestModernReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{Requeue: true}},
 		},
+		"ManagementPolicyOrphanCreateSuccessful": {
+			reason: "Successful managed resource creation using management policy Orphan should trigger a requeue after a short wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asModernManaged(obj, 42)
+							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newModernManaged(42)
+							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							meta.SetExternalCreatePending(want, time.Now())
+							meta.SetExternalCreateSucceeded(want, time.Now())
+							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+								reason := "Successful managed resource creation should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(&NopConnector{}),
+					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}},
+		},
 		"ManagementPolicyCreateCreateSuccessful": {
 			reason: "Successful managed resource creation using management policy Create should trigger a requeue after a short wait.",
 			args: args{
@@ -1841,6 +1880,53 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "A successful managed resource update should be reported as a conditioned status."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+							return nil
+						}),
+					},
+					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+							},
+							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
+								return ExternalUpdate{}, nil
+							},
+							DisconnectFn: func(_ context.Context) error {
+								return nil
+							},
+						}
+						return c, nil
+					})),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
+		},
+		"ManagementPolicyOrphanUpdateSuccessful": {
+			reason: "A successful managed resource update using management policy Orphan should trigger a requeue after a long wait.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asModernManaged(obj, 42)
+							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
+							return nil
+						}),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newModernManaged(42)
+							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionOrphan})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
@@ -2181,6 +2267,14 @@ func TestManagementPoliciesResolverShouldCreate(t *testing.T) {
 			},
 			want: true,
 		},
+		"ManagementPoliciesEnabledHasCreateOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
+		},
 		"ManagementPoliciesEnabledActionNotAllowed": {
 			reason: "Should return false if management policies are enabled and managementPolicies does not have Create",
 			args: args{
@@ -2242,6 +2336,14 @@ func TestManagementPoliciesResolverShouldUpdate(t *testing.T) {
 			},
 			want: false,
 		},
+		"ManagementPoliciesEnabledHasUpdateOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -2294,6 +2396,14 @@ func TestManagementPoliciesResolverShouldLateInitialize(t *testing.T) {
 				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionObserve},
 			},
 			want: false,
+		},
+		"ManagementPoliciesEnabledHasLateInitializeOrphan": {
+			reason: "Should return true if management policies are enabled and managementPolicies has action Orphan",
+			args: args{
+				managementPoliciesEnabled: true,
+				policy:                    xpv1.ManagementPolicies{xpv1.ManagementActionOrphan},
+			},
+			want: true,
 		},
 	}
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes

Added an Orphan management policy value which maps to ['Observe', 'Create', 'Update', 'LateInitialize'] in order to simplify the migration from `deletionPolicy` to `managementPolicies` and facilitate controlled orphaning of resources.

Fixes #6694 (Crossplane) 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
