### PR TITLE
fix(ci): pin which Nix Renovate's post-upgrade tasks use

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -42,6 +42,16 @@ extra-substituters = https://crossplane.cachix.org
 extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
 EOF
 
-echo "Nix $(nix --version) installed successfully"
+# Renovate installs its own Nix when it updates flake.lock. It goes earlier on
+# PATH than ours and ignores the config above, so all nix commands we run (e.g.
+# postUpgradeTasks) will go through this launcher, which pins both the binary
+# and the config it reads.
+cat > /usr/local/bin/crossplane-nix << 'EOF'
+#!/bin/bash
+exec env NIX_CONF_DIR=/etc/nix /usr/bin/nix "$@"
+EOF
+chmod +x /usr/local/bin/crossplane-nix
+
+echo "Nix $(crossplane-nix --version) installed successfully"
 
 renovate

--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -56,8 +56,8 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'nix run .#tidy',
-          'nix run .#generate',
+          'crossplane-nix run .#tidy',
+          'crossplane-nix run .#generate',
         ],
         fileFilters: [
           '**/*',
@@ -77,7 +77,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'nix run .#lint',
+          'crossplane-nix run .#lint',
         ],
         fileFilters: [
           '**/*',

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,7 +51,7 @@ jobs:
           # Use GitHub API to create commits
           RENOVATE_PLATFORM_COMMIT: "true"
           LOG_LEVEL: ${{ github.event.inputs.logLevel || env.LOG_LEVEL }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^nix .+", "^earthly .+"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^crossplane-nix .+", "^earthly .+"]'
         with:
           configurationFile: .github/renovate.json5
           token: '${{ steps.get-github-app-token.outputs.token }}'


### PR DESCRIPTION
### Description of your changes

This PR applies the same fix from https://github.com/crossplane/crossplane/pull/7709 to crossplane-runtime, which has been verified to work OK for CC in https://github.com/crossplane/crossplane/issues/7707#issuecomment-5193874589.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
