### PR TITLE
fix(ci): prioritize flake.lock maintenance updates

### DIFF
--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -10,18 +10,24 @@
   // Allow Renovate to update lock files, so we get new updates in Nix inputs
   // (e.g., nixpkgs, nixpkgs-unstable) regularly.
   //
-  // Note that we use a schedule of "on monday", because "schedule:weekly" only
-  // allows a window of 00:00 to 03:59, which we can't guarantee our Renovate
-  // workflow will run during. Using "on monday" is better since it doesn't
-  // require the workflow to run at a specific time.
+  // An empty schedule ("[]") means "at any time", so we can get a lock file
+  // maintenance PR during any run of Renovate. They can be important, so let's
+  // not throttle them unnecessarily.
   lockFileMaintenance: {
     enabled: true,
-    schedule: [
-      'on monday',
-    ],
+    schedule: [],
   },
 
   packageRules: [
+    {
+      // Give lock file maintenance PRs higher priority than other non-security
+      // related updates.
+      description: 'Sort lock file maintenance ahead of other updates',
+      matchUpdateTypes: [
+        'lockFileMaintenance',
+      ],
+      prPriority: 10,
+    },
     {
       // The base config disables all non-security updates on release branches,
       // but we still want Nix flake.lock to get updated there, since that's how


### PR DESCRIPTION
### Description of your changes

Same changes made in https://github.com/crossplane/crossplane/pull/7695, but here in crossplane-runtime.

Renovate sorts lock file maintenance last of all update types, so it's very easy for them to be rate-limited. This commit helps velocity for lock file maintenance PRs by doing the following:

- changing weekly schedule to eligible during any renovate run
- set prPriority so they will be at the top of the list only behind security vulnerability updates

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
