### PR TITLE
chore(deps): bump Go to 1.25.9 [security] (release-1.20)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane-runtime
 
-ARG --global GO_VERSION=1.23.7
+ARG --global GO_VERSION=1.25.9
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crossplane/crossplane-runtime
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
### Description of your changes

Mirrors #961 for release-1.20, adapted for Earthly.

`govulncheck` reports 5 reachable stdlib vulnerabilities on this branch
with the current Go 1.23.7 toolchain (same CVE set as release-2.0 and
release-2.1):

| ID | Package |
|---|---|
| GO-2026-4947 | crypto/x509 (chain-building DoS) |
| GO-2026-4946 | crypto/x509 (policy validation) |
| GO-2026-4870 | crypto/tls (KeyUpdate DoS) |
| GO-2026-4865 | html/template (XSS) |
| GO-2026-4601 | net/url |

Both Go 1.23 and Go 1.24 went end-of-life before the April 2026
security batch (1.23 EOL: 2025-08-12 when 1.25.0 shipped; 1.24 EOL:
2026-02-10 when 1.26.0 shipped). The latest 1.23 release (1.23.12)
does not contain these fixes and none will be backported. Fixing them
requires moving off the 1.23 line entirely.

This PR therefore jumps straight to Go 1.25.9 — a two-minor bump —
updating both the Earthfile toolchain and the \`go.mod\` directive.
The now-redundant \`toolchain go1.23.7\` line is dropped.

Alternatives worth considering before merging:

- Is release-1.20 still receiving patches? If it's effectively
  archived, we could mark these CVEs as won't-fix on this branch.
- A smaller jump to Go 1.24.x would not help — also EOL, no CVE fixes.
- If a minor bump is too intrusive but the CVEs are a blocker, we
  could bump only \`Earthfile\`'s \`GO_VERSION\` and leave \`go.mod\`
  untouched, keeping library consumers unaffected.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`earthly +reviewable\` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added \`backport release-x.y\` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute