### PR TITLE
chore(deps): bump Go to 1.25.9 [security] (release-2.0)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane-runtime
 
-ARG --global GO_VERSION=1.24.4
+ARG --global GO_VERSION=1.25.9
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.
@@ -102,7 +102,7 @@ go-test:
 
 # go-lint lints Go code.
 go-lint:
-  ARG GOLANGCI_LINT_VERSION=v2.2.1
+  ARG GOLANGCI_LINT_VERSION=v2.11.4
   FROM +go-modules
   # This cache is private because golangci-lint doesn't support concurrent runs.
   CACHE --id go-lint --sharing private /root/.cache/golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane-runtime/v2
 
-go 1.24.0
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.1

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -18,6 +18,8 @@ limitations under the License.
 package event
 
 import (
+	"maps"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -107,9 +109,7 @@ func (r *APIRecorder) Event(obj runtime.Object, e Event) {
 // annotations with all recorded events.
 func (r *APIRecorder) WithAnnotations(keysAndValues ...string) Recorder {
 	ar := NewAPIRecorder(r.kube)
-	for k, v := range r.annotations {
-		ar.annotations[k] = v
-	}
+	maps.Copy(ar.annotations, r.annotations)
 
 	sliceMap(keysAndValues, ar.annotations)
 

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package event records Kubernetes events.
 package event
 
 import (

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -79,13 +79,13 @@ func (sg Segments) String() string {
 		switch s.Type {
 		case SegmentField:
 			if s.Field == wildcard || strings.ContainsRune(s.Field, period) {
-				b.WriteString(fmt.Sprintf("[%s]", s.Field))
+				fmt.Fprintf(&b, "[%s]", s.Field)
 				continue
 			}
 
-			b.WriteString(fmt.Sprintf(".%s", s.Field))
+			fmt.Fprintf(&b, ".%s", s.Field)
 		case SegmentIndex:
-			b.WriteString(fmt.Sprintf("[%d]", s.Index))
+			fmt.Fprintf(&b, "[%d]", s.Index)
 		}
 	}
 

--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -326,6 +326,7 @@ func (p *Paved) GetStringObject(path string) (map[string]string, error) {
 	}
 
 	so := make(map[string]string)
+
 	for k, in := range o {
 		s, ok := in.(string)
 		if !ok {

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -740,6 +740,7 @@ func TestSetValue(t *testing.T) {
 						res := make([]any, DefaultMaxFieldPathIndex+2)
 						res[0] = "a"
 						res[DefaultMaxFieldPathIndex+1] = "c"
+
 						return res
 					}(),
 				},

--- a/pkg/logging/klog.go
+++ b/pkg/logging/klog.go
@@ -31,7 +31,7 @@ type requestThrottlingFilter struct {
 	logr.LogSink
 }
 
-func (l *requestThrottlingFilter) Info(level int, msg string, keysAndValues ...interface{}) {
+func (l *requestThrottlingFilter) Info(level int, msg string, keysAndValues ...any) {
 	if !strings.Contains(msg, "Waited for ") || !strings.Contains(msg, "  request: ") {
 		return
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -18,6 +18,8 @@ limitations under the License.
 package meta
 
 import (
+	"maps"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +67,7 @@ const (
 
 // ReferenceTo returns an object reference to the supplied object, presumed to
 // be of the supplied group, version, and kind.
+//
 // Deprecated: use a more specific reference type, such as TypedReference or
 // Reference instead of the overly verbose ObjectReference.
 // See https://github.com/crossplane/crossplane-runtime/issues/49
@@ -166,10 +169,8 @@ func AddControllerReference(o metav1.Object, r metav1.OwnerReference) error {
 // AddFinalizer to the supplied Kubernetes object's metadata.
 func AddFinalizer(o metav1.Object, finalizer string) {
 	f := o.GetFinalizers()
-	for _, e := range f {
-		if e == finalizer {
-			return
-		}
+	if slices.Contains(f, finalizer) {
+		return
 	}
 
 	o.SetFinalizers(append(f, finalizer))
@@ -190,13 +191,7 @@ func RemoveFinalizer(o metav1.Object, finalizer string) {
 // FinalizerExists checks whether given finalizer is already set.
 func FinalizerExists(o metav1.Object, finalizer string) bool {
 	f := o.GetFinalizers()
-	for _, e := range f {
-		if e == finalizer {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(f, finalizer)
 }
 
 // AddLabels to the supplied object.
@@ -207,9 +202,7 @@ func AddLabels(o metav1.Object, labels map[string]string) {
 		return
 	}
 
-	for k, v := range labels {
-		l[k] = v
-	}
+	maps.Copy(l, labels)
 
 	o.SetLabels(l)
 }
@@ -236,9 +229,7 @@ func AddAnnotations(o metav1.Object, annotations map[string]string) {
 		return
 	}
 
-	for k, v := range annotations {
-		a[k] = v
-	}
+	maps.Copy(a, annotations)
 
 	o.SetAnnotations(a)
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1087,6 +1087,7 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 					o := &corev1.Pod{}
 					t := time.Now().Add(-2 * time.Minute)
 					SetExternalCreateSucceeded(o, t)
+
 					return o
 				}(),
 				d: 1 * time.Minute,
@@ -1099,6 +1100,7 @@ func TestExternalCreateSucceededDuring(t *testing.T) {
 					o := &corev1.Pod{}
 					t := time.Now().Add(-30 * time.Second)
 					SetExternalCreateSucceeded(o, t)
+
 					return o
 				}(),
 				d: 1 * time.Minute,
@@ -1196,6 +1198,7 @@ func TestIsPaused(t *testing.T) {
 				p.SetAnnotations(map[string]string{
 					AnnotationKeyReconciliationPaused: "true",
 				})
+
 				return p
 			}(),
 			want: true,
@@ -1210,6 +1213,7 @@ func TestIsPaused(t *testing.T) {
 				p.SetAnnotations(map[string]string{
 					AnnotationKeyReconciliationPaused: "",
 				})
+
 				return p
 			}(),
 			want: false,

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -154,7 +154,7 @@ func (p *PackageParser) Parse(_ context.Context, reader io.ReadCloser) (*Package
 // is useful for filtering out empty YAML documents that would otherwise
 // cause issues when decoded.
 func isEmptyYAML(y []byte) bool {
-	for _, line := range strings.Split(string(y), "\n") {
+	for line := range strings.SplitSeq(string(y), "\n") {
 		trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
 		// We don't want to return an empty document with only separators that
 		// have nothing in-between.

--- a/pkg/ratelimiter/reconciler_test.go
+++ b/pkg/ratelimiter/reconciler_test.go
@@ -83,6 +83,7 @@ func TestReconcile(t *testing.T) {
 				// Rate limit the request once.
 				r := NewReconciler("test", inner, &predictableRateLimiter{d: 8 * time.Second})
 				r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "limited"}})
+
 				return r
 			}(),
 			args: args{

--- a/pkg/reconciler/managed/api_test.go
+++ b/pkg/reconciler/managed/api_test.go
@@ -142,7 +142,7 @@ func TestAPISecretPublisher(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.LegacyManaged
+		mg  resource.LegacyManaged //nolint:staticcheck // Tests need to cover the legacy managed path.
 		c   ConnectionDetails
 	}
 
@@ -183,12 +183,14 @@ func TestAPISecretPublisher(t *testing.T) {
 			fields: fields{
 				secret: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
 					want := resource.ConnectionSecretFor(mg, fake.GVK(mg))
+
 					want.Data = cd
 					for _, fn := range ao {
 						if err := fn(ctx, o, want); err != nil {
 							return err
 						}
 					}
+
 					return nil
 				}),
 				typer: fake.SchemeWith(&fake.LegacyManaged{}),
@@ -208,10 +210,12 @@ func TestAPISecretPublisher(t *testing.T) {
 			fields: fields{
 				secret: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 					want := resource.ConnectionSecretFor(mg, fake.GVK(mg))
+
 					want.Data = cd
 					if diff := cmp.Diff(want, o); diff != "" {
 						t.Errorf("-want, +got:\n%s", diff)
 					}
+
 					return nil
 				}),
 				typer: fake.SchemeWith(&fake.LegacyManaged{}),
@@ -302,12 +306,14 @@ func TestAPILocalSecretPublisher(t *testing.T) {
 			fields: fields{
 				secret: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
 					want := resource.LocalConnectionSecretFor(mg, fake.GVK(mg))
+
 					want.Data = cd
 					for _, fn := range ao {
 						if err := fn(ctx, o, want); err != nil {
 							return err
 						}
 					}
+
 					return nil
 				}),
 				typer: fake.SchemeWith(&fake.ModernManaged{}),
@@ -327,10 +333,12 @@ func TestAPILocalSecretPublisher(t *testing.T) {
 			fields: fields{
 				secret: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 					want := resource.LocalConnectionSecretFor(mg, fake.GVK(mg))
+
 					want.Data = cd
 					if diff := cmp.Diff(want, o); diff != "" {
 						t.Errorf("-want, +got:\n%s", diff)
 					}
+
 					return nil
 				}),
 				typer: fake.SchemeWith(&fake.ModernManaged{}),

--- a/pkg/reconciler/managed/changelogger_test.go
+++ b/pkg/reconciler/managed/changelogger_test.go
@@ -181,7 +181,7 @@ func equateApproxTimepb(margin time.Duration) []cmp.Option {
 		protocmp.Transform(),
 		cmp.FilterPath(
 			func(p cmp.Path) bool {
-				if p.Last().Type() == reflect.TypeOf(protocmp.Message{}) {
+				if p.Last().Type() == reflect.TypeFor[protocmp.Message]() {
 					a, b := p.Last().Values()
 					return msgIsTimestamp(a) && msgIsTimestamp(b)
 				}

--- a/pkg/reconciler/managed/policies.go
+++ b/pkg/reconciler/managed/policies.go
@@ -34,6 +34,7 @@ type ManagementPoliciesResolver struct {
 
 // LegacyManagementPoliciesResolver is used to perform management policy checks
 // based on the management policy and if the management policy feature is enabled.
+//
 // Deprecated: this is for LegacyManaged types, that had deletion policy.
 // ModernManaged resources should use ManagementPoliciesResolver.
 type LegacyManagementPoliciesResolver struct {
@@ -129,6 +130,7 @@ func NewManagementPoliciesResolver(managementPolicyEnabled bool, managementPolic
 // NewLegacyManagementPoliciesResolver returns an ManagementPolicyChecker based
 // on the management policies and if the management policies feature
 // is enabled.
+//
 // Deprecated: this is intended for LegacyManaged resources that had deletionPolicy
 // ModernManaged resources should use NewManagementPoliciesResolver.
 func NewLegacyManagementPoliciesResolver(managementPolicyEnabled bool, managementPolicy xpv1.ManagementPolicies, deletionPolicy xpv1.DeletionPolicy, o ...ManagementPoliciesResolverOption) ManagementPoliciesChecker {

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -926,7 +926,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	var policy ManagementPoliciesChecker
 
 	switch mg := managed.(type) {
-	case resource.LegacyManaged:
+	case resource.LegacyManaged: //nolint:staticcheck // Intentional branch for legacy managed resources.
 		policy = NewLegacyManagementPoliciesResolver(managementPoliciesEnabled, mg.GetManagementPolicies(), mg.GetDeletionPolicy(), WithSupportedManagementPolicies(r.supportedManagementPolicies))
 	default:
 		policy = NewManagementPoliciesResolver(managementPoliciesEnabled, managed.GetManagementPolicies(), WithSupportedManagementPolicies(r.supportedManagementPolicies))

--- a/pkg/reconciler/managed/reconciler_deprecated.go
+++ b/pkg/reconciler/managed/reconciler_deprecated.go
@@ -23,10 +23,12 @@ import (
 )
 
 // ExternalConnecter an alias to ExternalConnector.
+//
 // Deprecated: use ExternalConnector.
 type ExternalConnecter = ExternalConnector
 
 // TypedExternalConnecter an alias to TypedExternalConnector.
+//
 // Deprecated: use TypedExternalConnector.
 type TypedExternalConnecter[managed resource.Managed] interface {
 	TypedExternalConnector[managed]
@@ -54,6 +56,7 @@ type ExternalDisconnecter interface {
 }
 
 // NopDisconnecter aliases NopDisconnector.
+//
 // Deprecated: Use NopDisconnector.
 type NopDisconnecter = NopDisconnector
 
@@ -63,24 +66,29 @@ type NopDisconnecter = NopDisconnector
 // type TypedExternalConnectDisconnecterFns[managed resource.Managed] =  TypedExternalConnectDisconnectorFns[managed]
 
 // NewNopDisconnecter an alias to NewNopDisconnector.
+//
 // Deprecated: use NewNopDisconnector.
 func NewNopDisconnecter(c ExternalConnector) ExternalConnectDisconnector {
 	return NewNopDisconnector(c)
 }
 
 // ExternalDisconnecterFn aliases ExternalDisconnectorFn.
+//
 // Deprecated: use ExternalDisconnectorFn.
 type ExternalDisconnecterFn = ExternalDisconnectorFn
 
 // ExternalConnectDisconnecterFns aliases ExternalConnectDisconnectorFns.
+//
 // Deprecated: use ExternalConnectDisconnectorFns.
 type ExternalConnectDisconnecterFns = ExternalConnectDisconnectorFns
 
 // NopConnecter aliases NopConnector.
+//
 // Deprecated: use NopConnector.
 type NopConnecter = NopConnector
 
 // WithExternalConnecter aliases WithExternalConnector.
+//
 // Deprecated: use WithExternalConnector.
 func WithExternalConnecter(c ExternalConnector) ReconcilerOption {
 	return WithExternalConnector(c)
@@ -97,6 +105,7 @@ func WithExternalConnectDisconnector(c ExternalConnectDisconnector) ReconcilerOp
 }
 
 // WithExternalConnectDisconnecter aliases WithExternalConnectDisconnector.
+//
 // Deprecated: Please use Disconnect() on the ExternalClient for disconnecting from the provider.
 func WithExternalConnectDisconnecter(c ExternalConnectDisconnector) ReconcilerOption {
 	return func(r *Reconciler) {
@@ -115,6 +124,7 @@ func WithTypedExternalConnectDisconnector[managed resource.Managed](c TypedExter
 }
 
 // WithTypedExternalConnectDisconnecter aliases WithTypedExternalConnectDisconnector.
+//
 // Deprecated: Please use Disconnect() on the ExternalClient for disconnecting from the provider.
 func WithTypedExternalConnectDisconnecter[managed resource.Managed](c TypedExternalConnectDisconnector[managed]) ReconcilerOption {
 	return func(r *Reconciler) {

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -95,6 +95,7 @@ func TestReconciler(t *testing.T) {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetDeletionPolicy(xpv1.DeletionOrphan)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -103,10 +104,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionPolicy(xpv1.DeletionOrphan)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors unpublishing connection details should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -130,6 +133,7 @@ func TestReconciler(t *testing.T) {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetDeletionPolicy(xpv1.DeletionOrphan)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -138,10 +142,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionPolicy(xpv1.DeletionOrphan)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors removing the managed resource finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -163,6 +169,7 @@ func TestReconciler(t *testing.T) {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetDeletionPolicy(xpv1.DeletionOrphan)
+
 							return nil
 						}),
 					},
@@ -184,10 +191,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors initializing the managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -212,6 +221,7 @@ func TestReconciler(t *testing.T) {
 							mg.SetDeletionTimestamp(&now)
 							mg.SetDeletionPolicy(xpv1.DeletionDelete)
 							mg.SetFinalizers([]string{FinalizerName, "finalizer2"})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -231,6 +241,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -245,6 +256,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							asLegacyManaged(obj, 42)
 							meta.SetExternalCreatePending(obj, now.Time)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -253,10 +265,12 @@ func TestReconciler(t *testing.T) {
 							want.SetConditions(
 								xpv1.Creating().WithObservedGeneration(42),
 								xpv1.ReconcileError(errors.New(errCreateIncomplete)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "We should update our status when we're asked to reconcile a managed resource that is pending creation."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -278,10 +292,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors during reference resolution should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -306,10 +322,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileConnect)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
 								reason := "Errors connecting to the provider should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -334,10 +352,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful no-op reconcile should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -356,6 +376,7 @@ func TestReconciler(t *testing.T) {
 								return errBoom
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -372,10 +393,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileObserve)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors observing the managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -393,6 +416,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -424,6 +448,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -438,6 +463,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -445,10 +471,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileDelete)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "An error deleting an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -470,6 +498,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -484,6 +513,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -491,10 +521,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A deleted external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -516,6 +548,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -530,6 +563,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -537,10 +571,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors unpublishing connection details should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -559,6 +595,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withConnectionPublishers(ConnectionPublisherFns{
@@ -576,6 +613,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -583,10 +621,12 @@ func TestReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors removing the managed resource finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -605,6 +645,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom }}),
@@ -620,6 +661,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 					},
@@ -638,6 +680,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -654,10 +697,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -686,10 +731,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors adding a finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -718,10 +765,12 @@ func TestReconciler(t *testing.T) {
 							want.SetConditions(
 								xpv1.Creating().WithObservedGeneration(42),
 								xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManaged)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -743,6 +792,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -763,10 +813,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateFailed(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileCreate)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -788,6 +840,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					// We simulate our critical annotation update failing too here.
@@ -811,10 +864,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManagedAnnotations)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors updating critical annotations after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -836,6 +891,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -857,10 +913,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors publishing connection details after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -883,6 +941,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
@@ -894,6 +953,7 @@ func TestReconciler(t *testing.T) {
 							if _, ok := cd["create"]; ok {
 								return false, errBoom
 							}
+
 							return true, nil
 						},
 					}),
@@ -915,10 +975,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status." //nolint:goconst // used only in tests
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -943,6 +1005,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							asLegacyManaged(obj, 42)
 							meta.SetExternalCreatePending(obj, now.Time)
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -952,10 +1015,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -983,10 +1048,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManaged)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors updating a managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1005,6 +1072,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1021,10 +1089,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful no-op reconcile should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1043,6 +1113,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1075,6 +1146,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1088,6 +1160,7 @@ func TestReconciler(t *testing.T) {
 					if diff < 0 {
 						diff = -diff
 					}
+
 					return diff < time.Second
 				})},
 			},
@@ -1117,6 +1190,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1154,6 +1228,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1179,10 +1254,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileUpdate)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors while updating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1204,6 +1281,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1220,10 +1298,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after an update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1246,6 +1326,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withConnectionPublishers(ConnectionPublisherFns{
@@ -1256,6 +1337,7 @@ func TestReconciler(t *testing.T) {
 							if _, ok := cd["update"]; ok {
 								return false, errBoom
 							}
+
 							return false, nil
 						},
 					}),
@@ -1273,10 +1355,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status." //nolint:goconst // used only in tests
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1298,6 +1382,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1314,10 +1399,12 @@ func TestReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1339,6 +1426,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1356,16 +1444,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 							want.SetConditions(xpv1.ReconcilePaused().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has the pause annotation with value "true", it should acquire "Synced" status condition with the status "False" and the reason "ReconcilePaused".`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1383,16 +1474,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{})
 							want.SetConditions(xpv1.ReconcilePaused().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has the pause annotation with value "true", it should acquire "Synced" status condition with the status "False" and the reason "ReconcilePaused".`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1416,16 +1510,19 @@ func TestReconciler(t *testing.T) {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "false"})
 							mg.SetConditions(xpv1.ReconcilePaused())
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "false"})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `Managed resource should acquire Synced=False/ReconcileSuccess status condition after a resume.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1444,6 +1541,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1459,6 +1557,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -1479,16 +1578,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNonDefault, xpv1.ManagementPolicies{xpv1.ManagementActionCreate})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has a non default management policy but feature not enabled, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1506,16 +1608,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNotSupported, xpv1.ManagementPolicies{xpv1.ManagementActionCreate})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has non supported management policy, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1536,16 +1641,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNotSupported, xpv1.ManagementPolicies{xpv1.ManagementActionAll})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has non supported management policy, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1567,16 +1675,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errors.New(errExternalResourceNotExist), errReconcileObserve)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Resource does not exist should be reported as a conditioned status when ObserveOnly."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1595,6 +1706,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -1609,16 +1721,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1637,6 +1752,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withConnectionPublishers(ConnectionPublisherFns{
@@ -1656,16 +1772,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "With ObserveOnly, a successful managed resource observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1684,6 +1803,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withConnectionPublishers(ConnectionPublisherFns{
@@ -1704,6 +1824,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -1714,10 +1835,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1743,6 +1866,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -1753,10 +1877,12 @@ func TestReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1782,6 +1908,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
@@ -1789,10 +1916,12 @@ func TestReconciler(t *testing.T) {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `Managed resource should acquire Synced=False/ReconcileSuccess status condition.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1815,6 +1944,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1830,16 +1960,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1862,6 +1995,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1877,16 +2011,19 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1909,6 +2046,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1924,6 +2062,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
@@ -1931,10 +2070,12 @@ func TestReconciler(t *testing.T) {
 							want := newLegacyManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors updating a managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1954,6 +2095,7 @@ func TestReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1969,6 +2111,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asLegacyManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -1998,6 +2141,7 @@ func TestReconciler(t *testing.T) {
 								xpv1.ManagementActionUpdate,
 								xpv1.ManagementActionLateInitialize,
 							})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -2348,7 +2492,7 @@ func TestLegacyManagementPoliciesResolverOnlyObserve(t *testing.T) {
 func TestLegacyShouldDelete(t *testing.T) {
 	type args struct {
 		managementPoliciesEnabled bool
-		managed                   resource.LegacyManaged
+		managed                   resource.LegacyManaged //nolint:staticcheck // Tests need to cover the legacy managed path.
 	}
 
 	type want struct {
@@ -2518,6 +2662,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2556,6 +2701,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2593,6 +2739,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2631,6 +2778,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2651,6 +2799,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 							// set a deletion timestamp, which should trigger a delete operation
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockUpdate:       test.NewMockUpdateFn(nil),
@@ -2673,6 +2822,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2693,6 +2843,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 							// set a deletion timestamp, which should trigger a delete operation
 							mg := asLegacyManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockUpdate:       test.NewMockUpdateFn(nil),
@@ -2716,6 +2867,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -95,6 +95,7 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionCreate, xpv1.ManagementActionUpdate, xpv1.ManagementActionLateInitialize})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -103,10 +104,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionCreate, xpv1.ManagementActionUpdate, xpv1.ManagementActionLateInitialize})
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors unpublishing connection details should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -133,6 +136,7 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionCreate, xpv1.ManagementActionUpdate, xpv1.ManagementActionLateInitialize})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -141,10 +145,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionCreate, xpv1.ManagementActionUpdate, xpv1.ManagementActionLateInitialize})
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors removing the managed resource finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -167,6 +173,7 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 					},
@@ -189,10 +196,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors initializing the managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -216,6 +225,7 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetFinalizers([]string{FinalizerName, "finalizer2"})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -235,6 +245,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -249,6 +260,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							asModernManaged(obj, 42)
 							meta.SetExternalCreatePending(obj, now.Time)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -257,10 +269,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetConditions(
 								xpv1.Creating().WithObservedGeneration(42),
 								xpv1.ReconcileError(errors.New(errCreateIncomplete)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "We should update our status when we're asked to reconcile a managed resource that is pending creation."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -282,10 +296,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors during reference resolution should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -310,10 +326,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileConnect)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
 								reason := "Errors connecting to the provider should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -338,10 +356,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful no-op reconcile should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -360,6 +380,7 @@ func TestModernReconciler(t *testing.T) {
 								return errBoom
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -376,10 +397,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileObserve)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors observing the managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -397,6 +420,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -428,6 +452,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -442,6 +467,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -449,10 +475,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileDelete)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "An error deleting an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -474,6 +502,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -488,6 +517,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -495,10 +525,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A deleted external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -520,6 +552,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -534,6 +567,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -541,10 +575,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors unpublishing connection details should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -563,6 +599,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withLocalConnectionPublishers(LocalConnectionPublisherFns{
@@ -582,6 +619,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -589,10 +627,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetDeletionTimestamp(&now)
 							want.SetConditions(xpv1.Deleting().WithObservedGeneration(42))
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors removing the managed resource finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -611,6 +651,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom }}),
@@ -626,6 +667,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 					},
@@ -644,6 +686,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -660,10 +703,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -692,10 +737,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors adding a finalizer should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -724,10 +771,12 @@ func TestModernReconciler(t *testing.T) {
 							want.SetConditions(
 								xpv1.Creating().WithObservedGeneration(42),
 								xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManaged)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -749,6 +798,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -769,10 +819,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateFailed(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileCreate)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -794,6 +846,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					// We simulate our critical annotation update failing too here.
@@ -817,10 +870,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManagedAnnotations)).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors updating critical annotations after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -842,6 +897,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -863,10 +919,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Errors publishing connection details after creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -889,6 +947,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithCriticalAnnotationUpdater(CriticalAnnotationUpdateFn(func(_ context.Context, _ client.Object) error { return nil })),
@@ -900,6 +959,7 @@ func TestModernReconciler(t *testing.T) {
 							if _, ok := cd["create"]; ok {
 								return false, errBoom
 							}
+
 							return true, nil
 						},
 					}),
@@ -921,10 +981,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -949,6 +1011,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							asModernManaged(obj, 42)
 							meta.SetExternalCreatePending(obj, now.Time)
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -958,10 +1021,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -989,10 +1054,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errUpdateManaged)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors updating a managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1011,6 +1078,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1027,10 +1095,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful no-op reconcile should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1049,6 +1119,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1081,6 +1152,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1094,6 +1166,7 @@ func TestModernReconciler(t *testing.T) {
 					if diff < 0 {
 						diff = -diff
 					}
+
 					return diff < time.Second
 				})},
 			},
@@ -1123,6 +1196,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1160,6 +1234,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1185,10 +1260,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errReconcileUpdate)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors while updating an external resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1210,6 +1287,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1226,10 +1304,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after an update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1252,6 +1332,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withLocalConnectionPublishers(LocalConnectionPublisherFns{
@@ -1262,6 +1343,7 @@ func TestModernReconciler(t *testing.T) {
 							if _, ok := cd["update"]; ok {
 								return false, errBoom
 							}
+
 							return false, nil
 						},
 					}),
@@ -1279,10 +1361,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1304,6 +1388,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1320,10 +1405,12 @@ func TestModernReconciler(t *testing.T) {
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1345,6 +1432,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1362,16 +1450,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 							want.SetConditions(xpv1.ReconcilePaused().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has the pause annotation with value "true", it should acquire "Synced" status condition with the status "False" and the reason "ReconcilePaused".`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1389,16 +1480,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{})
 							want.SetConditions(xpv1.ReconcilePaused().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has the pause annotation with value "true", it should acquire "Synced" status condition with the status "False" and the reason "ReconcilePaused".`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1422,16 +1516,19 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "false"})
 							mg.SetConditions(xpv1.ReconcilePaused())
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "false"})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `Managed resource should acquire Synced=False/ReconcileSuccess status condition after a resume.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1450,6 +1547,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1465,6 +1563,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
@@ -1485,16 +1584,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNonDefault, xpv1.ManagementPolicies{xpv1.ManagementActionCreate})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has a non default management policy but feature not enabled, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1512,16 +1614,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionCreate})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNotSupported, xpv1.ManagementPolicies{xpv1.ManagementActionCreate})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has non supported management policy, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1542,16 +1647,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileError(fmt.Errorf(errFmtManagementPolicyNotSupported, xpv1.ManagementPolicies{xpv1.ManagementActionAll})).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `If managed resource has non supported management policy, it should return a proper error.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1573,16 +1681,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileError(errors.Wrap(errors.New(errExternalResourceNotExist), errReconcileObserve)).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Resource does not exist should be reported as a conditioned status when ObserveOnly."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1601,6 +1712,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -1615,16 +1727,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileError(errBoom).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1643,6 +1758,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withLocalConnectionPublishers(LocalConnectionPublisherFns{
@@ -1662,16 +1778,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "With ObserveOnly, a successful managed resource observation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1690,6 +1809,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					withLocalConnectionPublishers(LocalConnectionPublisherFns{
@@ -1710,6 +1830,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -1720,10 +1841,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1749,6 +1872,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -1759,10 +1883,12 @@ func TestModernReconciler(t *testing.T) {
 							meta.SetExternalCreateSucceeded(want, time.Now())
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
 							want.SetConditions(xpv1.Creating().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions(), cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1788,6 +1914,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
@@ -1795,10 +1922,12 @@ func TestModernReconciler(t *testing.T) {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := `Managed resource should acquire Synced=False/ReconcileSuccess status condition.`
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1821,6 +1950,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1836,16 +1966,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42).WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1868,6 +2001,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1883,16 +2017,19 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
+
 							return nil
 						}),
 						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionAll})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1915,6 +2052,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1930,6 +2068,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
@@ -1937,10 +2076,12 @@ func TestModernReconciler(t *testing.T) {
 							want := newModernManaged(42)
 							want.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionDelete})
 							want.SetConditions(xpv1.ReconcileSuccess().WithObservedGeneration(42))
+
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors updating a managed resource should be reported as a conditioned status."
 								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
 							}
+
 							return nil
 						}),
 					},
@@ -1960,6 +2101,7 @@ func TestModernReconciler(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
@@ -1975,6 +2117,7 @@ func TestModernReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							mg := asModernManaged(obj, 42)
 							mg.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve, xpv1.ManagementActionLateInitialize})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -2004,6 +2147,7 @@ func TestModernReconciler(t *testing.T) {
 								xpv1.ManagementActionUpdate,
 								xpv1.ManagementActionLateInitialize,
 							})
+
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -2469,6 +2613,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2507,6 +2652,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2544,6 +2690,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2582,6 +2729,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2602,6 +2750,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 							// set a deletion timestamp, which should trigger a delete operation
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockUpdate:       test.NewMockUpdateFn(nil),
@@ -2624,6 +2773,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},
@@ -2644,6 +2794,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 							// set a deletion timestamp, which should trigger a delete operation
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockUpdate:       test.NewMockUpdateFn(nil),
@@ -2667,6 +2818,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 								return nil
 							},
 						}
+
 						return c, nil
 					})),
 				},

--- a/pkg/reconciler/providerconfig/reconciler.go
+++ b/pkg/reconciler/providerconfig/reconciler.go
@@ -120,7 +120,7 @@ func NewReconciler(m manager.Manager, of resource.ProviderConfigKinds, o ...Reco
 		//nolint:forcetypeassert // If this isn't a ProviderConfigUsage it's a programming error and we want to panic.
 		return resource.MustCreateObject(of.UsageList, m.GetScheme()).(resource.ProviderConfigUsageList)
 	}
-	_, isLegacyPCU := resource.MustCreateObject(of.Usage, m.GetScheme()).(resource.LegacyProviderConfigUsage)
+	_, isLegacyPCU := resource.MustCreateObject(of.Usage, m.GetScheme()).(resource.LegacyProviderConfigUsage) //nolint:staticcheck // Intentional type check to route to the legacy PCU path.
 
 	// Panic early if we've been asked to reconcile a resource kind that has not
 	// been registered with our controller manager's scheme.

--- a/pkg/reconciler/providerconfig/reconciler_test.go
+++ b/pkg/reconciler/providerconfig/reconciler_test.go
@@ -157,6 +157,7 @@ func TestReconciler(t *testing.T) {
 							l.Items = []resource.ProviderConfigUsage{
 								&fake.ProviderConfigUsage{},
 							}
+
 							return nil
 						}),
 						MockDelete: test.NewMockDeleteFn(errBoom),
@@ -182,6 +183,7 @@ func TestReconciler(t *testing.T) {
 							pc := obj.(*fake.ProviderConfig)
 							pc.SetDeletionTimestamp(&now)
 							pc.SetUID(uid)
+
 							return nil
 						}),
 						MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
@@ -196,6 +198,7 @@ func TestReconciler(t *testing.T) {
 									},
 								},
 							}
+
 							return nil
 						}),
 						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
@@ -220,6 +223,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							pc := obj.(*fake.ProviderConfig)
 							pc.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockList:   test.NewMockListFn(nil),
@@ -245,6 +249,7 @@ func TestReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 							pc := obj.(*fake.ProviderConfig)
 							pc.SetDeletionTimestamp(&now)
+
 							return nil
 						}),
 						MockList:   test.NewMockListFn(nil),

--- a/pkg/reference/namespaced_reference.go
+++ b/pkg/reference/namespaced_reference.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package reference contains utilities for working with cross-resource
-// references.
 package reference
 
 import (

--- a/pkg/reference/namespaced_reference_test.go
+++ b/pkg/reference/namespaced_reference_test.go
@@ -203,6 +203,7 @@ func TestNamespacedResolve(t *testing.T) {
 					}
 
 					t.Errorf("Resolve did not infer to the MR namespace: %v", key)
+
 					return errBoom
 				},
 			},
@@ -236,6 +237,7 @@ func TestNamespacedResolve(t *testing.T) {
 					}
 
 					t.Errorf("Resolve did not infer to the other namespace: %v", key)
+
 					return errBoom
 				},
 			},
@@ -624,6 +626,7 @@ func TestNamespacedResolveMultiple(t *testing.T) {
 					}
 
 					t.Errorf("Resolve did not infer to the MR namespace: %v", key)
+
 					return errBoom
 				},
 			},
@@ -652,6 +655,7 @@ func TestNamespacedResolveMultiple(t *testing.T) {
 					}
 
 					t.Errorf("Resolve did not infer to the MR namespace: %v", key)
+
 					return errBoom
 				},
 			},
@@ -685,6 +689,7 @@ func TestNamespacedResolveMultiple(t *testing.T) {
 					}
 
 					t.Errorf("Resolve did not infer to the MR namespace: %v", key)
+
 					return errBoom
 				},
 			},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -258,6 +258,7 @@ func TestAPIUpdatingApplicator(t *testing.T) {
 					if diff := cmp.Diff(*desired, *o.(*object)); diff != "" {
 						t.Errorf("r: -want, +got:\n%s", diff)
 					}
+
 					return nil
 				}),
 			},

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -215,6 +215,7 @@ type ModernManaged interface {
 // A LegacyManaged is a cluster-scoped Kubernetes object representing a
 // concrete managed resource, with namespaced connection secret referencers
 // and untyped provider config reference.
+//
 // Deprecated: new namespace-scoped MRs should implement ModernManaged.
 type LegacyManaged interface {
 	Managed
@@ -232,6 +233,7 @@ type ManagedList interface {
 }
 
 // A LegacyManagedList is a list of managed resources.
+//
 // Deprecated: new types should implement ManagedList.
 type LegacyManagedList interface {
 	client.ObjectList
@@ -263,6 +265,7 @@ type TypedProviderConfigUsage interface {
 
 // A LegacyProviderConfigUsage is a ProviderConfigUsage that
 // has an untyped reference to a provider config.
+//
 // Deprecated: new PCUs should implement TypedProviderConfigUsage.
 type LegacyProviderConfigUsage interface {
 	ProviderConfigUsage

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"maps"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -25,12 +27,14 @@ import (
 )
 
 // A PredicateFn returns true if the supplied object should be reconciled.
+//
 // Deprecated: This type will be removed soon. Please use
 // controller-runtime's predicate.NewPredicateFuncs instead.
 type PredicateFn func(obj runtime.Object) bool
 
 // NewPredicates returns a set of Funcs that are all satisfied by the supplied
 // PredicateFn. The PredicateFn is run against the new object during updates.
+//
 // Deprecated: This function will be removed soon. Please use
 // controller-runtime's predicate.NewPredicateFuncs instead.
 func NewPredicates(fn PredicateFn) predicate.Funcs {
@@ -78,9 +82,7 @@ type AnnotationChangedPredicate struct {
 
 func copyAnnotations(an map[string]string) map[string]string {
 	r := make(map[string]string, len(an))
-	for k, v := range an {
-		r[k] = v
-	}
+	maps.Copy(r, an)
 
 	return r
 }

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -67,6 +67,7 @@ func TestDesiredStateChanged(t *testing.T) {
 				new: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetConditions(runtimev1.ReconcileSuccess())
+
 					return mg
 				}(),
 			},
@@ -83,6 +84,7 @@ func TestDesiredStateChanged(t *testing.T) {
 				new: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetAnnotations(map[string]string{meta.AnnotationKeyExternalCreatePending: time.Now().String()})
+
 					return mg
 				}(),
 			},
@@ -99,6 +101,7 @@ func TestDesiredStateChanged(t *testing.T) {
 				new: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetAnnotations(map[string]string{"foo": "bar"})
+
 					return mg
 				}(),
 			},
@@ -115,6 +118,7 @@ func TestDesiredStateChanged(t *testing.T) {
 				new: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetLabels(map[string]string{"foo": "bar"})
+
 					return mg
 				}(),
 			},
@@ -128,11 +132,13 @@ func TestDesiredStateChanged(t *testing.T) {
 				old: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetGeneration(1)
+
 					return mg
 				}(),
 				new: func() client.Object {
 					mg := &fake.Managed{}
 					mg.SetGeneration(2)
+
 					return mg
 				}(),
 			},

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -175,6 +175,7 @@ func TestExtractSecret(t *testing.T) {
 						s.Data = map[string][]byte{
 							"creds": credentials,
 						}
+
 						return nil
 					}),
 				},
@@ -286,6 +287,7 @@ func TestTrackLegacy(t *testing.T) {
 							return err
 						}
 					}
+
 					return errBoom
 				}),
 				of: &fake.LegacyProviderConfigUsage{},
@@ -380,6 +382,7 @@ func TestTrackModern(t *testing.T) {
 							return err
 						}
 					}
+
 					return errBoom
 				}),
 				of: &fake.ProviderConfigUsage{},

--- a/pkg/resource/unstructured/client_test.go
+++ b/pkg/resource/unstructured/client_test.go
@@ -90,6 +90,7 @@ func TestGet(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -99,6 +100,7 @@ func TestGet(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -134,6 +136,7 @@ func TestList(t *testing.T) {
 				if u.GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrappedList()},
@@ -144,6 +147,7 @@ func TestList(t *testing.T) {
 				if u.GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrappedList()},
@@ -178,6 +182,7 @@ func TestCreate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -187,6 +192,7 @@ func TestCreate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -221,6 +227,7 @@ func TestDelete(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -230,6 +237,7 @@ func TestDelete(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -264,6 +272,7 @@ func TestUpdate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -273,6 +282,7 @@ func TestUpdate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -308,6 +318,7 @@ func TestPatch(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -317,6 +328,7 @@ func TestPatch(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -351,6 +363,7 @@ func TestDeleteAllOf(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -360,6 +373,7 @@ func TestDeleteAllOf(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -395,6 +409,7 @@ func TestStatusCreate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -404,6 +419,7 @@ func TestStatusCreate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -438,6 +454,7 @@ func TestStatusUpdate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -447,6 +464,7 @@ func TestStatusUpdate(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},
@@ -482,6 +500,7 @@ func TestStatusPatch(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameUnwrapped {
 					return errWrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewUnwrapped()},
@@ -491,6 +510,7 @@ func TestStatusPatch(t *testing.T) {
 				if obj.(metav1.Object).GetName() != nameWrapped {
 					return errUnwrapped
 				}
+
 				return nil
 			})},
 			args: args{obj: NewWrapped()},


### PR DESCRIPTION
### Description of your changes

Mirrors #961 for release-2.0, adapted for Earthly.

`govulncheck` reports 5 reachable stdlib vulnerabilities on this branch
with the current Go 1.24.4 toolchain:

| ID | Package |
|---|---|
| GO-2026-4947 | crypto/x509 (chain-building DoS) |
| GO-2026-4946 | crypto/x509 (policy validation) |
| GO-2026-4870 | crypto/tls (KeyUpdate DoS) |
| GO-2026-4865 | html/template (XSS) |
| GO-2026-4601 | net/url |

Go 1.24 went end-of-life on 2026-02-10 (when 1.26.0 shipped) and did
not receive the April 2026 security batch — those fixes only landed in
1.25.9 and 1.26.2. The latest 1.24 release (1.24.13, 2026-02-04) does
not resolve these, so this PR does a minor version bump to 1.25.9
rather than a patch bump.

This differs from crossplane's release-2.0 bump
(crossplane/crossplane#7304), which was patch-level (1.25.6 → 1.25.9)
because that branch was already on the 1.25 line.

### Commits

1. **Bump Go to 1.25.9 to fix stdlib CVEs** —
   Earthfile \`GO_VERSION=1.24.4 → 1.25.9\`, \`go.mod\` \`go 1.24.0 →
   1.25.9\`, and golangci-lint \`v2.2.1 → v2.11.4\` (v2.2.1 was built
   with Go 1.24 and refuses to lint \`go 1.25.9\` targets).

2. **Apply golangci-lint v2.11.4 compliance fixes** — bumping
   golangci-lint surfaces new checks against existing code. Resolved
   in a single pass:
   - *gocritic deprecatedComment:* inserts a blank line between the
     description paragraph and \`// Deprecated:\` notices so they form
     a dedicated paragraph.
   - *godoclint package-godoc duplication:* removes the duplicate
     \`// Package X\` comment from \`event_test.go\` and
     \`namespaced_reference.go\`; the canonical comment stays on the
     package's primary file.
   - *staticcheck SA1019:* adds targeted \`//nolint:staticcheck\`
     comments on the legitimate internal uses of the now-properly-marked
     deprecated types.
   - *\`golangci-lint run --fix\` auto-fixes:* modernises a number of
     idioms enabled by the Go 1.25 bump (\`interface{}\` → \`any\`,
     \`strings.Split\` → \`strings.SplitSeq\`, small whitespace
     adjustments). Earthfile's \`+lint\` target saves these back to
     the tree, so they have to land on disk or \`check-diff\` flags
     the difference.

### Downstream impact

Bumping the \`go\` directive in \`go.mod\` to 1.25.9 forces consumers
of release-2.0 to Go ≥ 1.25. If that's too disruptive for a patch
release, we can drop the \`go.mod\` change (and the golangci-lint bump,
which only becomes necessary because of it); our CI binaries would
still pick up the Go fixes, but consumers would need to upgrade their
own toolchain to actually benefit.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`earthly +reviewable\` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added \`backport release-x.y\` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing