### PR TITLE
[Backport release-2.2] chore(deps): bump Go to 1.25.9 [security]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,10 +56,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     # TODO(negz): Unpin once https://github.com/nix-community/gomod2nix/pull/231 is released.
     gomod2nix = {
@@ -18,6 +19,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       gomod2nix,
     }:
     let
@@ -37,7 +39,13 @@
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ gomod2nix.overlays.default ];
+            overlays = [
+              gomod2nix.overlays.default
+              (_final: _prev: {
+                go = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+                inherit (nixpkgs-unstable.legacyPackages.${system}) go_1_25;
+              })
+            ];
           };
         };
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane-runtime/v2
 
-go 1.25.0
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Manual backport of #961 to \`release-2.2\`.

The auto-backport cherry-pick failed due to a trivial \`go.mod\`
conflict (release-2.2's \`go 1.25.0\` vs. main's \`go 1.25.5\`).
Resolved by taking the new value (\`go 1.25.9\`).

Changes are otherwise identical to #961:

- Adds \`nixpkgs-unstable\` input + overlay so \`pkgs.go\` and
  \`pkgs.go_1_25\` resolve to unstable's \`go_1_25\` (1.25.9).
- Bumps the \`go\` directive in \`go.mod\` to 1.25.9.

\`govulncheck ./...\` on this branch reports no vulnerabilities with
the new toolchain.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`./nix.sh flake check\` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added \`backport release-x.y\` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing