### PR TITLE
[Backport release-2.2] ci: drop trivy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,28 +82,6 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
 
-  trivy-scan-fs:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run Trivy vulnerability scanner in fs mode
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-        with:
-          scan-type: 'fs'
-          ignore-unfixed: true
-          skip-dirs: design
-          scan-ref: '.'
-          severity: 'CRITICAL,HIGH'
-          format: sarif
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy Results to GitHub
-        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-
   unit-tests:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
### Description of your changes

Backport of #943 to `release-2.2`.

The `trivy-action` has been compromised twice, most recently with credential exfiltration from CI runners ([aquasecurity/trivy-action#541](https://github.com/aquasecurity/trivy-action/issues/541)). This removes the `trivy-scan-fs` job from CI, mirroring the equivalent backports on crossplane/crossplane (crossplane/crossplane#7238, crossplane/crossplane#7299, crossplane/crossplane#7300, crossplane/crossplane#7301).

Opened manually because the parent PR #943 has been open but unmerged for a few weeks; these backports can be reviewed and merged independently.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet