### PR TITLE
Fix renovate-nix.json5 preset and validate presets in CI

### DIFF
--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -25,7 +25,7 @@
       matchBaseBranches: [
         'main',
         // Release 2.2 and newer use nix.
-        '/'^release-2\.([2-9]|..+)$/',
+        '/^release-2\.([2-9]|..+)$/',
       ],
       postUpgradeTasks: {
         commands: [
@@ -46,7 +46,7 @@
       matchBaseBranches: [
         'main',
         // Release 2.2 and newer use nix.
-        '/'^release-2\.([2-9]|..+)$/',
+        '/^release-2\.([2-9]|..+)$/',
       ],
       postUpgradeTasks: {
         commands: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,26 @@ jobs:
       - name: Verify Generated Code
         run: nix build .#checks.x86_64-linux.generate --print-build-logs
 
+  validate-renovate-config:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # renovate-config-validator only looks at the top-level file and does
+      # not recursively resolve local> presets, so we also syntax-check every
+      # renovate*.json5 with the json5 CLI to catch preset parse errors at
+      # PR time rather than 24h later in the scheduled Renovate job.
+      - name: Validate Renovate preset syntax
+        run: |
+          for f in .github/renovate*.json5; do
+            npx --yes json5 "$f" > /dev/null
+          done
+
+      - name: Validate Renovate JSON
+        run: npx --yes --package renovate -- renovate-config-validator
+
   lint:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,9 +24,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Don't waste time starting Renovate if JSON is invalid
+      # Don't waste time starting Renovate if any preset is unparseable.
+      # renovate-config-validator only looks at the top-level file and does
+      # not recursively resolve local> presets, so we also syntax-check every
+      # renovate*.json5 with the json5 CLI.
+      - name: Validate Renovate preset syntax
+        run: |
+          for f in .github/renovate*.json5; do
+            npx --yes json5 "$f" > /dev/null
+          done
+
       - name: Validate Renovate JSON
-        run:  npx --yes --package renovate -- renovate-config-validator
+        run: npx --yes --package renovate -- renovate-config-validator
 
       - name: Get token
         id: get-github-app-token


### PR DESCRIPTION
### Description of your changes

The `renovate-nix.json5` preset had a stray single quote inside two `matchBaseBranches` regex strings: `'/'^release-2\.([2-9]|..+)$/'`. That extra quote terminated the JSON5 string early and made the preset unparseable, so every Renovate run fails during preset resolution with:

```
ERROR: config-presets-invalid
  "validationError": "Preset is invalid JSON (local>crossplane/crossplane-runtime//.github/renovate-nix.json5)"
FATAL: Unknown error
```

See run https://github.com/crossplane/crossplane-runtime/actions/runs/24445182474/job/71419602985.

Because preset resolution happens before any package is evaluated, Renovate has been unable to open, rebase, or close any PRs since the preset was introduced in f1a70c6 ("renovate: Use nix for v2.2 and newer release branches"). Fixing the string to `'/^release-2\.([2-9]|..+)$/'` restores the intended regex and matches the equivalent pattern in crossplane/crossplane's config.

The typo only exists on `main`; the `release-2.2` copy of this preset does not yet have the release-branch regex, so no backport is needed.

#### Why CI didn't catch it

The existing `renovate-config-validator` pre-step has two gaps:

1. It only validates the top-level `.github/renovate.json5` and does not recursively resolve `local>` presets, so JSON5 syntax errors in `renovate-nix.json5`, `renovate-earthly.json5`, or `renovate-base.json5` are invisible to it.
2. It only runs inside the scheduled Renovate workflow, so a broken preset lands in `main` and is only caught 24h later by the cron.

This PR closes both gaps by adding a `json5` CLI syntax check for every `.github/renovate*.json5`:

- In `renovate.yml` before starting the Renovate job, so the scheduled run fails fast instead of going through Docker pull + Earthly/Nix bootstrap only to die in preset resolution.
- In a new `validate-renovate-config` job in `ci.yml`, so preset parse errors are blocked at PR review time.

I reintroduced the typo locally to confirm the new `json5` step exits non-zero on the broken file, and confirmed it exits zero after the fix.

The same gaps exist in `crossplane/crossplane`; I can follow up with an equivalent PR there if this approach looks right.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet