### PR TITLE
test: stabilize customresourcesgate TestReconcile [release-2.1 backport]

### DIFF
--- a/pkg/reconciler/customresourcesgate/reconciler_test.go
+++ b/pkg/reconciler/customresourcesgate/reconciler_test.go
@@ -533,23 +533,25 @@ func TestReconcile(t *testing.T) {
 
 			// Only check gate calls if gate is not nil
 			if tc.fields.gate != nil {
-				slices.SortFunc(tc.want.trueCalls, func(a, b schema.GroupVersionKind) int {
+				sortGVK := func(a, b schema.GroupVersionKind) int {
+					if c := strings.Compare(a.Group, b.Group); c != 0 {
+						return c
+					}
+					if c := strings.Compare(a.Version, b.Version); c != 0 {
+						return c
+					}
 					return strings.Compare(a.Kind, b.Kind)
-				})
-				slices.SortFunc(tc.fields.gate.TrueCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
+				}
+
+				slices.SortFunc(tc.want.trueCalls, sortGVK)
+				slices.SortFunc(tc.fields.gate.TrueCalls, sortGVK)
 
 				if diff := cmp.Diff(tc.want.trueCalls, tc.fields.gate.TrueCalls); diff != "" {
 					t.Errorf("\n%s\ngate.True calls: -want, +got:\n%s", tc.reason, diff)
 				}
 
-				slices.SortFunc(tc.want.falseCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
-				slices.SortFunc(tc.fields.gate.FalseCalls, func(a, b schema.GroupVersionKind) int {
-					return strings.Compare(a.Kind, b.Kind)
-				})
+				slices.SortFunc(tc.want.falseCalls, sortGVK)
+				slices.SortFunc(tc.fields.gate.FalseCalls, sortGVK)
 
 				if diff := cmp.Diff(tc.want.falseCalls, tc.fields.gate.FalseCalls); diff != "" {
 					t.Errorf("\n%s\ngate.False calls: -want, +got:\n%s", tc.reason, diff)


### PR DESCRIPTION
Backports the flaky-test fix from `main` (originally part of 552d14c, "Upgrade controller-runtime to v0.21.0") to `release-2.1`.

The normaliser in `TestReconcile` sorted recorded `gate.True`/`gate.False` calls by `Kind` only. The `EstablishedCRDCallsGateTrue` fixture contains two GVKs with identical `Kind="TestResource"` differing only in `Version`, so the sort could not disambiguate them — combined with the reconciler's nondeterministic `map[schema.GroupVersionKind]bool` iteration, the assertion was order-dependent and flaked intermittently in CI (also flaked on unrelated runs before the current security-bump PRs).

Replaces the comparator with a full GVK sort (Group, Version, Kind), matching what `main` and `release-2.2` already have.

## Test plan
- \`go test -count=10 -race ./pkg/reconciler/customresourcesgate/...\` → 10/10 pass locally.