### PR TITLE
chore: bump Go toolchain to 1.24.13 on release-1.20

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane-runtime
 
-ARG --global GO_VERSION=1.23.7
+ARG --global GO_VERSION=1.24.13
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/crossplane/crossplane-runtime
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.13
 
 require (
 	dario.cat/mergo v1.0.1

--- a/pkg/parser/fuzz_test.go
+++ b/pkg/parser/fuzz_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"testing"
 
@@ -10,11 +9,11 @@ import (
 )
 
 func FuzzParse(f *testing.F) {
-	f.Fuzz(func(_ *testing.T, data []byte) {
+	f.Fuzz(func(t *testing.T, data []byte) {
 		objScheme := runtime.NewScheme()
 		metaScheme := runtime.NewScheme()
 		p := New(metaScheme, objScheme)
 		r := io.NopCloser(bytes.NewReader(data))
-		_, _ = p.Parse(context.Background(), r)
+		_, _ = p.Parse(t.Context(), r)
 	})
 }


### PR DESCRIPTION
### Description of your changes

Minimal Go-only bump on `release-1.20` to unblock the queued security
dependency updates. No code changes.

#### Why

The security bumps currently failing CI on this branch each declare
`go 1.24.0` in their own `go.mod`:

* #918 - `golang.org/x/net` -> `v0.45.0` (CVE-2025-47911 quadratic parsing
  DoS in `html.Parse`, CVE-2025-58190 infinite parsing loop; GitHub
  advisory confirms `first_patched_version: 0.45.0`, no usable
  intermediate version on the `go 1.23` line).
* #971 - `google.golang.org/grpc` -> `v1.79.3` (CVE-2026-33186 authorization
  bypass via missing leading slash in `:path`).

With `release-1.20` pinned at `go 1.23.0` / `toolchain go1.23.7` and
Earthly set to `GOTOOLCHAIN=local`, `go mod download` fails for both PRs
with:

    go.mod requires go >= 1.24.0 (running go 1.23.7; GOTOOLCHAIN=local)

which cascades to `unit-tests`, `lint`, `check-diff`, and `codeql`.

#### What

* `go.mod`: `go 1.23.0` -> `go 1.24.0`, `toolchain go1.23.7` -> `go1.24.13`
  (latest 1.24 patch).
* `Earthfile`: `GO_VERSION=1.23.7` -> `1.24.13`.

`go mod tidy` produces no dependency changes. `go build ./...` and
`go vet ./...` are clean on the branch.

#### Why 1.24 and not 1.25

An earlier attempt to bump to 1.25 on this branch (#965) was closed as
won't-fix because it required:

1. A `golangci-lint` v1 -> v2 migration (the pinned `v1.64.8` refuses
   to lint code declaring `go 1.25`).
2. Dependency updates to escape an `x/tools v0.24.0` incompatibility
   with Go 1.25 (`invalid array length -delta * delta`).

Staying on the 1.24 line avoids both. `golangci-lint v1.64.8` was built
against Go 1.24 and continues to work, and `x/tools v0.24.0` is
compatible with Go 1.24. The 5 reachable stdlib CVEs flagged on this
branch remain won't-fix (Go 1.24 is also EOL and does not backport
them); this PR is scoped strictly to unblocking the dep bumps above.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~ (local Earthly setup unavailable; CI will run it)
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute