### PR TITLE
[Backport release-1.20] ci: drop trivy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,28 +145,6 @@ jobs:
           sarif_file: '_output/codeql/go.sarif'
 
 
-  trivy-scan-fs:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Run Trivy vulnerability scanner in fs mode
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
-        with:
-          scan-type: 'fs'
-          ignore-unfixed: true
-          skip-dirs: design
-          scan-ref: '.'
-          severity: 'CRITICAL,HIGH'
-          format: sarif
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy Results to GitHub
-        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-
   unit-tests:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
### Description of your changes

Backport of #943 to `release-1.20`.

The `trivy-action` has been compromised twice, most recently with credential exfiltration from CI runners ([aquasecurity/trivy-action#541](https://github.com/aquasecurity/trivy-action/issues/541)). This removes the `trivy-scan-fs` job from CI, mirroring the equivalent backports on crossplane/crossplane (crossplane/crossplane#7238, crossplane/crossplane#7299, crossplane/crossplane#7300, crossplane/crossplane#7301).

Opened manually because the parent PR #943 has been open but unmerged for a few weeks; these backports can be reviewed and merged independently.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet