### PR TITLE
fix(managed): requeue absent observe-only resources after the poll interval

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1196,12 +1196,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	}
 
 	// In the observe-only mode, !observation.ResourceExists will be an error
-	// case, and we will explicitly return this information to the user.
+	// case, and we will explicitly return this information to the user. This is
+	// a stable state rather than a transient failure, so we requeue after the
+	// poll interval instead of through the error rate limiter - only the
+	// appearance of the external resource can resolve it.
 	if !observation.ResourceExists && policy.ShouldOnlyObserve() {
 		record.Event(managed, event.Warning(reasonCannotObserve, errors.New(errExternalResourceNotExist)))
 		status.MarkConditions(xpv2.ReconcileError(errors.Wrap(errors.New(errExternalResourceNotExist), errReconcileObserve)))
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+		reconcileAfter := r.pollIntervalHook(managed, r.effectivePollInterval(managed))
+		log.Debug("External resource does not exist", "requeue-after", time.Now().Add(reconcileAfter))
+
+		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
 	}
 
 	// If this resource has a non-zero creation grace period we want to wait

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -385,7 +385,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ExternalObserveError": {
-			reason: "Errors observing the external resource should trigger a requeue after a short wait.",
+			reason: "Errors observing the external resource should trigger a rate limited requeue, even when a poll interval is configured.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -406,6 +406,7 @@ func TestReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
 				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
 					WithInitializers(),
 					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
@@ -1668,7 +1669,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{}},
 		},
 		"ObserveOnlyResourceDoesNotExist": {
-			reason: "With only Observe management action, observing a resource that does not exist should be reported as a conditioned status error.",
+			reason: "With only Observe management action, observing a resource that does not exist should be reported as a conditioned status error and requeued after the poll interval, not via the error rate limiter.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -1695,6 +1696,7 @@ func TestReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
 				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
@@ -1711,7 +1713,7 @@ func TestReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{Requeue: true}},
+			want: want{result: reconcile.Result{RequeueAfter: 10 * time.Minute}},
 		},
 		"ObserveOnlyPublishConnectionDetailsError": {
 			reason: "With Observe, errors publishing connection details after observation should trigger a requeue after a short wait.",

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -389,7 +389,7 @@ func TestModernReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ExternalObserveError": {
-			reason: "Errors observing the external resource should trigger a requeue after a short wait.",
+			reason: "Errors observing the external resource should trigger a rate limited requeue, even when a poll interval is configured.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -410,6 +410,7 @@ func TestModernReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
 				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
 					WithInitializers(),
 					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
 						c := &ExternalClientFns{
@@ -1674,7 +1675,7 @@ func TestModernReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{}},
 		},
 		"ObserveOnlyResourceDoesNotExist": {
-			reason: "With only Observe management action, observing a resource that does not exist should be reported as a conditioned status error.",
+			reason: "With only Observe management action, observing a resource that does not exist should be reported as a conditioned status error and requeued after the poll interval, not via the error rate limiter.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -1701,6 +1702,7 @@ func TestModernReconciler(t *testing.T) {
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
 				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
 					WithInitializers(),
 					WithManagementPolicies(),
 					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
@@ -1717,7 +1719,7 @@ func TestModernReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{Requeue: true}},
+			want: want{result: reconcile.Result{RequeueAfter: 10 * time.Minute}},
 		},
 		"ObserveOnlyPublishConnectionDetailsError": {
 			reason: "With Observe, errors publishing connection details after observation should trigger a requeue after a short wait.",


### PR DESCRIPTION
### Description of your changes

## Problem

A managed resource with `spec.managementPolicies: [Observe]` whose external object
does not exist is re-observed on the **error backoff schedule** rather than on the
configured poll interval. Because the condition is a *stable state* — nothing the
reconciler does can resolve it; only the external object appearing can — the
resource is retried indefinitely at the rate limiter's ceiling, and the operator's
configured poll interval has no effect on it whatsoever.

For a provider whose upstream API enforces a shared per-installation rate limit,
a handful of absent observe-only resources can consume a meaningful share of the
budget and starve unrelated reconciles.

## Evidence

`pkg/reconciler/managed/reconciler.go` returned `Requeue: true` for this branch:

```go
if !observation.ResourceExists && policy.ShouldOnlyObserve() {
    record.Event(managed, event.Warning(reasonCannotObserve, errors.New(errExternalResourceNotExist)))
    status.MarkConditions(xpv2.ReconcileError(errors.Wrap(errors.New(errExternalResourceNotExist), errReconcileObserve)))

    return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
}
```

`Requeue: true` causes controller-runtime to `AddRateLimited`, and
`pkg/controller/options.go`'s `ForControllerRuntime()` hardcodes
`RateLimiter: ratelimiter.NewController()` — which is

```go
workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, 60*time.Second)
```

So the retry schedule is **1s, 2s, 4s, 8s, 16s, 32s, 60s, 60s, …**. The queue item
is never `Forget()`-ten while the condition persists, so it pins at the 60s ceiling
forever.

Two consequences, both independent of how the interval is configured:

1. **The configured poll interval is ignored.** Neither the reconciler's
   `--poll-interval` nor the per-resource poll-interval annotation
   (`effectivePollInterval`) influences this path at all. Providers commonly
   configure 10m; the resource was polled at 60s regardless.
2. **A stable state is driven by a failure-backoff limiter.** The initial
   1s→32s burst is pure waste: no amount of prompt retrying can make an
   external object exist.

Note for reviewers: `defaultPollInterval` is `1 * time.Minute`
(`reconciler.go:52`), which coincides with the limiter's 60s ceiling. With stock
defaults the *steady-state* cadence is therefore unchanged. The wins are (a) the
initial 1s–32s retry burst is eliminated, (b) an operator-configured poll interval
is now actually honored, and (c) the per-resource poll-interval annotation now
works on this path.

This also aligns the branch with controller-runtime's own guidance. `Result.Requeue`
is deprecated as of the version in `go.mod` (v0.23.1), and its doc comment
describes precisely this case:

> When waiting for an external event to happen, either the duration until it is
> supposed to happen or an appropriate poll interval should be used, rather than
> an interval emitted by a ratelimiter whose purpose it is to control retry on
> error.

## The change

Requeue after the poll interval, using the same idiom as every other steady-state
path in this reconciler (so the jitter hook and the per-resource annotation
override both apply):

```go
reconcileAfter := r.pollIntervalHook(managed, r.effectivePollInterval(managed))
log.Debug("External resource does not exist", "requeue-after", time.Now().Add(reconcileAfter))

return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
```

The `errors.Wrap(updateStatus(), errUpdateManagedStatus)` return is retained
deliberately: if the status update itself fails, that *is* a transient error and
should still back off. controller-runtime discards `Result` when `err != nil`, so
this matches the contract used by the other `RequeueAfter` paths in this file.

## Why the event and condition are retained

Unchanged, byte for byte: the `reasonCannotObserve` **Warning event** and the
`ReconcileError` condition (`Synced=False` with `external resource does not
exist`). Operators must not lose visibility that an observe-only resource is
missing — this PR changes only the *cadence* of the retry, not its diagnostics.
Anything alerting on the condition or the event is unaffected.

## Blast radius

Confined to the single `!observation.ResourceExists && policy.ShouldOnlyObserve()`
branch. `errExternalResourceNotExist` has no other non-test reference in the repo.

- **Detection latency.** The appearance of the external object is now noticed
  within the poll interval — the same guarantee already relied upon for drift
  detection on an observe-only resource that *does* exist. `crossplane.io/reconcile-request`
  still forces an immediate reconcile for operators who want to poll now
  (covered by `TestReconcileRequestAnnotation`).
- **The genuine-Observe-error branch is untouched.** An error returned from
  `external.Observe` still returns `Requeue: true` and still backs off, which is
  correct: that *is* a transient failure.
- No API, option, or default changes; no behavioral change for resources under
  any other management policy.

## Tests

Extended the existing table-driven cases in both the modern and legacy suites
rather than adding parallel ones. Both cases now configure
`WithPollInterval(10 * time.Minute)`, which makes the pair a controlled
experiment on the same input:

- `ObserveOnlyResourceDoesNotExist` — asserts `RequeueAfter: 10m` (was
  `Requeue: true`), and continues to assert the `ReconcileError` condition via
  the existing `MockStatusUpdate`.
- `ExternalObserveError` — still asserts `Requeue: true` *despite* the same
  configured poll interval, proving the fix is surgical and the error path still
  rate-limits.

Verified the assertion discriminates: with the test changes applied but the
source change reverted, both `ObserveOnlyResourceDoesNotExist` cases fail with
`-RequeueAfter: s"10m0s" / +RequeueAfter: s"0s"`, while both
`ExternalObserveError` cases pass. With the source change, the full package and
the full repo suite pass, along with `go vet` and `gofmt -l`.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ Nix is
      not available in my environment. I ran instead, all clean:
      `go build ./...`, `go test ./...` (full repo), `go test -race ./pkg/reconciler/managed/...`,
      `go vet ./pkg/reconciler/managed/...`, `gofmt -l` (repo-wide), and
      `golangci-lint run ./pkg/reconciler/managed/...` against the repo's
      `.golangci.yml` (`0 issues`). Happy to rerun under Nix if that gate catches
      something these did not.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ This
      changes retry cadence for one internal branch, with no API or option
      change. Glad to file a docs tracking issue if you consider the cadence
      change user-visible enough to warrant one.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Deferring
      the backport decision to maintainers; I can add labels if you tell me which
      release branches you want this in.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new

Opened as a draft: happy to adjust the approach before review if you would rather
solve this differently (for example by making the rate limiter configurable
instead).

🤖