### PR TITLE
test: stabilize customresourcesgate TestReconcile

### DIFF
--- a/pkg/reconciler/customresourcesgate/reconciler_test.go
+++ b/pkg/reconciler/customresourcesgate/reconciler_test.go
@@ -533,23 +533,25 @@ func TestReconcile(t *testing.T) {
 
 			// Only check gate calls if gate is not nil
 			if tc.fields.gate != nil {
-				slices.SortFunc(tc.want.trueCalls, func(a, b schema.GroupVersionKind) int {
+				sortGVK := func(a, b schema.GroupVersionKind) int {
+					if c := strings.Compare(a.Group, b.Group); c != 0 {
+						return c
+					}
+					if c := strings.Compare(a.Version, b.Version); c != 0 {
+						return c
+					}
 					return strings.Compare(a.Kind, b.Kind)
-				})
-				slices.SortFunc(tc.fields.gate.TrueCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
+				}
+
+				slices.SortFunc(tc.want.trueCalls, sortGVK)
+				slices.SortFunc(tc.fields.gate.TrueCalls, sortGVK)
 
 				if diff := cmp.Diff(tc.want.trueCalls, tc.fields.gate.TrueCalls); diff != "" {
 					t.Errorf("\n%s\ngate.True calls: -want, +got:\n%s", tc.reason, diff)
 				}
 
-				slices.SortFunc(tc.want.falseCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
-				slices.SortFunc(tc.fields.gate.FalseCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
+				slices.SortFunc(tc.want.falseCalls, sortGVK)
+				slices.SortFunc(tc.fields.gate.FalseCalls, sortGVK)
 
 				if diff := cmp.Diff(tc.want.falseCalls, tc.fields.gate.FalseCalls); diff != "" {
 					t.Errorf("\n%s\ngate.False calls: -want, +got:\n%s", tc.reason, diff)


### PR DESCRIPTION
### Description of your changes

Fixes a flake in `TestReconcile/EstablishedCRDCallsGateTrue` (and other subtests with multi-version fixtures) in `pkg/reconciler/customresourcesgate`.

The test normaliser sorted recorded `gate.True` / `gate.False` calls by `GroupVersionKind.Kind` only. Several fixtures contain multiple GVKs that share the same `Kind` but differ in `Version` (e.g. `TestResource` at `v1alpha1` and `v1beta1`). Because the reconciler iterates a `map[schema.GroupVersionKind]bool` — whose iteration order is nondeterministic in Go — the resulting slice order is not stable, and the Kind-only sort cannot disambiguate entries, so the assertion becomes order-dependent and intermittently fails.

Sort on the full GVK (Group, Version, Kind) so the comparison is stable regardless of reconciler iteration order. This is a test-only change; reconciler behaviour is unchanged.

This has been blocking PRs #919 and #972 (and caused an unrelated flake observed in run #955, which predates the recent dep bumps).

This mirrors the fix already on `main` as part of 552d14c ("Upgrade controller-runtime to v0.21.0"), backported here for `release-2.0`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.

### How has this code been tested

Ran `go test -count=10 -race ./pkg/reconciler/customresourcesgate/...` and the full `TestReconcile/EstablishedCRDCallsGateTrue` subtest 10/10 times under `-race` — all passing.

[contribution process]: https://git.io/fj2m9