### PR TITLE
fix : Add Groups filter to CustomResourceDefinition reconciler

### DIFF
--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -77,6 +77,11 @@ type Options struct {
 
 	// EventFilterFunctions used to filter events emitted by the controllers.
 	EventFilterFunctions []event.FilterFn
+
+	// Groups is the list of API groups managed by this provider.
+	// If specified, the CRD gate will only watch CRDs belonging to these groups,
+	// reducing unnecessary reconciles from unrelated CRDs in the cluster.
+	Groups []string
 }
 
 // ForControllerRuntime extracts options for controller-runtime.

--- a/pkg/reconciler/customresourcesgate/reconciler_test.go
+++ b/pkg/reconciler/customresourcesgate/reconciler_test.go
@@ -23,10 +23,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -556,6 +559,88 @@ func TestReconcile(t *testing.T) {
 				if diff := cmp.Diff(tc.want.falseCalls, tc.fields.gate.FalseCalls); diff != "" {
 					t.Errorf("\n%s\ngate.False calls: -want, +got:\n%s", tc.reason, diff)
 				}
+			}
+		})
+	}
+}
+
+func TestGroupPredicate(t *testing.T) {
+	type args struct {
+		groups []string
+		obj    client.Object
+	}
+	type want struct {
+		match bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"CRDGroupPresent": {
+			reason: "CRD is present in the specified groups, predicate should return true",
+			args: args{
+				groups: []string{"example.com"},
+				obj: &apiextensionsv1.CustomResourceDefinition{
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Group: "example.com",
+					},
+				},
+			},
+			want: want{
+				match: true,
+			},
+		},
+		"CRDGroupAbsent": {
+			reason: "CRD is not present in the specified groups, predicate should return false",
+			args: args{
+				groups: []string{"example.com"},
+				obj: &apiextensionsv1.CustomResourceDefinition{
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Group: "other.com",
+					},
+				},
+			},
+			want: want{
+				match: false,
+			},
+		},
+		"EmptyGroups": {
+			reason: "No groups specified, predicate should return false for any CRD",
+			args: args{
+				groups: []string{},
+				obj: &apiextensionsv1.CustomResourceDefinition{
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Group: "example.com",
+					},
+				},
+			},
+			want: want{
+				match: false,
+			},
+		},
+		"NonCRDObject": {
+			reason: "Object is not a CRD, predicate should return false",
+			args: args{
+				groups: []string{"example.com"},
+				obj:    &corev1.ConfigMap{},
+			},
+			want: want{
+				match: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GroupPredicate(tc.args.groups...)
+			ev := event.GenericEvent{
+				Object: tc.args.obj,
+			}
+			match := got.Generic(ev)
+			if match != tc.want.match {
+				t.Errorf("\n%s\nGroupPredicate(...): -want match, +got match:\n%s", tc.reason, cmp.Diff(tc.want.match, match))
 			}
 		})
 	}

--- a/pkg/reconciler/customresourcesgate/setup.go
+++ b/pkg/reconciler/customresourcesgate/setup.go
@@ -22,6 +22,8 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
@@ -38,9 +40,29 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		log:  o.Logger,
 		gate: o.Gate,
 	}
-
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&apiextensionsv1.CustomResourceDefinition{}).
-		Named("crd-gate").
-		Complete(reconcile.AsReconciler[*apiextensionsv1.CustomResourceDefinition](mgr.GetClient(), r))
+		Named("crd-gate")
+
+	if len(o.Groups) > 0 {
+		b = b.WithEventFilter(GroupPredicate(o.Groups...))
+	}
+
+	return b.Complete(reconcile.AsReconciler[*apiextensionsv1.CustomResourceDefinition](mgr.GetClient(), r))
+}
+
+// GroupPredicate returns a predicate that filters CustomResourceDefinitions by group.
+func GroupPredicate(groups ...string) predicate.Predicate {
+	groupSet := make(map[string]struct{})
+	for _, g := range groups {
+		groupSet[g] = struct{}{}
+	}
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return false
+		}
+		_, ok = groupSet[crd.Spec.Group]
+		return ok
+	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Fixes #910 

**What this  fix does?**
The `customresourcesgate` reconciler was watching all CRDs cluster-wide with no filtering. This caused unnecessary reconcile cycles whenever any CRD event occurred — including CRDs from unrelated providers like cert-manager, flux, or other Crossplane providers installed in the same cluster.

**Fix**
Adds a `Groups []string` field to controller.Options. When set, the CRD gate controller applies a predicate that filters watch events to only CRDs belonging to the specified API groups.

**Note**
Provider authors need to populate Groups in their main.go. upjet-based providers can be fixed upstream in code generation in a follow-up PR.


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Docs tracking issue: [1067](https://github.com/crossplane/docs/issues/1067)

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
- [X] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
