### PR TITLE
fix(tests): update error messages for semver v3.5.0 constraint quotes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.9
 require (
 	dario.cat/mergo v1.0.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
-	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/crossplane/crossplane/apis/v2 v2.0.0-20260424160951-8f231230ebb6
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/Azure/go-autorest/tracing v0.6.1 h1:YUMSrC/CeD1ZnnXcNYU4a/fzsO35u2Fsf
 github.com/Azure/go-autorest/tracing v0.6.1/go.mod h1:/3EgjbsjraOqiicERAeu3m7/z0x1TzjQGAwDrJrXGkc=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -41,8 +41,8 @@ schema = 3
     version = "v0.6.1"
     hash = "sha256-nstDZC8Btx78yzqIR4clfu+R93rebUOZalEW1ZaQfIY="
   [mod."github.com/Masterminds/semver/v3"]
-    version = "v3.4.0"
-    hash = "sha256-75kRraVwYVjYLWZvuSlts4Iu28Eh3SpiF0GHc7vCYHI="
+    version = "v3.5.0"
+    hash = "sha256-Ps7gEw0nkHDZO/iDru/s+X8rMaUkNmiZ7id1GsIKlDU="
   [mod."github.com/antlr4-go/antlr/v4"]
     version = "v4.13.1"
     hash = "sha256-beAuxHNRUuhzcSJUh/8ztVf1zCUiaT72fg2Jvx0AuNQ="

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -77,7 +77,7 @@ func TestInRange(t *testing.T) {
 				r:       ">a2",
 			},
 			want: want{
-				err: errors.New("improper constraint: >a2"),
+				err: errors.New("improper constraint: \">a2\""),
 			},
 		},
 		"ValidSpaceSeparatedRange": {
@@ -107,7 +107,7 @@ func TestInRange(t *testing.T) {
 				r:       ">=v2.0.0 >v5a.0.0",
 			},
 			want: want{
-				err: errors.New("improper constraint: >=v2.0.0 >v5a.0.0"),
+				err: errors.New("improper constraint: \">=v2.0.0 >v5a.0.0\""),
 			},
 		},
 	}

--- a/pkg/xpkg/lint_test.go
+++ b/pkg/xpkg/lint_test.go
@@ -421,7 +421,7 @@ func TestPackageValidSemver(t *testing.T) {
 					},
 				},
 			},
-			err: errors.Wrap(fmt.Errorf("improper constraint: %s", invalidConstraint), errBadConstraints),
+			err: errors.Wrap(fmt.Errorf("improper constraint: \"%s\"", invalidConstraint), errBadConstraints),
 		},
 	}
 


### PR DESCRIPTION
semver v3.5.0 wraps invalid constraint values in double quotes in error messages.

Updated test expectations in:
- pkg/version/version_test.go: constraint strings now include quotes
- pkg/xpkg/lint_test.go: constraint error string format updated

Tests verified locally with go test ./...