### PR TITLE
chore: bump Go to 1.25.10 and golangci-lint to v2.12.2 on release-1.20

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,11 @@
-run:
-  timeout: 10m
-  # Pin to go.mod's `go` directive. `toolchain` only swaps the Go binary
-  # (bumped for security patches); source semantics are still gated by
-  # `go`, so analyzing as 1.24 stays accurate. Without this, golangci-lint
-  # reads `toolchain` and errors when its own binary was built with older Go.
-  go: "1.24"
-
+version: "2"
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-    - format: colored-line-number
+    text:
       path: stderr
-
 linters:
-  enable-all: true
-  fast: false
-
+  default: all
   disable:
-    # These linters are all deprecated. We disable them explicitly to avoid the
-    # linter logging deprecation warnings.
-    - tenv
-
     # These are linters we'd like to enable, but that will be labor intensive to
     # make existing code compliant.
     - wrapcheck
@@ -28,6 +13,7 @@ linters:
     - testpackage
     - paralleltest
     - nilnil
+    - funcorder
 
     # Below are linters that lint for things we don't value. Each entry below
     # this line must have a comment explaining the rationale.
@@ -36,6 +22,7 @@ linters:
     # This isn't a widely accepted Go best practice, and would be laborious to
     # apply to existing code.
     - wsl
+    - wsl_v5
     - nlreturn
 
     # Warns about uses of fmt.Sprintf that are less performant than alternatives
@@ -102,213 +89,143 @@ linters:
     # numbers, but we should not be strict about it.
     - mnd
 
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: false
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-  govet:
-    # report about shadowed variables
-    disable:
-      - shadow
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-
-  gci:
-    custom-order: true
-    sections:
-      - standard
-      - default
-      - prefix(github.com/crossplane/crossplane-runtime)
-      - prefix(github.com/crossplane/crossplane)
-      - blank
-      - dot
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-
-  lll:
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    exported-is-used: true
-    exported-fields-are-used: true
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
-
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-
-    settings: # settings passed to gocritic
-      captLocal: # must be valid enabled check name
-        paramsOnly: true
-      rangeValCopy:
-        sizeThreshold: 32
-
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-
-  depguard:
-    rules:
-      no_third_party_test_libraries:
-        list-mode: lax
-        files:
-        - $test
-        deny:
-        - pkg: github.com/stretchr/testify
-          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
-        - pkg: github.com/onsi/ginkgo
-          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
-        - pkg: github.com/onsi/gomega
-          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
-
-  interfacebloat:
-    max: 5
-
-  tagliatelle:
-    case:
+    # Warns about if err := Foo(); err != nil style error checks. Seems to go
+    # against idiomatic Go programming, which encourages this approach - e.g.
+    # to scope errors.
+    - noinlineerr
+  settings:
+    depguard:
       rules:
-        json: goCamel
-
-  recvcheck:
-    exclusions:
-    - "*.DeepCopy" # DeepCopy* methods are generated and always use a pointer receiver, which may conflict with other methods for a given type.
-    - "*.DeepCopyInto"
-
+        no_third_party_test_libraries:
+          list-mode: lax
+          files:
+            - $test
+          deny:
+            - pkg: github.com/stretchr/testify
+              desc: See https://go.dev/wiki/TestComments#assert-libraries
+            - pkg: github.com/onsi/ginkgo
+              desc: See https://go.dev/wiki/TestComments#assert-libraries
+            - pkg: github.com/onsi/gomega
+              desc: See https://go.dev/wiki/TestComments#assert-libraries
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      enabled-tags:
+        - performance
+      settings:
+        captLocal:
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+    govet:
+      disable:
+        - shadow
+    interfacebloat:
+      max: 5
+    lll:
+      tab-width: 1
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+    recvcheck:
+      exclusions:
+        - '*.DeepCopy'
+        - '*.DeepCopyInto'
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+    unparam:
+      check-exported: false
+    unused:
+      exported-fields-are-used: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - containedctx
+          - embeddedstructfieldcheck
+          - errcheck
+          - forcetypeassert
+          - gochecknoglobals
+          - gochecknoinits
+          - gocognit
+          - goconst
+          - gosec
+          - scopelint
+          - unparam
+        path: _test(ing)?\.go
+      - linters:
+          - gocritic
+        path: _test\.go
+        text: (unnamedResult|exitAfterDefer)
+      - linters:
+          - gochecknoglobals
+          - gochecknoinits
+        path: apis/
+      - linters:
+          - gocritic
+        text: '(hugeParam|rangeValCopy):'
+      - linters:
+          - staticcheck
+        text: 'SA3000:'
+      - linters:
+          - gosec
+        text: 'G101:'
+      - linters:
+          - gosec
+        text: 'G104:'
+      - linters:
+          - gosec
+        text: 'G601:'
+      - linters:
+          - musttag
+        path: k8s.io/
+    paths:
+      - zz_generated\..+\.go$
+      - .+\.pb.go$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Excluding generated files.
-  exclude-files:
-  - "zz_generated\\..+\\.go$"
-  - ".+\\.pb.go$"
-  # Excluding configuration per-path and per-linter.
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test(ing)?\.go
-      linters:
-        - gocognit
-        - errcheck
-        - gosec
-        - scopelint
-        - unparam
-        - gochecknoinits
-        - gochecknoglobals
-        - containedctx
-        - forcetypeassert
-
-    # Ease some gocritic warnings on test files.
-    - path: _test\.go
-      text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
-
-    # It's idiomatic to register Kubernetes types with a package scoped
-    # SchemeBuilder using an init function.
-    - path: apis/
-      linters:
-      - gochecknoinits
-      - gochecknoglobals
-
-    # These are performance optimisations rather than style issues per se.
-    # They warn when function arguments or range values copy a lot of memory
-    # rather than using a pointer.
-    - text: "(hugeParam|rangeValCopy):"
-      linters:
-      - gocritic
-
-    # This "TestMain should call os.Exit to set exit code" warning is not clever
-    # enough to notice that we call a helper method that calls os.Exit.
-    - text: "SA3000:"
-      linters:
-      - staticcheck
-
-    - text: "k8s.io/api/core/v1"
-      linters:
-      - goimports
-
-    # This is a "potential hardcoded credentials" warning. It's triggered by
-    # any variable with 'secret' in the same, and thus hits a lot of false
-    # positives in Kubernetes land where a Secret is an object type.
-    - text: "G101:"
-      linters:
-      - gosec
-      - gas
-
-    # This is an 'errors unhandled' warning that duplicates errcheck.
-    - text: "G104:"
-      linters:
-      - gosec
-      - gas
-
-    # This is about implicit memory aliasing in a range loop.
-    # This is a false positive with Go v1.22 and above.
-    - text: "G601:"
-      linters:
-      - gosec
-      - gas
-
-    # Some k8s dependencies do not have JSON tags on all fields in structs.
-    - path: k8s.io/
-      linters:
-      - musttag
-
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing
-  # large codebase. It's not practical to fix all existing issues at the moment
-  # of integration: much better don't allow issues in new code.
-  # Default is false.
-  new: false
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+  new: false
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/crossplane/crossplane-runtime)
+        - prefix(github.com/crossplane/crossplane)
+        - blank
+        - dot
+      custom-order: true
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated\..+\.go$
+      - .+\.pb.go$
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,52 +108,77 @@ linters:
             - pkg: github.com/onsi/gomega
               desc: See https://go.dev/wiki/TestComments#assert-libraries
     dupl:
+      # tokens count to trigger issue, 150 by default
       threshold: 100
     errcheck:
+      # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+      # default is false: such cases aren't reported by default.
       check-type-assertions: false
+      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+      # default is false: such cases aren't reported by default.
       check-blank: false
     goconst:
+      # minimal length of string constant, 3 by default
       min-len: 3
+      # minimal occurrences count to trigger, 3 by default
       min-occurrences: 5
     gocritic:
+      # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
+      # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
       enabled-tags:
         - performance
-      settings:
-        captLocal:
+      settings: # settings passed to gocritic
+        captLocal: # must be valid enabled check name
           paramsOnly: true
         rangeValCopy:
           sizeThreshold: 32
     govet:
+      # report about shadowed variables
       disable:
         - shadow
     interfacebloat:
       max: 5
     lll:
+      # tab width in spaces. Default to 1.
       tab-width: 1
     nakedret:
+      # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
       max-func-lines: 30
     nolintlint:
       require-explanation: true
       require-specific: true
     prealloc:
+      # XXX: we don't recommend using this linter before doing performance profiling.
+      # For most programs usage of prealloc will be a premature optimization.
+
+      # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+      # True by default.
       simple: true
-      range-loops: true
-      for-loops: false
+      range-loops: true # Report preallocation suggestions on range loops, true by default
+      for-loops: false # Report preallocation suggestions on for loops, false by default
     recvcheck:
       exclusions:
-        - '*.DeepCopy'
+        - '*.DeepCopy' # DeepCopy* methods are generated and always use a pointer receiver, which may conflict with other methods for a given type.
         - '*.DeepCopyInto'
     tagliatelle:
       case:
         rules:
           json: goCamel
     unparam:
+      # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+      # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+      # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+      # with golangci-lint call it on a directory with the changed file.
       check-exported: false
     unused:
+      # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+      # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+      # with golangci-lint call it on a directory with the changed file.
       exported-fields-are-used: true
   exclusions:
     generated: lax
     rules:
+      # Exclude some linters from running on tests files.
       - linters:
           - containedctx
           - embeddedstructfieldcheck
@@ -167,29 +192,52 @@ linters:
           - scopelint
           - unparam
         path: _test(ing)?\.go
+
+      # Ease some gocritic warnings on test files.
       - linters:
           - gocritic
         path: _test\.go
         text: (unnamedResult|exitAfterDefer)
+
+      # It's idiomatic to register Kubernetes types with a package scoped
+      # SchemeBuilder using an init function.
       - linters:
           - gochecknoglobals
           - gochecknoinits
         path: apis/
+
+      # These are performance optimisations rather than style issues per se.
+      # They warn when function arguments or range values copy a lot of memory
+      # rather than using a pointer.
       - linters:
           - gocritic
         text: '(hugeParam|rangeValCopy):'
+
+      # This "TestMain should call os.Exit to set exit code" warning is not clever
+      # enough to notice that we call a helper method that calls os.Exit.
       - linters:
           - staticcheck
         text: 'SA3000:'
+
+      # This is a "potential hardcoded credentials" warning. It's triggered by
+      # any variable with 'secret' in the same, and thus hits a lot of false
+      # positives in Kubernetes land where a Secret is an object type.
       - linters:
           - gosec
         text: 'G101:'
+
+      # This is an 'errors unhandled' warning that duplicates errcheck.
       - linters:
           - gosec
         text: 'G104:'
+
+      # This is about implicit memory aliasing in a range loop.
+      # This is a false positive with Go v1.22 and above.
       - linters:
           - gosec
         text: 'G601:'
+
+      # Some k8s dependencies do not have JSON tags on all fields in structs.
       - linters:
           - musttag
         path: k8s.io/
@@ -200,8 +248,18 @@ linters:
       - builtin$
       - examples$
 issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing
+  # large codebase. It's not practical to fix all existing issues at the moment
+  # of integration: much better don't allow issues in new code.
+  # Default is false.
   new: false
 formatters:
   enable:
@@ -220,6 +278,7 @@ formatters:
         - dot
       custom-order: true
     gofmt:
+      # simplify code: gofmt with `-s` option, true by default
       simplify: true
   exclusions:
     generated: lax

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane-runtime
 
-ARG --global GO_VERSION=1.24.13
+ARG --global GO_VERSION=1.25.10
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.
@@ -102,12 +102,12 @@ go-test:
 
 # go-lint lints Go code.
 go-lint:
-  ARG GOLANGCI_LINT_VERSION=v1.64.8
+  ARG GOLANGCI_LINT_VERSION=v2.12.2
   FROM +go-modules
   # This cache is private because golangci-lint doesn't support concurrent runs.
   CACHE --id go-lint --sharing private /root/.cache/golangci-lint
   CACHE --id go-build --sharing shared /root/.cache/go-build
-  RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+  RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
   COPY .golangci.yml .
   COPY --dir apis/ pkg/ .
   RUN golangci-lint run --fix

--- a/apis/common/v1/connection_details.go
+++ b/apis/common/v1/connection_details.go
@@ -151,6 +151,7 @@ type KubernetesAuthConfig struct {
 
 	// CommonCredentialSelectors provides common selectors for extracting
 	// credentials.
+	//nolint:embeddedstructfieldcheck // Reordering would change generated CRD field order.
 	CommonCredentialSelectors `json:",inline"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane-runtime
 
-go 1.24.0
+go 1.25.0
 
 toolchain go1.25.10
 

--- a/pkg/certificates/certificates_test.go
+++ b/pkg/certificates/certificates_test.go
@@ -92,16 +92,16 @@ func TestLoad(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			certsFolderPath := tc.args.certsFolderPath
-			requireClient := tc.args.requireClientValidation
+			certsFolderPath := tc.certsFolderPath
+			requireClient := tc.requireClientValidation
 
 			cfg, err := LoadMTLSConfig(filepath.Join(certsFolderPath, caCertFileName), filepath.Join(certsFolderPath, tlsCertFileName), filepath.Join(certsFolderPath, tlsKeyFileName), requireClient)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nLoad(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
 			if requireClient {
-				if diff := cmp.Diff(tc.want.out.ClientAuth, cfg.ClientAuth); diff != "" {
+				if diff := cmp.Diff(tc.out.ClientAuth, cfg.ClientAuth); diff != "" {
 					t.Errorf("\n%s\nLoad(...): -want, +got:\n%s", tc.reason, diff)
 				}
 			}

--- a/pkg/connection/fake/mocks.go
+++ b/pkg/connection/fake/mocks.go
@@ -56,9 +56,9 @@ func (ss *SecretStore) DeleteKeyValues(ctx context.Context, s *store.Secret, do 
 // StoreConfig is a mock implementation of the StoreConfig interface.
 type StoreConfig struct {
 	metav1.ObjectMeta
+	v1.ConditionedStatus
 
 	Config v1.SecretStoreConfig
-	v1.ConditionedStatus
 }
 
 // GetStoreConfig returns SecretStoreConfig.

--- a/pkg/connection/manager_test.go
+++ b/pkg/connection/manager_test.go
@@ -144,10 +144,10 @@ func TestManagerConnectStore(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewDetailsManager(tc.args.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.args.sb))
+			m := NewDetailsManager(tc.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.sb))
 
-			_, err := m.connectStore(context.Background(), tc.args.p)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			_, err := m.connectStore(context.Background(), tc.p)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\nReason: %s\nm.connectStore(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
@@ -289,13 +289,13 @@ func TestManagerPublishConnection(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewDetailsManager(tc.args.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.args.sb))
+			m := NewDetailsManager(tc.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.sb))
 
-			published, err := m.PublishConnection(context.Background(), tc.args.so, tc.args.conn)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			published, err := m.PublishConnection(context.Background(), tc.so, tc.conn)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\nReason: %s\nm.publishConnection(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.published, published); diff != "" {
+			if diff := cmp.Diff(tc.published, published); diff != "" {
 				t.Errorf("\nReason: %s\nm.publishConnection(...): -want published, +got published:\n%s", tc.reason, diff)
 			}
 		})
@@ -489,10 +489,10 @@ func TestManagerUnpublishConnection(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewDetailsManager(tc.args.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.args.sb))
+			m := NewDetailsManager(tc.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.sb))
 
-			err := m.UnpublishConnection(context.Background(), tc.args.so, tc.args.conn)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			err := m.UnpublishConnection(context.Background(), tc.so, tc.conn)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\nReason: %s\nm.unpublishConnection(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
@@ -632,13 +632,13 @@ func TestManagerFetchConnection(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewDetailsManager(tc.args.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.args.sb))
+			m := NewDetailsManager(tc.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.sb))
 
-			got, err := m.FetchConnection(context.Background(), tc.args.so)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			got, err := m.FetchConnection(context.Background(), tc.so)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\nReason: %s\nm.FetchConnection(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.conn, got); diff != "" {
+			if diff := cmp.Diff(tc.conn, got); diff != "" {
 				t.Errorf("\nReason: %s\nm.FetchConnection(...): -want connDetails, +got connDetails:\n%s", tc.reason, diff)
 			}
 		})
@@ -1213,13 +1213,13 @@ func TestManagerPropagateConnection(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewDetailsManager(tc.args.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.args.sb))
+			m := NewDetailsManager(tc.c, resourcefake.GVK(&fake.StoreConfig{}), WithStoreBuilder(tc.sb))
 
-			got, err := m.PropagateConnection(context.Background(), tc.args.to, tc.args.from)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			got, err := m.PropagateConnection(context.Background(), tc.to, tc.from)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\nReason: %s\nm.PropagateConnection(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.propagated, got); diff != "" {
+			if diff := cmp.Diff(tc.propagated, got); diff != "" {
 				t.Errorf("\nReason: %s\nm.PropagateConnection(...): -want propagated, +got propagated:\n%s", tc.reason, diff)
 			}
 		})

--- a/pkg/connection/store/kubernetes/store_test.go
+++ b/pkg/connection/store/kubernetes/store_test.go
@@ -139,17 +139,17 @@ func TestSecretStoreReadKeyValues(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ss := &SecretStore{
-				client: tc.args.client,
+				client: tc.client,
 			}
 
 			s := &store.Secret{}
-			s.ScopedName = tc.args.n
-			err := ss.ReadKeyValues(context.Background(), tc.args.n, s)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			s.ScopedName = tc.n
+			err := ss.ReadKeyValues(context.Background(), tc.n, s)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.ReadKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if diff := cmp.Diff(tc.want.result, s.Data); diff != "" {
+			if diff := cmp.Diff(tc.result, s.Data); diff != "" {
 				t.Errorf("\n%s\nss.ReadKeyValues(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
@@ -465,14 +465,14 @@ func TestSecretStoreWriteKeyValues(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ss := &SecretStore{
-				client:           tc.args.client,
-				defaultNamespace: tc.args.defaultNamespace,
+				client:           tc.client,
+				defaultNamespace: tc.defaultNamespace,
 			}
-			changed, err := ss.WriteKeyValues(context.Background(), tc.args.secret, tc.args.wo...)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			changed, err := ss.WriteKeyValues(context.Background(), tc.secret, tc.wo...)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.WriteKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.changed, changed); diff != "" {
+			if diff := cmp.Diff(tc.changed, changed); diff != "" {
 				t.Errorf("\n%s\nss.WriteKeyValues(...): -want changed, +got changed:\n%s", tc.reason, diff)
 			}
 		})
@@ -655,11 +655,11 @@ func TestSecretStoreDeleteKeyValues(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ss := &SecretStore{
-				client:           tc.args.client,
-				defaultNamespace: tc.args.defaultNamespace,
+				client:           tc.client,
+				defaultNamespace: tc.defaultNamespace,
 			}
-			err := ss.DeleteKeyValues(context.Background(), tc.args.secret, tc.args.do...)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			err := ss.DeleteKeyValues(context.Background(), tc.secret, tc.do...)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.DeleteKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
@@ -836,8 +836,8 @@ users:
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewSecretStore(context.Background(), tc.args.client, nil, tc.args.cfg)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			_, err := NewSecretStore(context.Background(), tc.client, nil, tc.cfg)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nNewSecretStore(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})

--- a/pkg/connection/store/plugin/fake/mocks.go
+++ b/pkg/connection/store/plugin/fake/mocks.go
@@ -24,10 +24,11 @@ import (
 
 // ExternalSecretStorePluginServiceClient is a fake ExternalSecretStorePluginServiceClient.
 type ExternalSecretStorePluginServiceClient struct {
+	*ess.UnimplementedExternalSecretStorePluginServiceServer
+
 	GetSecretFn   func(context.Context, *ess.GetSecretRequest, ...grpc.CallOption) (*ess.GetSecretResponse, error)
 	ApplySecretFn func(context.Context, *ess.ApplySecretRequest, ...grpc.CallOption) (*ess.ApplySecretResponse, error)
 	DeleteKeysFn  func(context.Context, *ess.DeleteKeysRequest, ...grpc.CallOption) (*ess.DeleteKeysResponse, error)
-	*ess.UnimplementedExternalSecretStorePluginServiceServer
 }
 
 // GetSecret returns the secret.

--- a/pkg/connection/store/plugin/store.go
+++ b/pkg/connection/store/plugin/store.go
@@ -20,6 +20,7 @@ package plugin
 import (
 	"context"
 	"crypto/tls"
+	"maps"
 	"path/filepath"
 
 	"google.golang.org/grpc"
@@ -90,9 +91,7 @@ func (ss *SecretStore) ReadKeyValues(ctx context.Context, n store.ScopedName, s 
 	if len(respSecretMetadata) != 0 {
 		s.Metadata = new(v1.ConnectionSecretMetadata)
 		s.Metadata.Labels = make(map[string]string, len(respSecretMetadata))
-		for k, v := range respSecretMetadata {
-			s.Metadata.Labels[k] = v
-		}
+		maps.Copy(s.Metadata.Labels, respSecretMetadata)
 	}
 
 	return nil
@@ -102,16 +101,10 @@ func (ss *SecretStore) ReadKeyValues(ctx context.Context, n store.ScopedName, s 
 func (ss *SecretStore) WriteKeyValues(ctx context.Context, s *store.Secret, _ ...store.WriteOption) (changed bool, err error) {
 	sec := &essproto.Secret{}
 	sec.ScopedName = ss.getScopedName(s.ScopedName)
-	sec.Data = make(map[string][]byte, len(s.Data))
-	for k, v := range s.Data {
-		sec.Data[k] = v
-	}
+	sec.Data = maps.Clone(s.Data)
 
 	if s.Metadata != nil && len(s.Metadata.Labels) != 0 {
-		sec.Metadata = make(map[string]string, len(s.Metadata.Labels))
-		for k, v := range s.Metadata.Labels {
-			sec.Metadata[k] = v
-		}
+		sec.Metadata = maps.Clone(s.Metadata.Labels)
 	}
 
 	resp, err := ss.client.ApplySecret(ctx, &essproto.ApplySecretRequest{Secret: sec, Config: ss.getConfigReference()})

--- a/pkg/connection/store/plugin/store_test.go
+++ b/pkg/connection/store/plugin/store_test.go
@@ -123,7 +123,7 @@ func TestReadKeyValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			ss := &SecretStore{
-				client: tc.args.client,
+				client: tc.client,
 				config: &v1.Config{
 					APIVersion: "v1alpha1",
 					Kind:       "VaultConfig",
@@ -132,13 +132,13 @@ func TestReadKeyValues(t *testing.T) {
 			}
 			s := &store.Secret{}
 
-			err := ss.ReadKeyValues(ctx, tc.args.sn, s)
+			err := ss.ReadKeyValues(ctx, tc.sn, s)
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.ReadKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if diff := cmp.Diff(tc.want.out, s); diff != "" {
+			if diff := cmp.Diff(tc.out, s); diff != "" {
 				t.Errorf("\n%s\nss.ReadKeyValues(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
@@ -195,7 +195,7 @@ func TestWriteKeyValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			ss := &SecretStore{
-				client: tc.args.client,
+				client: tc.client,
 				config: &v1.Config{
 					APIVersion: "v1alpha1",
 					Kind:       "VaultConfig",
@@ -206,11 +206,11 @@ func TestWriteKeyValues(t *testing.T) {
 
 			isChanged, err := ss.WriteKeyValues(ctx, s)
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.WriteKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if diff := cmp.Diff(tc.want.isChanged, isChanged); diff != "" {
+			if diff := cmp.Diff(tc.isChanged, isChanged); diff != "" {
 				t.Errorf("\n%s\nss.WriteKeyValues(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
@@ -260,7 +260,7 @@ func TestDeleteKeyValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			ss := &SecretStore{
-				client: tc.args.client,
+				client: tc.client,
 				config: &v1.Config{
 					APIVersion: "v1alpha1",
 					Kind:       "VaultConfig",
@@ -271,7 +271,7 @@ func TestDeleteKeyValues(t *testing.T) {
 
 			err := ss.DeleteKeyValues(ctx, s)
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nss.DeletKeyValues(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})

--- a/pkg/connection/store/store.go
+++ b/pkg/connection/store/store.go
@@ -43,6 +43,7 @@ type ScopedName struct {
 // A Secret is an entity representing a set of sensitive Key Values.
 type Secret struct {
 	ScopedName
+
 	Metadata *v1.ConnectionSecretMetadata
 	Data     KeyValues
 }

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -18,6 +18,8 @@ limitations under the License.
 package event
 
 import (
+	"maps"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -94,9 +96,7 @@ func (r *APIRecorder) Event(obj runtime.Object, e Event) {
 // annotations with all recorded events.
 func (r *APIRecorder) WithAnnotations(keysAndValues ...string) Recorder {
 	ar := NewAPIRecorder(r.kube)
-	for k, v := range r.annotations {
-		ar.annotations[k] = v
-	}
+	maps.Copy(ar.annotations, r.annotations)
 	sliceMap(keysAndValues, ar.annotations)
 	return ar
 }

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package event records Kubernetes events.
 package event
 
 import (

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -79,12 +79,12 @@ func (sg Segments) String() string {
 		switch s.Type {
 		case SegmentField:
 			if s.Field == wildcard || strings.ContainsRune(s.Field, period) {
-				b.WriteString(fmt.Sprintf("[%s]", s.Field))
+				fmt.Fprintf(&b, "[%s]", s.Field)
 				continue
 			}
-			b.WriteString(fmt.Sprintf(".%s", s.Field))
+			fmt.Fprintf(&b, ".%s", s.Field)
 		case SegmentIndex:
-			b.WriteString(fmt.Sprintf("[%d]", s.Index))
+			fmt.Fprintf(&b, "[%d]", s.Index)
 		}
 	}
 

--- a/pkg/fieldpath/merge.go
+++ b/pkg/fieldpath/merge.go
@@ -82,10 +82,10 @@ func merge(dst, src any, mergeOptions *xpv1.MergeOptions) (any, error) {
 
 func removeSourceDuplicates(dst, src any) any {
 	sliceDst, sliceSrc := reflect.ValueOf(dst), reflect.ValueOf(src)
-	if sliceDst.Kind() == reflect.Ptr {
+	if sliceDst.Kind() == reflect.Pointer {
 		sliceDst = sliceDst.Elem()
 	}
-	if sliceSrc.Kind() == reflect.Ptr {
+	if sliceSrc.Kind() == reflect.Pointer {
 		sliceSrc = sliceSrc.Elem()
 	}
 	if sliceDst.Kind() != reflect.Slice || sliceSrc.Kind() != reflect.Slice {

--- a/pkg/logging/klog.go
+++ b/pkg/logging/klog.go
@@ -31,7 +31,7 @@ type requestThrottlingFilter struct {
 	logr.LogSink
 }
 
-func (l *requestThrottlingFilter) Info(level int, msg string, keysAndValues ...interface{}) {
+func (l *requestThrottlingFilter) Info(level int, msg string, keysAndValues ...any) {
 	if !strings.Contains(msg, "Waited for ") || !strings.Contains(msg, "  request: ") {
 		return
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -18,6 +18,8 @@ limitations under the License.
 package meta
 
 import (
+	"maps"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +67,7 @@ const (
 
 // ReferenceTo returns an object reference to the supplied object, presumed to
 // be of the supplied group, version, and kind.
+//
 // Deprecated: use a more specific reference type, such as TypedReference or
 // Reference instead of the overly verbose ObjectReference.
 // See https://github.com/crossplane/crossplane-runtime/issues/49
@@ -160,10 +163,8 @@ func AddControllerReference(o metav1.Object, r metav1.OwnerReference) error {
 // AddFinalizer to the supplied Kubernetes object's metadata.
 func AddFinalizer(o metav1.Object, finalizer string) {
 	f := o.GetFinalizers()
-	for _, e := range f {
-		if e == finalizer {
-			return
-		}
+	if slices.Contains(f, finalizer) {
+		return
 	}
 	o.SetFinalizers(append(f, finalizer))
 }
@@ -182,12 +183,7 @@ func RemoveFinalizer(o metav1.Object, finalizer string) {
 // FinalizerExists checks whether given finalizer is already set.
 func FinalizerExists(o metav1.Object, finalizer string) bool {
 	f := o.GetFinalizers()
-	for _, e := range f {
-		if e == finalizer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(f, finalizer)
 }
 
 // AddLabels to the supplied object.
@@ -197,9 +193,7 @@ func AddLabels(o metav1.Object, labels map[string]string) {
 		o.SetLabels(labels)
 		return
 	}
-	for k, v := range labels {
-		l[k] = v
-	}
+	maps.Copy(l, labels)
 	o.SetLabels(l)
 }
 
@@ -222,9 +216,7 @@ func AddAnnotations(o metav1.Object, annotations map[string]string) {
 		o.SetAnnotations(annotations)
 		return
 	}
-	for k, v := range annotations {
-		a[k] = v
-	}
+	maps.Copy(a, annotations)
 	o.SetAnnotations(a)
 }
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -48,6 +48,7 @@ func TestReferenceTo(t *testing.T) {
 	}
 	tests := map[string]struct {
 		args
+
 		want *corev1.ObjectReference
 	}{
 		"WithTypeMeta": {
@@ -77,7 +78,7 @@ func TestReferenceTo(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ReferenceTo(tc.args.o, tc.args.of)
+			got := ReferenceTo(tc.o, tc.of)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("ReferenceTo(): -want, +got:\n%s", diff)
 			}
@@ -92,6 +93,7 @@ func TestTypedReferenceTo(t *testing.T) {
 	}
 	tests := map[string]struct {
 		args
+
 		want *xpv1.TypedReference
 	}{
 		"WithTypeMeta": {
@@ -120,7 +122,7 @@ func TestTypedReferenceTo(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := TypedReferenceTo(tc.args.o, tc.args.of)
+			got := TypedReferenceTo(tc.o, tc.of)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("TypedReferenceTo(): -want, +got:\n%s", diff)
 			}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -143,7 +143,7 @@ func (p *PackageParser) Parse(_ context.Context, reader io.ReadCloser) (*Package
 // is useful for filtering out empty YAML documents that would otherwise
 // cause issues when decoded.
 func isEmptyYAML(y []byte) bool {
-	for _, line := range strings.Split(string(y), "\n") {
+	for line := range strings.SplitSeq(string(y), "\n") {
 		trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
 		// We don't want to return an empty document with only separators that
 		// have nothing in-between.

--- a/pkg/reconciler/managed/changelogger_test.go
+++ b/pkg/reconciler/managed/changelogger_test.go
@@ -179,7 +179,7 @@ func equateApproxTimepb(margin time.Duration) []cmp.Option {
 		protocmp.Transform(),
 		cmp.FilterPath(
 			func(p cmp.Path) bool {
-				if p.Last().Type() == reflect.TypeOf(protocmp.Message{}) {
+				if p.Last().Type() == reflect.TypeFor[protocmp.Message]() {
 					a, b := p.Last().Values()
 					return msgIsTimestamp(a) && msgIsTimestamp(b)
 				}

--- a/pkg/reconciler/managed/metrics.go
+++ b/pkg/reconciler/managed/metrics.go
@@ -28,7 +28,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
-const subSystem = "crossplane"
+const (
+	subSystem = "crossplane"
+	labelGVK  = "gvk"
+)
 
 // MetricRecorder records the managed resource metrics.
 type MetricRecorder interface { //nolint:interfacebloat // The first two methods are coming from Prometheus
@@ -61,25 +64,25 @@ func NewMRMetricRecorder() *MRMetricRecorder {
 			Name:      "managed_resource_first_time_to_reconcile_seconds",
 			Help:      "The time it took for a managed resource to be detected by the controller",
 			Buckets:   kmetrics.ExponentialBuckets(10e-9, 10, 10),
-		}, []string{"gvk"}),
+		}, []string{labelGVK}),
 		mrFirstTimeReady: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Subsystem: subSystem,
 			Name:      "managed_resource_first_time_to_readiness_seconds",
 			Help:      "The time it took for a managed resource to become ready first time after creation",
 			Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 300, 600, 1800, 3600},
-		}, []string{"gvk"}),
+		}, []string{labelGVK}),
 		mrDeletion: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Subsystem: subSystem,
 			Name:      "managed_resource_deletion_seconds",
 			Help:      "The time it took for a managed resource to be deleted",
 			Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 300, 600, 1800, 3600},
-		}, []string{"gvk"}),
+		}, []string{labelGVK}),
 		mrDrift: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Subsystem: subSystem,
 			Name:      "managed_resource_drift_seconds",
 			Help:      "ALPHA: How long since the previous successful reconcile when a resource was found to be out of sync; excludes restart of the provider",
 			Buckets:   kmetrics.ExponentialBuckets(10e-9, 10, 10),
-		}, []string{"gvk"}),
+		}, []string{labelGVK}),
 	}
 }
 
@@ -173,6 +176,6 @@ func (r *NopMetricRecorder) recordFirstTimeReady(_ resource.Managed) {}
 
 func getLabels(r resource.Managed) prometheus.Labels {
 	return prometheus.Labels{
-		"gvk": r.GetObjectKind().GroupVersionKind().String(),
+		labelGVK: r.GetObjectKind().GroupVersionKind().String(),
 	}
 }

--- a/pkg/reconciler/managed/reconciler_typed.go
+++ b/pkg/reconciler/managed/reconciler_typed.go
@@ -52,6 +52,7 @@ func (c *typedExternalClientWrapper[managed]) Create(ctx context.Context, mg res
 	}
 	return c.c.Create(ctx, cr)
 }
+
 func (c *typedExternalClientWrapper[managed]) Update(ctx context.Context, mg resource.Managed) (ExternalUpdate, error) {
 	cr, ok := mg.(managed)
 	if !ok {

--- a/pkg/reconciler/providerconfig/reconciler_test.go
+++ b/pkg/reconciler/providerconfig/reconciler_test.go
@@ -41,6 +41,7 @@ import (
 // GetItems returning managed.ProviderConfigUsage.
 type ProviderConfigUsageList struct {
 	client.ObjectList
+
 	Items []resource.ProviderConfigUsage
 }
 

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -107,7 +107,7 @@ func ToIntPtrValue(v string) *int64 {
 // string pointers and need to be resolved as part of `ResolveMultiple`.
 func FromPtrValues(v []*string) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromPtrValue(v[i])
 	}
 	return res
@@ -116,7 +116,7 @@ func FromPtrValues(v []*string) []string {
 // FromFloatPtrValues adapts a slice of float64 pointer fields for use as CurrentValues.
 func FromFloatPtrValues(v []*float64) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromFloatPtrValue(v[i])
 	}
 	return res
@@ -125,7 +125,7 @@ func FromFloatPtrValues(v []*float64) []string {
 // FromIntPtrValues adapts a slice of int64 pointer fields for use as CurrentValues.
 func FromIntPtrValues(v []*int64) []string {
 	res := make([]string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = FromIntPtrValue(v[i])
 	}
 	return res
@@ -138,7 +138,7 @@ func FromIntPtrValues(v []*int64) []string {
 // string pointers and need to be resolved as part of `ResolveMultiple`.
 func ToPtrValues(v []string) []*string {
 	res := make([]*string, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToPtrValue(v[i])
 	}
 	return res
@@ -147,7 +147,7 @@ func ToPtrValues(v []string) []*string {
 // ToFloatPtrValues adapts ResolvedValues for use as a slice of float64 pointer fields.
 func ToFloatPtrValues(v []string) []*float64 {
 	res := make([]*float64, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToFloatPtrValue(v[i])
 	}
 	return res
@@ -156,7 +156,7 @@ func ToFloatPtrValues(v []string) []*float64 {
 // ToIntPtrValues adapts ResolvedValues for use as a slice of int64 pointer fields.
 func ToIntPtrValues(v []string) []*int64 {
 	res := make([]*int64, len(v))
-	for i := range len(v) {
+	for i := range v {
 		res[i] = ToIntPtrValue(v[i])
 	}
 	return res

--- a/pkg/resource/late_initializer_test.go
+++ b/pkg/resource/late_initializer_test.go
@@ -75,10 +75,10 @@ func TestLateInitializeStringPtr(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			li := NewLateInitializer()
 			got := li.LateInitializeStringPtr(tc.org, tc.from)
-			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+			if diff := cmp.Diff(tc.result, got); diff != "" {
 				t.Errorf("LateInitializeStringPtr(...): -want, +got:\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+			if diff := cmp.Diff(tc.changed, li.IsChanged()); diff != "" {
 				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
 			}
 		})
@@ -136,10 +136,10 @@ func TestLateInitializeInt64Ptr(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			li := NewLateInitializer()
 			got := li.LateInitializeInt64Ptr(tc.org, tc.from)
-			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+			if diff := cmp.Diff(tc.result, got); diff != "" {
 				t.Errorf("LateInitializeBoolPtr(...): -want, +got:\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+			if diff := cmp.Diff(tc.changed, li.IsChanged()); diff != "" {
 				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
 			}
 		})
@@ -197,10 +197,10 @@ func TestLateInitializeBoolPtr(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			li := NewLateInitializer()
 			got := li.LateInitializeBoolPtr(tc.org, tc.from)
-			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+			if diff := cmp.Diff(tc.result, got); diff != "" {
 				t.Errorf("LateInitializeBoolPtr(...): -want, +got:\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+			if diff := cmp.Diff(tc.changed, li.IsChanged()); diff != "" {
 				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
 			}
 		})
@@ -259,10 +259,10 @@ func TestLateInitializeTimePtr(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			li := NewLateInitializer()
 			got := li.LateInitializeTimePtr(tc.org, tc.from)
-			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+			if diff := cmp.Diff(tc.result, got); diff != "" {
 				t.Errorf("LateInitializeTimePtr(...): -want, +got:\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.want.changed, li.IsChanged()); diff != "" {
+			if diff := cmp.Diff(tc.changed, li.IsChanged()); diff != "" {
 				t.Errorf("IsChanged(...): -want, +got:\n%s", diff)
 			}
 		})

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"maps"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -25,12 +27,14 @@ import (
 )
 
 // A PredicateFn returns true if the supplied object should be reconciled.
+//
 // Deprecated: This type will be removed soon. Please use
 // controller-runtime's predicate.NewPredicateFuncs instead.
 type PredicateFn func(obj runtime.Object) bool
 
 // NewPredicates returns a set of Funcs that are all satisfied by the supplied
 // PredicateFn. The PredicateFn is run against the new object during updates.
+//
 // Deprecated: This function will be removed soon. Please use
 // controller-runtime's predicate.NewPredicateFuncs instead.
 func NewPredicates(fn PredicateFn) predicate.Funcs {
@@ -72,14 +76,13 @@ func DesiredStateChanged() predicate.Predicate {
 // being able to ignore certain annotations.
 type AnnotationChangedPredicate struct {
 	predicate.Funcs
+
 	ignored []string
 }
 
 func copyAnnotations(an map[string]string) map[string]string {
 	r := make(map[string]string, len(an))
-	for k, v := range an {
-		r[k] = v
-	}
+	maps.Copy(r, an)
 	return r
 }
 

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -142,11 +142,11 @@ func TestDesiredStateChanged(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := DesiredStateChanged().Update(event.UpdateEvent{
-				ObjectOld: tc.args.old,
-				ObjectNew: tc.args.new,
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
 			})
 
-			if diff := cmp.Diff(tc.want.desiredStateChanged, got); diff != "" {
+			if diff := cmp.Diff(tc.desiredStateChanged, got); diff != "" {
 				t.Errorf("DesiredStateChanged(...): -want, +got:\n%s", diff)
 			}
 		})

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -215,6 +215,7 @@ type shouldRetryFunc func(error) bool
 // An ApplicatorWithRetry applies changes to an object, retrying on transient failures.
 type ApplicatorWithRetry struct {
 	Applicator
+
 	shouldRetry shouldRetryFunc
 	backoff     wait.Backoff
 }

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -401,7 +401,7 @@ type object struct {
 }
 
 func (o *object) DeepCopyObject() runtime.Object {
-	return &object{ObjectMeta: *o.ObjectMeta.DeepCopy()}
+	return &object{ObjectMeta: *o.DeepCopy()}
 }
 
 func TestIsNotControllable(t *testing.T) {

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -71,8 +71,8 @@ func TestDefault(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			v := NewMutator(WithMutationFns(tc.fns...))
-			err := v.Default(context.TODO(), tc.args.obj)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			err := v.Default(context.TODO(), tc.obj)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDefault(...): -want, +got\n%s\n", tc.reason, diff)
 			}
 		})

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -107,11 +107,11 @@ func TestValidateCreate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			v := NewValidator(WithValidateCreationFns(tc.fns...))
-			warn, err := v.ValidateCreate(context.TODO(), tc.args.obj)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			warn, err := v.ValidateCreate(context.TODO(), tc.obj)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nValidateCreate(...): -want error, +got error\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("\n%s\nValidateCreate(...): -want warnings, +got warnings\n%s\n", tc.reason, diff)
 			}
 		})
@@ -187,11 +187,11 @@ func TestValidateUpdate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			v := NewValidator(WithValidateUpdateFns(tc.fns...))
-			warn, err := v.ValidateUpdate(context.TODO(), tc.args.oldObj, tc.args.newObj)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			warn, err := v.ValidateUpdate(context.TODO(), tc.oldObj, tc.newObj)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nValidateUpdate(...): -want error, +got error\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("\n%s\nValidateUpdate(...): -want warnings, +got warnings\n%s\n", tc.reason, diff)
 			}
 		})
@@ -266,11 +266,11 @@ func TestValidateDelete(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			v := NewValidator(WithValidateDeletionFns(tc.fns...))
-			warn, err := v.ValidateDelete(context.TODO(), tc.args.obj)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			warn, err := v.ValidateDelete(context.TODO(), tc.obj)
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nValidateDelete(...): -want error, +got error\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.warnings, warn, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("\n%s\nValidateDelete(...): -want warnings, +got warnings\n%s\n", tc.reason, diff)
 			}
 		})


### PR DESCRIPTION
### Description of your changes

This PR bumps `release-1.20` to Go 1.25 and `golangci-lint` v2 ahead of Reonvate's PR #989. `golang.org/x/net@v0.53.0` declares `go 1.25.0` in its go.mod, so #989 basically fails with the current Earthfile pin of `GO_VERSION=1.24.13` and `golangci-lint v1.64.8`. Landing this first gets `release-1.20` into good shape for #989 to land.

Specific changes:
* `GO_VERSION` `1.24.13 -> 1.25.10`
* `GOLANGCI_LINT_VERSION` `v1.64.8 -> v2.12.2`
* `go.mod`'s `go` directive `1.24.0 -> 1.25.0` (that's just saying we support the minimum go language of 1.25.0, the toolchain directive will still have us use v1.25.0 for all the security fixes)
* `.golangci.yml` migrated to v2 via `golangci-lint migrate` with the disable list and test-file exclusions aligned to our current approach on `main`. This also completes the v1 -> v2 `golangci-lint` migration that #977 deferred when it stayed on the 1.24 line, and drops the `run.go: "1.24"` pin from f78224f that's now not needed.

One non-obvious thing worth flagging: the install.sh URL also moves from `https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh` to the canonical `https://golangci-lint.run/install.sh`. See golangci/golangci-lint#6539 for the upstream fix and the maintainer's note recommending the canonical URL.

### How has this code been tested

I have verified the new lint path end-to-end by running all the earthly checks, e.g. `earthly +lint`.

Most of the source diff is `golangci-lint run --fix` output across test files (removing redundant embedded field qualifiers, switching to Go 1.22 range-over-int, and `maps.Copy`/`maps.Clone` for trivial map copies). The commit message covers the handful of hand fixes (`reflect.Ptr -> reflect.Pointer`, `//nolint:embeddedstructfieldcheck` usage, etc.)

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
