### PR TITLE
fix(meta): RemoveFinalizer handles duplicate finalizers without panicking

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -190,11 +190,9 @@ func AddFinalizer(o metav1.Object, finalizer string) {
 // RemoveFinalizer from the supplied Kubernetes object's metadata.
 func RemoveFinalizer(o metav1.Object, finalizer string) {
 	f := o.GetFinalizers()
-	for i, e := range f {
-		if e == finalizer {
-			f = append(f[:i], f[i+1:]...)
-		}
-	}
+	f = slices.DeleteFunc(f, func(e string) bool {
+		return e == finalizer
+	})
 
 	o.SetFinalizers(f)
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -538,6 +538,28 @@ func TestRemoveFinalizer(t *testing.T) {
 			},
 			want: []string{funalizer},
 		},
+		"DuplicateFinalizersExist": {
+			args: args{
+				o: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{finalizer, finalizer},
+					},
+				},
+				finalizer: finalizer,
+			},
+			want: []string{},
+		},
+		"DuplicateFinalizersWithOther": {
+			args: args{
+				o: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{finalizer, funalizer, finalizer},
+					},
+				},
+				finalizer: finalizer,
+			},
+			want: []string{funalizer},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes

`RemoveFinalizer` in pkg/meta deletes from the finalizer slice in place while ranging over it by index, which is the classic delete-while-ranging bug:

```go
for i, e := range f {
    if e == finalizer {
        f = append(f[:i], f[i+1:]...)
    }
}
```

`range` fixes the length at loop start but `append(f[:i], f[i+1:]...)` shrinks `f` underneath it, so after one removal the loop keeps indexing into a now-shorter slice. When the finalizer appears more than once this either panics (`["fin","fin"]`) or silently leaves a copy behind (`["fin","fin","fun"]` returns `["fin","fun"]`). It backs `APIFinalizer.RemoveFinalizer` on the managed-resource deletion path, so a duplicate finalizer (concurrent reconciles, patch races, version skew) can crash a controller during deletion or leave it stuck Terminating, which lines up with #1010. `AddFinalizer` already dedupes with `slices.Contains`; this side didn't.

Swapped the loop for `slices.DeleteFunc`, which removes all matches in one pass. `slices` is already imported here, so no new deps. Added two duplicate cases to `TestRemoveFinalizer`; they panic before the change and pass after.

`go test -race ./pkg/meta/...`, `go vet ./pkg/meta/...`, and `go build ./...` are all green.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ (ran `go test -race`, `go vet`, and `go build ./...` directly; happy to run flake check if needed)
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (internal helper, no user-facing docs)
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ (deferring to maintainers on backport scope)

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
