### PR TITLE
Fix npe in reconciler

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1107,9 +1107,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 			record.Event(managed, event.Warning(reasonCannotDisconnect, err))
 		}
 
-		if err := external.Disconnect(ctx); err != nil {
-			log.Debug("Cannot disconnect from provider", "error", err)
-			record.Event(managed, event.Warning(reasonCannotDisconnect, err))
+		if external != nil {
+			if err := external.Disconnect(ctx); err != nil {
+				log.Debug("Cannot disconnect from provider", "error", err)
+				record.Event(managed, event.Warning(reasonCannotDisconnect, err))
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

The problem is that when r.external.Connect(externalCtx, managed) fails at line 1086, the code returns early at line 1102, but the defer function at line 1105 still executes. However, since the Connect call failed, the external variable was ever properly assigned a valid value, so it's nil.

 When the defer function tries to call external.Disconnect(ctx) at line 1111, it's trying to call a method on a nil pointer, causing the panic.

```
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1395160, 0x259ae40})
        k8s.io/apimachinery@v0.30.0/pkg/util/runtime/runtime.go:75 +0x7c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:103 +0xa4
panic({0x1395160?, 0x259ae40?})
        runtime/panic.go:770 +0x124
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.ExternalClientFns.Disconnect(...)
        github.com/crossplane/crossplane-runtime@v1.17.0/pkg/reconciler/managed/reconciler.go:387
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile.func2()
        github.com/crossplane/crossplane-runtime@v1.17.0/pkg/reconciler/managed/reconciler.go:967 +0x1e8
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0x400033f560, {0x18964c8, 0x40007c5c20}, {{{0x0, 0x0}, {0x40006fa940, 0x3d}}})
        github.com/crossplane/crossplane-runtime@v1.17.0/pkg/reconciler/managed/reconciler.go:1253 +0x758c
github.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile(0x400016a690, {0x18964c8, 0x40007c5c20}, {{{0x0?, 0x400015dca8?}, {0x40006fa940?, 0x400015dd08?}}})
        github.com/crossplane/crossplane-runtime@v1.17.0/pkg/ratelimiter/reconciler.go:54 +0x124
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x189ab10?, {0x18964c8?, 0x40007c5c20?}, {{{0x0?, 0xb?}, {0x40006fa940?, 0x0?}}})
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:114 +0x8c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x400014e4d0, {0x1896500, 0x4000149d10}, {0x141fb40, 0x40000b2140})
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:311 +0x2dc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x400014e4d0, {0x1896500, 0x4000149d10})
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:261 +0x16c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:222 +0x74
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 99
        sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:218 +0x3bc
```

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
