### PR TITLE
fix(ci): clean /homeless-shelter between Renovate's Nix builds

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -14,6 +14,15 @@ apt-get update && apt-get install -y nix-bin
 
 # Configure Nix
 mkdir -p /etc/nix
+
+# The Renovate container can't run Nix as sandboxed, so HOME=/homeless-shelter. Any build that
+# writes to $HOME, will cause subsequent builds to fail if that directory isn't cleaned up first.
+cat > /usr/local/bin/nix-clean-homeless-shelter << 'EOF'
+#!/bin/sh
+rm -rf /homeless-shelter
+EOF
+chmod +x /usr/local/bin/nix-clean-homeless-shelter
+
 cat > /etc/nix/nix.conf << 'EOF'
 # Enable flakes and the nix command (e.g. nix run, nix build).
 experimental-features = nix-command flakes
@@ -22,8 +31,11 @@ experimental-features = nix-command flakes
 # needing to create the nixbld group and users in this ephemeral container.
 build-users-group =
 
-# Build derivations in parallel, one per CPU core.
-max-jobs = auto
+# One build at a time, so no build starts before we can clean up /homeless-shelter.
+max-jobs = 1
+
+# Removes /homeless-shelter after each build (see the hook script above).
+post-build-hook = /usr/local/bin/nix-clean-homeless-shelter
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
 extra-substituters = https://crossplane.cachix.org


### PR DESCRIPTION
### Description of your changes

This PR sets out to solve the same problem as crossplane/crossplane#7652, where our Renovate job fails intermittently with `error: home directory '/homeless-shelter' exists`, as in this [example](https://github.com/crossplane/crossplane-runtime/pull/993#issuecomment-4412052047).

In crossplane/crossplane the fix has to prevent creation of the dir rather than cleaning it up afterwards, but we need a different fix here because the builds that create the directory (e.g., `pkgs.gomod2nix`) come from our dependencies rather than our own Nix code, so we have nowhere to set a writeable `HOME` here.

This PR adds a `post-build-hook` that deletes `/homeless-shelter` after each build, and sets `max-jobs = 1` so no new build starts before we can clean it up.

Only `main` needs this since all Renovate runs use the entrypoint from main, regardless of the branch they target.

Related to crossplane/crossplane#7390

### How has this code been tested

I reproduced the failure and the fix in `ghcr.io/renovatebot/renovate:43`, the same image the Renovate action uses. 

On the current code and with gomod2nix's derivations missing from the caches, several of them build in parallel. One creates `/homeless-shelter` by writing to `$HOME`, and the next build to start then fails the purity check, which aborts `nix run .#tidy`. The directory is left behind, so `nix run .#generate` afterwards fails right away.

With this change, in the same container using our updated entrypoint, both commands complete and the `/homeless-shelter` directory does not cause any issues ✅ 

When this is merged, I will run the Renovate action to verify the full flow there too.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
