### PR TITLE
fix(fieldpath): do not recurse forever on a field named *

### DIFF
--- a/pkg/fieldpath/paved.go
+++ b/pkg/fieldpath/paved.go
@@ -213,6 +213,13 @@ func expandWildcards(data any, segments Segments) ([]Segments, error) { //nolint
 				}
 			case map[string]any:
 				for k := range mapOrArray {
+					// A field literally named "*" would be substituted back
+					// in as a wildcard segment, so the expansion below would
+					// recurse on the same input forever.
+					if k == wildcard {
+						return nil, errors.Errorf("%q: object has a field named %q, which cannot be distinguished from a wildcard", segments[:i], wildcard)
+					}
+
 					expanded := make(Segments, len(segments))
 					copy(expanded, segments)
 					expanded = append(append(expanded[:i], Field(k)), expanded[i+1:]...)

--- a/pkg/fieldpath/paved_test.go
+++ b/pkg/fieldpath/paved_test.go
@@ -979,6 +979,14 @@ func TestExpandWildcards(t *testing.T) {
 				err: errors.Wrap(errors.New("unexpected ']' at position 5"), "cannot parse path \"spec[]\""),
 			},
 		},
+		"LiteralWildcardKey": {
+			reason: "Expanding over an object that has a field literally named * should fail rather than recurse forever",
+			path:   "spec[*]",
+			data:   []byte(`{"spec":{"*":"star","other":"value"}}`),
+			want: want{
+				err: errors.Wrapf(errors.Errorf("%q: object has a field named %q, which cannot be distinguished from a wildcard", "spec", "*"), "cannot expand wildcards for segments: %q", "spec[*]"),
+			},
+		},
 		"NilValue": {
 			reason: "Requesting a wildcard for an object that has nil value",
 			path:   "spec.containers[*].name",


### PR DESCRIPTION
### Description of your changes

`expandWildcards` handles a wildcard segment over a map by substituting each key back into the segment list and re-expanding from the top:

```go
expanded = append(append(expanded[:i], Field(k)), expanded[i+1:]...)
r, err := expandWildcards(data, expanded)
```

If one of those keys is literally `*`, the substituted segment is a wildcard again, so the call re-expands the identical input and never makes progress. The goroutine stack fills and Go reports `fatal error: stack overflow`, which is not recoverable, so a `recover()` further up the stack cannot contain it.

Reproduced against `main` before the fix, with `ExpandWildcards("spec[*]")` on `{"spec":{"*":"star"}}`:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

A literal `*` field cannot be represented in `Segments` at all: `Segments.String` renders such a field as `[*]`, and parsing that back yields a wildcard. So rather than trying to expand it, this returns an error for that key. Objects without a `*` key are unaffected, and the array branch is untouched.

Test case `LiteralWildcardKey` added to `TestExpandWildcards`. It overflows the stack on the unmodified tree and passes with the change; the rest of the package passes either way.

Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ (ran `go test ./pkg/fieldpath/...`, `go vet` and `gofmt` locally; happy to run the full flake check if you want it)
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing docs change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Let me know if you want this backported.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
