### PR TITLE
fix(deps): update semver to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	dario.cat/mergo v1.0.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/crossplane/crossplane/apis/v2 v2.0.0-20260407152912-8f8e265fb638
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/Azure/go-autorest/tracing v0.6.1 h1:YUMSrC/CeD1ZnnXcNYU4a/fzsO35u2Fsf
 github.com/Azure/go-autorest/tracing v0.6.1/go.mod h1:/3EgjbsjraOqiicERAeu3m7/z0x1TzjQGAwDrJrXGkc=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -40,9 +40,9 @@ schema = 3
   [mod."github.com/Azure/go-autorest/tracing"]
     version = "v0.6.1"
     hash = "sha256-nstDZC8Btx78yzqIR4clfu+R93rebUOZalEW1ZaQfIY="
-  [mod."github.com/Masterminds/semver"]
-    version = "v1.5.0"
-    hash = "sha256-3fEInOXFdzCiGdDZ1s9otEes7VXiL8Q1RVB3zXRPJsQ="
+  [mod."github.com/Masterminds/semver/v3"]
+    version = "v3.4.0"
+    hash = "sha256-75kRraVwYVjYLWZvuSlts4Iu28Eh3SpiF0GHc7vCYHI="
   [mod."github.com/antlr4-go/antlr/v4"]
     version = "v4.13.1"
     hash = "sha256-beAuxHNRUuhzcSJUh/8ztVf1zCUiaT72fg2Jvx0AuNQ="

--- a/pkg/version/fake/mocks.go
+++ b/pkg/version/fake/mocks.go
@@ -18,7 +18,7 @@ limitations under the License.
 package fake
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/version"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ limitations under the License.
 package version
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 var version string

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -69,7 +68,6 @@ func TestInRange(t *testing.T) {
 			},
 			want: want{
 				err: errors.New("invalid semantic version"),
-				err: semver.ErrInvalidSemVer
 			},
 		},
 		"InvalidRange": {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -80,6 +80,36 @@ func TestInRange(t *testing.T) {
 				err: errors.New("improper constraint: >a2"),
 			},
 		},
+		"ValidSpaceSeparatedRange": {
+			reason: "Should return true if version is within a valid space separated ranged constraint",
+			args: args{
+				version: "v1.13.0",
+				r:       ">=v2.0.0 <v5.0.0",
+			},
+			want: want{
+				is: true,
+			},
+		},
+		"CommaSeparatedRangedConstraint": {
+			reason: "Should return true if version is within a valid comma-separated ranged constraint",
+			args: args{
+				version: "v1.13.0",
+				r:       ">=v2.0.0,<v5.0.0",
+			},
+			want: want{
+				is: true,
+			},
+		},
+		"InvalidSpaceSeparatedRange": {
+			reason: "Should return error if the ranged constraint is invalid",
+			args: args{
+				version: "v1.13.0",
+				r:       ">=v2.0.0 >v5.0.0",
+			},
+			want: want{
+				err: errors.New("improper constraint: >=v2.0.0 >v5.0.0"),
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -68,6 +69,7 @@ func TestInRange(t *testing.T) {
 			},
 			want: want{
 				err: errors.New("invalid semantic version"),
+				err: semver.ErrInvalidSemVer
 			},
 		},
 		"InvalidRange": {
@@ -90,7 +92,7 @@ func TestInRange(t *testing.T) {
 				is: true,
 			},
 		},
-		"CommaSeparatedRangedConstraint": {
+		"ValidCommaSeparatedRangedConstraint": {
 			reason: "Should return true if version is within a valid comma-separated ranged constraint",
 			args: args{
 				version: "v2.13.0",

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -67,7 +67,7 @@ func TestInRange(t *testing.T) {
 				version: "v0a.13.0",
 			},
 			want: want{
-				err: errors.New("Invalid Semantic Version"),
+				err: errors.New("invalid semantic version"),
 			},
 		},
 		"InvalidRange": {
@@ -83,7 +83,7 @@ func TestInRange(t *testing.T) {
 		"ValidSpaceSeparatedRange": {
 			reason: "Should return true if version is within a valid space separated ranged constraint",
 			args: args{
-				version: "v1.13.0",
+				version: "v2.13.0",
 				r:       ">=v2.0.0 <v5.0.0",
 			},
 			want: want{
@@ -93,7 +93,7 @@ func TestInRange(t *testing.T) {
 		"CommaSeparatedRangedConstraint": {
 			reason: "Should return true if version is within a valid comma-separated ranged constraint",
 			args: args{
-				version: "v1.13.0",
+				version: "v2.13.0",
 				r:       ">=v2.0.0,<v5.0.0",
 			},
 			want: want{
@@ -104,10 +104,10 @@ func TestInRange(t *testing.T) {
 			reason: "Should return error if the ranged constraint is invalid",
 			args: args{
 				version: "v1.13.0",
-				r:       ">=v2.0.0 >v5.0.0",
+				r:       ">=v2.0.0 >v5a.0.0",
 			},
 			want: want{
-				err: errors.New("improper constraint: >=v2.0.0 >v5.0.0"),
+				err: errors.New("improper constraint: >=v2.0.0 >v5a.0.0"),
 			},
 		},
 	}

--- a/pkg/xpkg/client.go
+++ b/pkg/xpkg/client.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
 	ociname "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"

--- a/pkg/xpkg/lint.go
+++ b/pkg/xpkg/lint.go
@@ -17,7 +17,7 @@ limitations under the License.
 package xpkg
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
 	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	v2 "github.com/crossplane/crossplane/apis/v2/apiextensions/v2"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Updates semver package to v3.
This adds support for properly detecting comma/space separated version constraint ranges - added test cases for this.

The casing in semver error messages has [changed](https://github.com/Masterminds/semver/commit/a2cd9c2c2e49a0a0af115a08be31d410eacdf9e4), which required me to also fix the "invalid semantic version"-test.


Background: Based on feedback in https://github.com/crossplane/crossplane/pull/7050, I started to look if i can reuse pkg/xpkg, and see that this update would be needed anyway.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
