### PR TITLE
chore: bump actions/create-github-app-token to v3.1.1 for Node 24

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get token
         id: get-github-app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.RENOVATE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

GitHub Actions annotations flag the currently pinned `actions/create-github-app-token@v2` digest (`29824e69f54612133e76f7eaac726eef6c875baf`) as running on Node 20, which is deprecated.

This bumps the action to `v3.1.1`, the latest release, whose `action.yml` declares `using: node24`.

## Scope

- Only `main` is targeted. Backports to `release-*` branches, if needed, are handled by Renovate or dedicated PRs.

## Pin format

Preserves the repo convention of pinning to a full commit SHA with a `# v<version>` comment for Renovate:

- `actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1`