### PR TITLE
chore(deps): bump Go to 1.25.9 [security]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,10 +56,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     # TODO(negz): Unpin once https://github.com/nix-community/gomod2nix/pull/231 is released.
     gomod2nix = {
@@ -18,6 +19,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       gomod2nix,
     }:
     let
@@ -37,7 +39,13 @@
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ gomod2nix.overlays.default ];
+            overlays = [
+              gomod2nix.overlays.default
+              (_final: _prev: {
+                go = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+                inherit (nixpkgs-unstable.legacyPackages.${system}) go_1_25;
+              })
+            ];
           };
         };
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane-runtime/v2
 
-go 1.25.5
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
### Description of your changes

Mirrors crossplane/crossplane#7306 for crossplane-runtime.

`govulncheck` reports ten reachable stdlib vulnerabilities on `main` with
the current Go 1.25.5 toolchain, spanning `crypto/x509`, `crypto/tls`,
`html/template`, `archive/tar`, `net/url` and `os`. All are fixed in Go
1.25.9.

Since the pinned `nixos-25.11` revision only exposes Go 1.25.5, this PR
adds a dedicated `nixpkgs-unstable` input and overlays `pkgs.go` and
`pkgs.go_1_25` with unstable's `go_1_25` (1.25.9). The `go_1_25`
override is needed so `gomod2nix.buildGoApplication` can find a Go
toolchain satisfying `go.mod`'s minimum.

Re-running `govulncheck ./...` with the new toolchain reports "No
vulnerabilities found".

#### Differences from crossplane/crossplane#7306

- No `apis/go.mod` to bump — crossplane-runtime has a single module.
- The overlay uses `inherit (…) go_1_25;` and `_final: _prev:` to pass
  `statix check` and `deadnix --fail` in the `nix-lint` flake check.
  These lints aren't wired into crossplane's CI upstream, so the
  original PR's naive form merged without issue; here they would fail
  `nix flake check` locally.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Note: `release-2.1`, `release-2.0` and `release-1.20` still use Earthly,
so they need to be handled separately rather than via auto-backport.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute