### PR TITLE
docs: add docstring to FuzzParse function

### DIFF
--- a/pkg/xpkg/parser/fuzz_test.go
+++ b/pkg/xpkg/parser/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// FuzzParse is a fuzz test function used to test the robustness of the parser.
 func FuzzParse(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, data []byte) {
 		objScheme := runtime.NewScheme()


### PR DESCRIPTION
### 问题背景
公共函数 `FuzzParse` 缺少文档注释，这降低了代码的可读性和可维护性，不符合开源项目的最佳实践。

### 修改内容
- 在 `pkg/xpkg/parser/fuzz_test.go` 文件中的 `FuzzParse` 函数上添加了文档注释，解释其作为模糊测试函数的作用，用于测试解析器的鲁棒性。这提升了代码的自文档化能力。

### 验证方式
修改仅添加注释，不改变代码逻辑，因此通过运行现有测试（如 `go test ./pkg/xpkg/parser/...`）验证正确性，确保无回归问题。

### 其他信息
- 没有 breaking changes。
- 不需要更新文档。