### PR TITLE
Protect ProviderConfigs while managed resources terminate

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -205,6 +205,23 @@ func FinalizerExists(o metav1.Object, finalizer string) bool {
 	return slices.Contains(f, finalizer)
 }
 
+// FinalizersExcludingPropagation returns the supplied object's finalizers
+// without Kubernetes deletion propagation finalizers.
+func FinalizersExcludingPropagation(o metav1.Object) []string {
+	f := o.GetFinalizers()
+	out := make([]string, 0, len(f))
+
+	for _, e := range f {
+		if e == metav1.FinalizerDeleteDependents || e == metav1.FinalizerOrphanDependents {
+			continue
+		}
+
+		out = append(out, e)
+	}
+
+	return out
+}
+
 // AddLabels to the supplied object.
 func AddLabels(o metav1.Object, labels map[string]string) {
 	l := o.GetLabels()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -205,9 +205,11 @@ func FinalizerExists(o metav1.Object, finalizer string) bool {
 	return slices.Contains(f, finalizer)
 }
 
-// FinalizersExcludingPropagation returns the supplied object's finalizers
-// without Kubernetes deletion propagation finalizers.
-func FinalizersExcludingPropagation(o metav1.Object) []string {
+// NonGCFinalizers returns the supplied object's finalizers, excluding the two
+// the Kubernetes garbage collector uses to implement deletion propagation -
+// foregroundDeletion and orphan. Neither belongs to a controller, and neither
+// makes a claim on an external system.
+func NonGCFinalizers(o metav1.Object) []string {
 	f := o.GetFinalizers()
 	out := make([]string, 0, len(f))
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -605,6 +605,36 @@ func TestFinalizerExists(t *testing.T) {
 	}
 }
 
+func TestFinalizersExcludingPropagation(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		o      metav1.Object
+		want   []string
+	}{
+		"NoFinalizers": {
+			reason: "An object without finalizers has no finalizers after propagation finalizers are excluded.",
+			o:      &corev1.Pod{},
+			want:   []string{},
+		},
+		"OnlyPropagationFinalizers": {
+			reason: "Kubernetes foreground and orphan propagation finalizers must both be excluded.",
+			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{
+				metav1.FinalizerDeleteDependents,
+				metav1.FinalizerOrphanDependents,
+			}}},
+			want: []string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, FinalizersExcludingPropagation(tc.o)); diff != "" {
+				t.Errorf("%s\nFinalizersExcludingPropagation(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestAddLabels(t *testing.T) {
 	key, value := "key", "value"
 	existingKey, existingValue := "ekey", "evalue"

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -605,31 +605,45 @@ func TestFinalizerExists(t *testing.T) {
 	}
 }
 
-func TestFinalizersExcludingPropagation(t *testing.T) {
+func TestNonGCFinalizers(t *testing.T) {
+	type args struct {
+		o metav1.Object
+	}
+
 	cases := map[string]struct {
 		reason string
-		o      metav1.Object
+		args   args
 		want   []string
 	}{
 		"NoFinalizers": {
-			reason: "An object without finalizers has no finalizers after propagation finalizers are excluded.",
-			o:      &corev1.Pod{},
+			reason: "An object without finalizers has no finalizers after garbage collector finalizers are excluded.",
+			args:   args{o: &corev1.Pod{}},
 			want:   []string{},
 		},
-		"OnlyPropagationFinalizers": {
-			reason: "Kubernetes foreground and orphan propagation finalizers must both be excluded.",
-			o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{
+		"OnlyGCFinalizers": {
+			reason: "The foregroundDeletion and orphan finalizers must both be excluded.",
+			args: args{o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{
 				metav1.FinalizerDeleteDependents,
 				metav1.FinalizerOrphanDependents,
-			}}},
+			}}}},
 			want: []string{},
+		},
+		"KeepsControllerFinalizers": {
+			reason: "Finalizers that don't belong to the garbage collector must be kept, in order.",
+			args: args{o: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{
+				metav1.FinalizerDeleteDependents,
+				"example.org/first",
+				metav1.FinalizerOrphanDependents,
+				"example.org/second",
+			}}}},
+			want: []string{"example.org/first", "example.org/second"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.want, FinalizersExcludingPropagation(tc.o)); diff != "" {
-				t.Errorf("%s\nFinalizersExcludingPropagation(...): -want, +got:\n%s", tc.reason, diff)
+			if diff := cmp.Diff(tc.want, NonGCFinalizers(tc.args.o)); diff != "" {
+				t.Errorf("%s\nNonGCFinalizers(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/reconciler/managed/providerconfigusage_test.go
+++ b/pkg/reconciler/managed/providerconfigusage_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// anotherProviderConfigUsage is a second namespaced usage kind, so a scheme can
+// register more than one of them.
+type anotherProviderConfigUsage struct {
+	fake.ProviderConfigUsage
+}
+
+func (p *anotherProviderConfigUsage) DeepCopyObject() runtime.Object {
+	return &anotherProviderConfigUsage{}
+}
+
+func TestDefaultProviderConfigUsageCleaner(t *testing.T) {
+	type args struct {
+		mg     resource.Managed
+		scheme *runtime.Scheme
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   string
+	}{
+		"LegacyManaged": {
+			reason: "A cluster scoped managed resource gets a legacy tracker for the cluster scoped usage kind in its scheme.",
+			args: args{
+				mg:     &fake.LegacyManaged{},
+				scheme: fake.SchemeWith(&fake.LegacyManaged{}, &fake.LegacyProviderConfigUsage{}, &fake.ProviderConfigUsage{}),
+			},
+			want: "*resource.LegacyProviderConfigUsageTracker",
+		},
+		"ModernManaged": {
+			reason: "A namespaced managed resource gets a tracker for the namespaced usage kind in its scheme.",
+			args: args{
+				mg:     &fake.ModernManaged{},
+				scheme: fake.SchemeWith(&fake.ModernManaged{}, &fake.LegacyProviderConfigUsage{}, &fake.ProviderConfigUsage{}),
+			},
+			want: "*resource.ProviderConfigUsageTracker",
+		},
+		"NoUsageKind": {
+			reason: "A scheme that registers no usage kind yields a cleaner that does nothing.",
+			args: args{
+				mg:     &fake.ModernManaged{},
+				scheme: fake.SchemeWith(&fake.ModernManaged{}),
+			},
+			want: "resource.ProviderConfigUsageCleanerFns",
+		},
+		"UsageKindOfOtherScope": {
+			reason: "A usage kind of the other scope must not be used.",
+			args: args{
+				mg:     &fake.LegacyManaged{},
+				scheme: fake.SchemeWith(&fake.LegacyManaged{}, &fake.ProviderConfigUsage{}),
+			},
+			want: "resource.ProviderConfigUsageCleanerFns",
+		},
+		"AmbiguousUsageKind": {
+			reason: "A scheme that registers several usage kinds of the managed resource's scope yields a cleaner that does nothing.",
+			args: args{
+				mg:     &fake.ModernManaged{},
+				scheme: fake.SchemeWith(&fake.ModernManaged{}, &fake.ProviderConfigUsage{}, &anotherProviderConfigUsage{}),
+			},
+			want: "resource.ProviderConfigUsageCleanerFns",
+		},
+		"UnscopedManaged": {
+			reason: "A managed resource that is neither cluster scoped nor namespaced yields a cleaner that does nothing.",
+			args: args{
+				mg:     &fake.Managed{},
+				scheme: fake.SchemeWith(&fake.Managed{}, &fake.LegacyProviderConfigUsage{}, &fake.ProviderConfigUsage{}),
+			},
+			want: "resource.ProviderConfigUsageCleanerFns",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := &fake.Manager{Client: &test.MockClient{}, Scheme: tc.args.scheme}
+
+			got := fmt.Sprintf("%T", defaultProviderConfigUsageCleaner(m, tc.args.mg))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("%s\ndefaultProviderConfigUsageCleaner(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -19,12 +19,14 @@ package managed
 import (
 	"context"
 	"math/rand"
+	"reflect"
 	"strings"
 	"time"
 
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -622,19 +624,68 @@ type mrManaged struct {
 	resource.ProviderConfigUsageCleaner
 }
 
-func defaultMRManaged(m manager.Manager) mrManaged {
+func defaultMRManaged(m manager.Manager, mg resource.Managed) mrManaged {
 	return mrManaged{
-		CriticalAnnotationUpdater: NewRetryingCriticalAnnotationUpdater(m.GetClient()),
-		Finalizer:                 resource.NewAPIFinalizer(m.GetClient(), FinalizerName),
-		Initializer:               NewNameAsExternalName(m.GetClient()),
-		ReferenceResolver:         NewAPISimpleReferenceResolver(m.GetClient()),
-		ConnectionPublisher:       NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
-		LocalConnectionPublisher:  NewAPILocalSecretPublisher(m.GetClient(), m.GetScheme()),
-
-		// Providers opt in to ProviderConfigUsage protection by supplying their
-		// tracker via WithProviderConfigUsageCleaner.
-		ProviderConfigUsageCleaner: resource.NewNopProviderConfigUsageCleaner(),
+		CriticalAnnotationUpdater:  NewRetryingCriticalAnnotationUpdater(m.GetClient()),
+		Finalizer:                  resource.NewAPIFinalizer(m.GetClient(), FinalizerName),
+		Initializer:                NewNameAsExternalName(m.GetClient()),
+		ReferenceResolver:          NewAPISimpleReferenceResolver(m.GetClient()),
+		ConnectionPublisher:        NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
+		LocalConnectionPublisher:   NewAPILocalSecretPublisher(m.GetClient(), m.GetScheme()),
+		ProviderConfigUsageCleaner: defaultProviderConfigUsageCleaner(m, mg),
 	}
+}
+
+// defaultProviderConfigUsageCleaner returns the cleaner that protects and
+// releases the ProviderConfigUsages of the supplied managed resource. The
+// tracker family follows the managed resource's scope, and the usage kind is
+// the only ProviderConfigUsage of that scope registered with the manager's
+// scheme - the same kind the provider's connector records usages with. A
+// managed resource that is neither cluster scoped nor namespaced, or whose
+// scheme registers no or several usage kinds of its scope, gets a cleaner that
+// does nothing; WithProviderConfigUsageCleaner overrides the choice.
+func defaultProviderConfigUsageCleaner(m manager.Manager, mg resource.Managed) resource.ProviderConfigUsageCleaner {
+	switch mg.(type) {
+	case resource.LegacyManaged:
+		if u, ok := onlyUsageKind[resource.LegacyProviderConfigUsage](m.GetScheme()); ok {
+			return resource.NewLegacyProviderConfigUsageTracker(m.GetClient(), u)
+		}
+	case resource.ModernManaged:
+		if u, ok := onlyUsageKind[resource.TypedProviderConfigUsage](m.GetScheme()); ok {
+			return resource.NewProviderConfigUsageTracker(m.GetClient(), u)
+		}
+	}
+
+	return resource.NewNopProviderConfigUsageCleaner()
+}
+
+// onlyUsageKind returns the single ProviderConfigUsage kind implementing U that
+// is registered with the supplied scheme. It returns false if the scheme
+// registers no such kind, or more than one.
+func onlyUsageKind[U resource.ProviderConfigUsage](s *runtime.Scheme) (U, bool) {
+	var found []U
+
+	seen := map[reflect.Type]bool{}
+
+	for _, t := range s.AllKnownTypes() {
+		if seen[t] {
+			continue
+		}
+
+		seen[t] = true
+
+		if u, ok := reflect.New(t).Interface().(U); ok {
+			found = append(found, u)
+		}
+	}
+
+	if len(found) != 1 {
+		var zero U
+
+		return zero, false
+	}
+
+	return found[0], true
 }
 
 func (m mrManaged) PublishConnection(ctx context.Context, managed resource.Managed, c ConnectionDetails) (bool, error) {
@@ -813,14 +864,15 @@ func WithFinalizer(f resource.Finalizer) ReconcilerOption {
 }
 
 // WithProviderConfigUsageCleaner specifies how the Reconciler should protect
-// and release the managed resource's ProviderConfigUsage. Managed resources
-// that don't use a ProviderConfigUsage don't need this option; the Reconciler
-// neither protects nor releases a usage by default.
+// and release the managed resource's ProviderConfigUsage. The Reconciler adds
+// the usage's finalizer once it has connected, and removes it once the managed
+// resource no longer needs its ProviderConfig.
 //
-// Supplying a cleaner is what enables ProviderConfig deletion protection. The
-// Reconciler adds the usage's finalizer once it has connected, and removes it
-// once the managed resource no longer needs its ProviderConfig, so the
-// finalizer is only ever added where something is wired up to remove it.
+// By default the Reconciler derives a cleaner from the managed resource's scope
+// and the ProviderConfigUsage kind registered with the manager's scheme, so
+// most providers need not supply one. Supply one when the scheme registers no
+// or several usage kinds of the managed resource's scope, or supply
+// resource.NewNopProviderConfigUsageCleaner() to turn protection off.
 //
 // The cleaner need not be the tracker the provider records usages with. It's
 // only used to find the usage belonging to a managed resource, so a separately
@@ -926,7 +978,7 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOp
 		pollIntervalHook:            defaultPollIntervalHook,
 		creationGracePeriod:         defaultGracePeriod,
 		timeout:                     reconcileTimeout,
-		managed:                     defaultMRManaged(m),
+		managed:                     defaultMRManaged(m, nm()),
 		external:                    defaultMRExternal(),
 		supportedManagementPolicies: defaultSupportedManagementPolicies(),
 		log:                         logging.NewNopLogger(),

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -67,6 +67,7 @@ const (
 	errReconcileUpdate          = "update failed"
 	errReconcileDelete          = "delete failed"
 	errRecordChangeLog          = "cannot record change log entry"
+	errUntrackProviderConfig    = "cannot release ProviderConfigUsage"
 
 	errExternalResourceNotExist = "external resource does not exist"
 
@@ -615,6 +616,7 @@ type mrManaged struct {
 	Initializer
 	ReferenceResolver
 	LocalConnectionPublisher
+	resource.ProviderConfigUsageCleaner
 }
 
 func defaultMRManaged(m manager.Manager) mrManaged {
@@ -876,12 +878,18 @@ func (r *Reconciler) effectivePollInterval(o metav1.Object) time.Duration {
 
 // NewReconciler returns a Reconciler that reconciles managed resources of the
 // supplied ManagedKind with resources in an external system such as a cloud
-// provider API. It panics if asked to reconcile a managed resource kind that is
-// not registered with the supplied manager's runtime.Scheme. The returned
-// Reconciler reconciles with a dummy, no-op 'external system' by default;
-// callers should supply an ExternalConnector that returns an ExternalClient
-// capable of managing resources in a real system.
-func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOption) *Reconciler {
+// provider API. The usage cleaner should be the tracker used to track the
+// managed resource's ProviderConfigUsage. Managed resources that do not use a
+// ProviderConfigUsage should pass resource.NewNopProviderConfigUsageCleaner().
+// NewReconciler panics if the usage cleaner is nil or the managed resource kind
+// is not registered with the supplied manager's runtime.Scheme. The returned
+// Reconciler uses a no-op external system by default; callers should supply an
+// ExternalConnector that can manage resources in a real system.
+func NewReconciler(m manager.Manager, of resource.ManagedKind, usage resource.ProviderConfigUsageCleaner, o ...ReconcilerOption) *Reconciler {
+	if usage == nil {
+		panic("managed reconciler requires a ProviderConfigUsageCleaner")
+	}
+
 	nm := func() resource.Managed {
 		//nolint:forcetypeassert // If this isn't an MR it's a programming error and we want to panic.
 		return resource.MustCreateObject(schema.GroupVersionKind(of), m.GetScheme()).(resource.Managed)
@@ -907,6 +915,7 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOp
 		change:                      newNopChangeLogger(),
 		conditions:                  new(conditions.ObservedGenerationPropagationManager),
 	}
+	r.managed.ProviderConfigUsageCleaner = usage
 
 	for _, ro := range o {
 		ro(r)
@@ -1070,6 +1079,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 			return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
 		}
 
+		// Release the usage after removing the managed resource finalizer so the
+		// ProviderConfig remains available throughout deletion.
+		if err := r.managed.Untrack(ctx, managed); err != nil {
+			log.Debug("Cannot release ProviderConfigUsage", "error", err)
+			uerr := errors.Wrap(err, errUntrackProviderConfig)
+			status.MarkConditions(xpv2.Deleting(), xpv2.ReconcileError(uerr))
+			if err := updateStatus(); err != nil {
+				return reconcile.Result{Requeue: true}, errors.Wrap(err, errUpdateManagedStatus)
+			}
+			return reconcile.Result{Requeue: true}, uerr
+		}
+
 		// We've successfully unpublished our managed resource's connection
 		// details and removed our finalizer. If we assume we were the only
 		// controller that added a finalizer to this resource then it should no
@@ -1231,7 +1252,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	if meta.WasDeleted(managed) {
 		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
 
-		if len(managed.GetFinalizers()) > 1 {
+		if numControllerFinalizers(managed) > 1 {
 			// There are other controllers monitoring this resource so preserve the external instance
 			// until all other finalizers have been removed
 			log.Debug("Delay external deletion until all finalizers have been removed")
@@ -1309,6 +1330,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 			status.MarkConditions(xpv2.Deleting(), xpv2.ReconcileError(err))
 
 			return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+		}
+
+		// Release the usage after removing the managed resource finalizer so the
+		// ProviderConfig remains available throughout deletion.
+		if err := r.managed.Untrack(ctx, managed); err != nil {
+			log.Debug("Cannot release ProviderConfigUsage", "error", err)
+			uerr := errors.Wrap(err, errUntrackProviderConfig)
+			status.MarkConditions(xpv2.Deleting(), xpv2.ReconcileError(uerr))
+			if err := updateStatus(); err != nil {
+				return reconcile.Result{Requeue: true}, errors.Wrap(err, errUpdateManagedStatus)
+			}
+			return reconcile.Result{Requeue: true}, uerr
 		}
 
 		// We've successfully deleted our external resource (if necessary) and
@@ -1575,4 +1608,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	status.MarkConditions(xpv2.ReconcileSuccess())
 
 	return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+}
+
+// numControllerFinalizers returns the number of finalizers not managed by the
+// Kubernetes garbage collector.
+func numControllerFinalizers(mg resource.Managed) int {
+	return len(meta.FinalizersExcludingPropagation(mg))
 }

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -67,6 +67,7 @@ const (
 	errReconcileUpdate          = "update failed"
 	errReconcileDelete          = "delete failed"
 	errRecordChangeLog          = "cannot record change log entry"
+	errProtectProviderConfig    = "cannot protect ProviderConfigUsage"
 	errUntrackProviderConfig    = "cannot release ProviderConfigUsage"
 
 	errExternalResourceNotExist = "external resource does not exist"
@@ -83,6 +84,8 @@ const (
 	reasonCannotObserve           event.Reason = "CannotObserveExternalResource"
 	reasonCannotCreate            event.Reason = "CannotCreateExternalResource"
 	reasonCannotDelete            event.Reason = "CannotDeleteExternalResource"
+	reasonCannotProtect           event.Reason = "CannotProtectProviderConfigUsage"
+	reasonCannotUntrack           event.Reason = "CannotReleaseProviderConfigUsage"
 	reasonCannotPublish           event.Reason = "CannotPublishConnectionDetails"
 	reasonCannotUnpublish         event.Reason = "CannotUnpublishConnectionDetails"
 	reasonCannotUpdate            event.Reason = "CannotUpdateExternalResource"
@@ -627,6 +630,10 @@ func defaultMRManaged(m manager.Manager) mrManaged {
 		ReferenceResolver:         NewAPISimpleReferenceResolver(m.GetClient()),
 		ConnectionPublisher:       NewAPISecretPublisher(m.GetClient(), m.GetScheme()),
 		LocalConnectionPublisher:  NewAPILocalSecretPublisher(m.GetClient(), m.GetScheme()),
+
+		// Providers opt in to ProviderConfigUsage protection by supplying their
+		// tracker via WithProviderConfigUsageCleaner.
+		ProviderConfigUsageCleaner: resource.NewNopProviderConfigUsageCleaner(),
 	}
 }
 
@@ -805,6 +812,25 @@ func WithFinalizer(f resource.Finalizer) ReconcilerOption {
 	}
 }
 
+// WithProviderConfigUsageCleaner specifies how the Reconciler should protect
+// and release the managed resource's ProviderConfigUsage. Managed resources
+// that don't use a ProviderConfigUsage don't need this option; the Reconciler
+// neither protects nor releases a usage by default.
+//
+// Supplying a cleaner is what enables ProviderConfig deletion protection. The
+// Reconciler adds the usage's finalizer once it has connected, and removes it
+// once the managed resource no longer needs its ProviderConfig, so the
+// finalizer is only ever added where something is wired up to remove it.
+//
+// The cleaner need not be the tracker the provider records usages with. It's
+// only used to find the usage belonging to a managed resource, so a separately
+// constructed one with the same client and usage type behaves identically.
+func WithProviderConfigUsageCleaner(c resource.ProviderConfigUsageCleaner) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.managed.ProviderConfigUsageCleaner = c
+	}
+}
+
 // WithReferenceResolver specifies how the Reconciler should resolve any
 // inter-resource references it encounters while reconciling managed resources.
 func WithReferenceResolver(rr ReferenceResolver) ReconcilerOption {
@@ -878,18 +904,12 @@ func (r *Reconciler) effectivePollInterval(o metav1.Object) time.Duration {
 
 // NewReconciler returns a Reconciler that reconciles managed resources of the
 // supplied ManagedKind with resources in an external system such as a cloud
-// provider API. The usage cleaner should be the tracker used to track the
-// managed resource's ProviderConfigUsage. Managed resources that do not use a
-// ProviderConfigUsage should pass resource.NewNopProviderConfigUsageCleaner().
-// NewReconciler panics if the usage cleaner is nil or the managed resource kind
-// is not registered with the supplied manager's runtime.Scheme. The returned
-// Reconciler uses a no-op external system by default; callers should supply an
-// ExternalConnector that can manage resources in a real system.
-func NewReconciler(m manager.Manager, of resource.ManagedKind, usage resource.ProviderConfigUsageCleaner, o ...ReconcilerOption) *Reconciler {
-	if usage == nil {
-		panic("managed reconciler requires a ProviderConfigUsageCleaner")
-	}
-
+// provider API. It panics if asked to reconcile a managed resource kind that is
+// not registered with the supplied manager's runtime.Scheme. The returned
+// Reconciler reconciles with a dummy, no-op 'external system' by default;
+// callers should supply an ExternalConnector that returns an ExternalClient
+// capable of managing resources in a real system.
+func NewReconciler(m manager.Manager, of resource.ManagedKind, o ...ReconcilerOption) *Reconciler {
 	nm := func() resource.Managed {
 		//nolint:forcetypeassert // If this isn't an MR it's a programming error and we want to panic.
 		return resource.MustCreateObject(schema.GroupVersionKind(of), m.GetScheme()).(resource.Managed)
@@ -915,7 +935,6 @@ func NewReconciler(m manager.Manager, of resource.ManagedKind, usage resource.Pr
 		change:                      newNopChangeLogger(),
 		conditions:                  new(conditions.ObservedGenerationPropagationManager),
 	}
-	r.managed.ProviderConfigUsageCleaner = usage
 
 	for _, ro := range o {
 		ro(r)
@@ -1084,6 +1103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		if err := r.managed.Untrack(ctx, managed); err != nil {
 			log.Debug("Cannot release ProviderConfigUsage", "error", err)
 			uerr := errors.Wrap(err, errUntrackProviderConfig)
+			record.Event(managed, event.Warning(reasonCannotUntrack, uerr))
 			status.MarkConditions(xpv2.Deleting(), xpv2.ReconcileError(uerr))
 			if err := updateStatus(); err != nil {
 				return reconcile.Result{Requeue: true}, errors.Wrap(err, errUpdateManagedStatus)
@@ -1196,6 +1216,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		}
 	}()
 
+	// We've connected, so the managed resource is using its ProviderConfig and
+	// its usage must outlive that need. The Reconciler owns both ends of the
+	// usage finalizer - added here, removed by Untrack below - so a provider's
+	// tracker never has to, and can't get out of step with us.
+	if err := r.managed.Protect(ctx, managed); err != nil {
+		log.Debug("Cannot protect ProviderConfigUsage", "error", err)
+
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		perr := errors.Wrap(err, errProtectProviderConfig)
+		record.Event(managed, event.Warning(reasonCannotProtect, perr))
+		status.MarkConditions(xpv2.ReconcileError(perr))
+
+		return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+	}
+
 	observation, err := external.Observe(externalCtx, managed)
 	if err != nil {
 		// We'll usually hit this case if our Provider credentials are invalid
@@ -1252,7 +1290,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	if meta.WasDeleted(managed) {
 		log = log.WithValues("deletion-timestamp", managed.GetDeletionTimestamp())
 
-		if numControllerFinalizers(managed) > 1 {
+		if len(meta.NonGCFinalizers(managed)) > 1 {
 			// There are other controllers monitoring this resource so preserve the external instance
 			// until all other finalizers have been removed
 			log.Debug("Delay external deletion until all finalizers have been removed")
@@ -1337,6 +1375,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		if err := r.managed.Untrack(ctx, managed); err != nil {
 			log.Debug("Cannot release ProviderConfigUsage", "error", err)
 			uerr := errors.Wrap(err, errUntrackProviderConfig)
+			record.Event(managed, event.Warning(reasonCannotUntrack, uerr))
 			status.MarkConditions(xpv2.Deleting(), xpv2.ReconcileError(uerr))
 			if err := updateStatus(); err != nil {
 				return reconcile.Result{Requeue: true}, errors.Wrap(err, errUpdateManagedStatus)
@@ -1608,10 +1647,4 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	status.MarkConditions(xpv2.ReconcileSuccess())
 
 	return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
-}
-
-// numControllerFinalizers returns the number of finalizers not managed by the
-// Kubernetes garbage collector.
-func numControllerFinalizers(mg resource.Managed) int {
-	return len(meta.FinalizersExcludingPropagation(mg))
 }

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -2165,7 +2165,7 @@ func TestReconciler(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -2886,7 +2886,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.args.o = append(tc.args.o, WithChangeLogger(NewGRPCChangeLogger(tc.args.c, WithProviderVersion("provider-cool:v9.99.999"))))
-			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
 			r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.callCount, len(tc.args.c.requests)); diff != "" {

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -2165,7 +2165,7 @@ func TestReconciler(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -2886,7 +2886,7 @@ func TestLegacyReconcilerChangeLogs(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.args.o = append(tc.args.o, WithChangeLogger(NewGRPCChangeLogger(tc.args.c, WithProviderVersion("provider-cool:v9.99.999"))))
-			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
 			r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.callCount, len(tc.args.c.requests)); diff != "" {

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -43,28 +43,82 @@ import (
 
 var _ reconcile.Reconciler = &Reconciler{}
 
-func TestNewReconcilerRequiresProviderConfigUsageCleaner(t *testing.T) {
-	defer func() {
-		got := recover()
-		if got == nil {
-			t.Fatal("NewReconciler(...): expected a panic when the ProviderConfigUsageCleaner is nil")
-		}
+// TestProviderConfigUsageProtectedByReconciler ensures the Reconciler protects a
+// managed resource's usage itself, through the cleaner it was given, once it has
+// connected. Track never writes the finalizer, so a provider that builds a fresh
+// tracker per connection - the shape upjet generates - cannot silently end up
+// creating usages that nothing protects.
+func TestProviderConfigUsageProtectedByReconciler(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		wire   bool
+		want   bool
+	}{
+		"NotWired": {
+			reason: "A Reconciler with no cleaner must not protect the usage.",
+			wire:   false,
+			want:   false,
+		},
+		"Wired": {
+			reason: "A Reconciler given a cleaner must protect the usage once it has connected.",
+			wire:   true,
+			want:   true,
+		},
+	}
 
-		want := "managed reconciler requires a ProviderConfigUsageCleaner"
-		if diff := cmp.Diff(want, fmt.Sprint(got)); diff != "" {
-			t.Errorf("NewReconciler(...): -want panic, +got panic:\n%s", diff)
-		}
-	}()
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var protected bool
 
-	NewReconciler(nil, resource.ManagedKind{}, nil)
+			o := []ReconcilerOption{
+				WithInitializers(),
+				WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+				WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+					return &ExternalClientFns{
+						ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+							return ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+						},
+						DisconnectFn: func(_ context.Context) error { return nil },
+					}, nil
+				})),
+			}
+
+			if tc.wire {
+				o = append(o, WithProviderConfigUsageCleaner(resource.ProviderConfigUsageCleanerFns{
+					ProtectFn: func(_ context.Context, _ resource.Managed) error {
+						protected = true
+						return nil
+					},
+					UntrackFn: func(_ context.Context, _ resource.Managed) error { return nil },
+				}))
+			}
+
+			m := &fake.Manager{
+				Client: &test.MockClient{
+					MockGet:          test.NewMockGetFn(nil),
+					MockUpdate:       test.NewMockUpdateFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
+				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+			}
+
+			r := NewReconciler(m, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), o...)
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+				t.Fatalf("%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
+			}
+
+			if diff := cmp.Diff(tc.want, protected); diff != "" {
+				t.Errorf("%s\nProviderConfigUsage protected: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
 }
 
 func TestModernReconciler(t *testing.T) {
 	type args struct {
-		m     manager.Manager
-		mg    resource.ManagedKind
-		usage resource.ProviderConfigUsageCleaner
-		o     []ReconcilerOption
+		m  manager.Manager
+		mg resource.ManagedKind
+		o  []ReconcilerOption
 	}
 
 	type want struct {
@@ -198,14 +252,17 @@ func TestModernReconciler(t *testing.T) {
 						Scheme: fake.SchemeWith(&fake.ModernManaged{}),
 					},
 					mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
-					usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
-						if !finalizerRemoved {
-							t.Error("ProviderConfigUsage released before managed resource finalizer was removed")
-						}
-						return nil
-					}),
 					o: []ReconcilerOption{
 						WithManagementPolicies(),
+						WithProviderConfigUsageCleaner(resource.ProviderConfigUsageCleanerFns{
+							ProtectFn: func(_ context.Context, _ resource.Managed) error { return nil },
+							UntrackFn: func(_ context.Context, _ resource.Managed) error {
+								if !finalizerRemoved {
+									t.Error("ProviderConfigUsage released before managed resource finalizer was removed")
+								}
+								return nil
+							},
+						}),
 						WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
 							finalizerRemoved = true
 							return nil
@@ -231,12 +288,15 @@ func TestModernReconciler(t *testing.T) {
 					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
-				usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
-					return errBoom
-				}),
 				o: []ReconcilerOption{
 					WithManagementPolicies(),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+					WithProviderConfigUsageCleaner(resource.ProviderConfigUsageCleanerFns{
+						ProtectFn: func(_ context.Context, _ resource.Managed) error { return nil },
+						UntrackFn: func(_ context.Context, _ resource.Managed) error {
+							return errBoom
+						},
+					}),
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: true}, err: errors.Wrap(errBoom, errUntrackProviderConfig)},
@@ -763,10 +823,13 @@ func TestModernReconciler(t *testing.T) {
 					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
-				usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
-					return errBoom
-				}),
 				o: []ReconcilerOption{
+					WithProviderConfigUsageCleaner(resource.ProviderConfigUsageCleanerFns{
+						ProtectFn: func(_ context.Context, _ resource.Managed) error { return nil },
+						UntrackFn: func(_ context.Context, _ resource.Managed) error {
+							return errBoom
+						},
+					}),
 					WithInitializers(),
 					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
@@ -2258,11 +2321,7 @@ func TestModernReconciler(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			usage := tc.args.usage
-			if usage == nil {
-				usage = resource.NewNopProviderConfigUsageCleaner()
-			}
-			r := NewReconciler(tc.args.m, tc.args.mg, usage, tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -2928,7 +2987,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.args.o = append(tc.args.o, WithChangeLogger(NewGRPCChangeLogger(tc.args.c, WithProviderVersion("provider-cool:v9.99.999"))))
-			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
 			r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.callCount, len(tc.args.c.requests)); diff != "" {
@@ -3072,7 +3131,7 @@ func TestReconcilePollIntervalAnnotation(t *testing.T) {
 					}),
 				},
 				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
-			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
+			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
 				WithPollInterval(tc.pollInterval),
 				WithMinPollInterval(tc.minPollInterval),
 				WithInitializers(),
@@ -3161,7 +3220,7 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 					}),
 				},
 				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
-			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
+			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
 				WithInitializers(),
 				WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 				WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
@@ -3264,7 +3323,7 @@ func TestReconcilePropagationFinalizersDoNotDelayDelete(t *testing.T) {
 				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
 			}
 
-			r := NewReconciler(m, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
+			r := NewReconciler(m, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
 				WithInitializers(),
 				WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 				WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -43,11 +43,28 @@ import (
 
 var _ reconcile.Reconciler = &Reconciler{}
 
+func TestNewReconcilerRequiresProviderConfigUsageCleaner(t *testing.T) {
+	defer func() {
+		got := recover()
+		if got == nil {
+			t.Fatal("NewReconciler(...): expected a panic when the ProviderConfigUsageCleaner is nil")
+		}
+
+		want := "managed reconciler requires a ProviderConfigUsageCleaner"
+		if diff := cmp.Diff(want, fmt.Sprint(got)); diff != "" {
+			t.Errorf("NewReconciler(...): -want panic, +got panic:\n%s", diff)
+		}
+	}()
+
+	NewReconciler(nil, resource.ManagedKind{}, nil)
+}
+
 func TestModernReconciler(t *testing.T) {
 	type args struct {
-		m  manager.Manager
-		mg resource.ManagedKind
-		o  []ReconcilerOption
+		m     manager.Manager
+		mg    resource.ManagedKind
+		usage resource.ProviderConfigUsageCleaner
+		o     []ReconcilerOption
 	}
 
 	type want struct {
@@ -58,7 +75,6 @@ func TestModernReconciler(t *testing.T) {
 
 	errBoom := errors.New("boom")
 	now := metav1.Now()
-
 	cases := map[string]struct {
 		reason string
 		args   args
@@ -166,6 +182,41 @@ func TestModernReconciler(t *testing.T) {
 		},
 		"DeleteSuccessfulDeletionPolicyOrphan": {
 			reason: "Successful managed resource deletion with no-delete management policy should not trigger a requeue or status update.",
+			args: func() args {
+				finalizerRemoved := false
+				return args{
+					m: &fake.Manager{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								mg := asModernManaged(obj, 42)
+								mg.SetDeletionTimestamp(&now)
+								mg.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve})
+
+								return nil
+							}),
+						},
+						Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+					},
+					mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+					usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
+						if !finalizerRemoved {
+							t.Error("ProviderConfigUsage released before managed resource finalizer was removed")
+						}
+						return nil
+					}),
+					o: []ReconcilerOption{
+						WithManagementPolicies(),
+						WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
+							finalizerRemoved = true
+							return nil
+						}}),
+					},
+				}
+			}(),
+			want: want{result: reconcile.Result{Requeue: false}},
+		},
+		"UntrackErrorDeletionPolicyOrphan": {
+			reason: "Errors releasing the ProviderConfigUsage after orphaning the external resource should be returned.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{
@@ -173,19 +224,22 @@ func TestModernReconciler(t *testing.T) {
 							mg := asModernManaged(obj, 42)
 							mg.SetDeletionTimestamp(&now)
 							mg.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve})
-
 							return nil
 						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 					},
 					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
 				},
 				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
+					return errBoom
+				}),
 				o: []ReconcilerOption{
 					WithManagementPolicies(),
 					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
 				},
 			},
-			want: want{result: reconcile.Result{Requeue: false}},
+			want: want{result: reconcile.Result{Requeue: true}, err: errors.Wrap(errBoom, errUntrackProviderConfig)},
 		},
 		"InitializeError": {
 			reason: "Errors initializing the managed resource should trigger a requeue after a short wait.",
@@ -694,6 +748,39 @@ func TestModernReconciler(t *testing.T) {
 				},
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
+		},
+		"UntrackErrorDeletionPolicyDelete": {
+			reason: "Errors releasing the ProviderConfigUsage after deleting the external resource should be returned.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							asModernManaged(obj, 42).SetDeletionTimestamp(&now)
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+					},
+					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				usage: resource.ProviderConfigUsageCleanerFn(func(_ context.Context, _ resource.Managed) error {
+					return errBoom
+				}),
+				o: []ReconcilerOption{
+					WithInitializers(),
+					WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						return &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+							DisconnectFn: func(_ context.Context) error { return nil },
+						}, nil
+					})),
+					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{Requeue: true}, err: errors.Wrap(errBoom, errUntrackProviderConfig)},
 		},
 		"PublishObservationConnectionDetailsError": {
 			reason: "Errors publishing connection details after observation should trigger a requeue after a short wait.",
@@ -2171,7 +2258,11 @@ func TestModernReconciler(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
+			usage := tc.args.usage
+			if usage == nil {
+				usage = resource.NewNopProviderConfigUsageCleaner()
+			}
+			r := NewReconciler(tc.args.m, tc.args.mg, usage, tc.args.o...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -2837,7 +2928,7 @@ func TestReconcilerChangeLogs(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.args.o = append(tc.args.o, WithChangeLogger(NewGRPCChangeLogger(tc.args.c, WithProviderVersion("provider-cool:v9.99.999"))))
-			r := NewReconciler(tc.args.m, tc.args.mg, tc.args.o...)
+			r := NewReconciler(tc.args.m, tc.args.mg, resource.NewNopProviderConfigUsageCleaner(), tc.args.o...)
 			r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.callCount, len(tc.args.c.requests)); diff != "" {
@@ -2981,7 +3072,7 @@ func TestReconcilePollIntervalAnnotation(t *testing.T) {
 					}),
 				},
 				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
-			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
 				WithPollInterval(tc.pollInterval),
 				WithMinPollInterval(tc.minPollInterval),
 				WithInitializers(),
@@ -3070,7 +3161,7 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 					}),
 				},
 				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
-			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+			}, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
 				WithInitializers(),
 				WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
 				WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
@@ -3114,4 +3205,90 @@ func modernManagedMockGetFn(err error, generation int64) test.MockGetFn {
 		asModernManaged(obj, generation)
 		return nil
 	})
+}
+
+// TestReconcilePropagationFinalizersDoNotDelayDelete ensures Kubernetes
+// propagation finalizers do not prevent external deletion.
+func TestReconcilePropagationFinalizersDoNotDelayDelete(t *testing.T) {
+	errBoom := errors.New("boom")
+	now := metav1.Now()
+
+	cases := map[string]struct {
+		reason           string
+		finalizers       []string
+		wantDeleteCalled bool
+	}{
+		"ForegroundDeletion": {
+			reason:           "Kubernetes' foregroundDeletion finalizer must not delay the external delete.",
+			finalizers:       []string{FinalizerName, metav1.FinalizerDeleteDependents},
+			wantDeleteCalled: true,
+		},
+		"OrphanDependents": {
+			reason:           "Kubernetes' orphan finalizer must not delay the external delete.",
+			finalizers:       []string{FinalizerName, metav1.FinalizerOrphanDependents},
+			wantDeleteCalled: true,
+		},
+		"BothPropagationFinalizers": {
+			reason:           "Neither propagation finalizer must delay the external delete.",
+			finalizers:       []string{FinalizerName, metav1.FinalizerDeleteDependents, metav1.FinalizerOrphanDependents},
+			wantDeleteCalled: true,
+		},
+		"ForeignFinalizer": {
+			reason:           "A finalizer belonging to another controller must still delay the external delete.",
+			finalizers:       []string{FinalizerName, "example.org/another-controller"},
+			wantDeleteCalled: false,
+		},
+		"ForeignFinalizerAlongsidePropagation": {
+			reason:           "A foreign finalizer must delay the external delete even when a propagation finalizer is also present.",
+			finalizers:       []string{FinalizerName, metav1.FinalizerDeleteDependents, "example.org/another-controller"},
+			wantDeleteCalled: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			deleteCalled := false
+
+			m := &fake.Manager{
+				Client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						mg := asModernManaged(obj, 42)
+						mg.SetDeletionTimestamp(&now)
+						mg.SetFinalizers(tc.finalizers)
+
+						return nil
+					}),
+					MockUpdate:       test.NewMockUpdateFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
+				Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+			}
+
+			r := NewReconciler(m, resource.ManagedKind(fake.GVK(&fake.ModernManaged{})), resource.NewNopProviderConfigUsageCleaner(),
+				WithInitializers(),
+				WithReferenceResolver(ReferenceResolverFn(func(_ context.Context, _ resource.Managed) error { return nil })),
+				WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+					return &ExternalClientFns{
+						ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+							return ExternalObservation{ResourceExists: true}, nil
+						},
+						// Stop after recording whether Delete was called.
+						DeleteFn: func(_ context.Context, _ resource.Managed) (ExternalDelete, error) {
+							deleteCalled = true
+							return ExternalDelete{}, errBoom
+						},
+						DisconnectFn: func(_ context.Context) error { return nil },
+					}, nil
+				})),
+			)
+
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+				t.Errorf("%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
+			}
+
+			if diff := cmp.Diff(tc.wantDeleteCalled, deleteCalled); diff != "" {
+				t.Errorf("%s\nr.Reconcile(...): -want external Delete called, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
 }

--- a/pkg/reconciler/providerconfig/reconciler.go
+++ b/pkg/reconciler/providerconfig/reconciler.go
@@ -25,7 +25,9 @@ import (
 
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -45,6 +47,8 @@ const (
 	errGetPC        = "cannot get ProviderConfig"
 	errListPCUs     = "cannot list ProviderConfigUsages"
 	errDeletePCU    = "cannot delete ProviderConfigUsage"
+	errGetPCUOwner  = "cannot get ProviderConfigUsage owner"
+	errReleasePCU   = "cannot release ProviderConfigUsage"
 	errUpdate       = "cannot update ProviderConfig"
 	errUpdateStatus = "cannot update ProviderConfig status"
 )
@@ -83,6 +87,8 @@ func ControllerName(kind string) string {
 // for which it is responsible.
 type Reconciler struct {
 	client client.Client
+	// apiReader bypasses the cache when checking a usage's owner.
+	apiReader client.Reader
 
 	newConfig    func() resource.ProviderConfig
 	newUsageList func() resource.ProviderConfigUsageList
@@ -127,7 +133,8 @@ func NewReconciler(m manager.Manager, of resource.ProviderConfigKinds, o ...Reco
 	_, _ = nc(), nul()
 
 	r := &Reconciler{
-		client: m.GetClient(),
+		client:    m.GetClient(),
+		apiReader: m.GetAPIReader(),
 
 		newConfig:    nc,
 		newUsageList: nul,
@@ -192,8 +199,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	users := int64(len(l.GetItems()))
+
+	// Requeue while waiting for an owner because this controller does not watch
+	// managed resources.
+	recheck := false
+
 	for _, pcu := range l.GetItems() {
-		if metav1.GetControllerOf(pcu) == nil {
+		ref := metav1.GetControllerOf(pcu)
+		if ref == nil {
 			// Usages should always have a controller reference. If this one has
 			// none it's probably been stripped off (e.g. by a Velero restore).
 			// We can safely delete it - it's either stale, or will be recreated
@@ -206,10 +219,62 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 
 			users--
+			continue
 		}
+
+		if !meta.WasDeleted(pcu) || !meta.FinalizerExists(pcu, resource.ProviderConfigUsageFinalizer) {
+			continue
+		}
+
+		// Read the owner from the API server, not the cache. This reconciler
+		// runs inside providers that configure their own manager cache; an
+		// informer restricted by selector or namespace, or one that isn't
+		// synced, reports a live owner as not found. Releasing the usage on a
+		// false not-found lets the ProviderConfig and its credentials go while
+		// the owner is still deleting its external resource.
+		owner := &unstructured.Unstructured{}
+		owner.SetAPIVersion(ref.APIVersion)
+		owner.SetKind(ref.Kind)
+
+		err := r.apiReader.Get(ctx, client.ObjectKey{Namespace: pcu.GetNamespace(), Name: ref.Name}, owner)
+		if err != nil && !apierrors.IsNotFound(err) {
+			// We can't tell whether the owner still needs its ProviderConfig -
+			// its kind may no longer be served, for example. Keep blocking
+			// deletion and surface why, rather than risking orphaned external
+			// resources.
+			log.Debug(errGetPCUOwner, "error", err)
+			r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errGetPCUOwner)))
+
+			recheck = true
+			continue
+		}
+
+		if err == nil && owner.GetUID() == ref.UID && !ownerFinishedTeardown(owner) {
+			// Recheck the usage after its owner has had time to finish deleting.
+			recheck = true
+			continue
+		}
+
+		// The owner is gone, was recreated, or has finished tearing down its
+		// external resource. Nothing will release this usage but us.
+		meta.RemoveFinalizer(pcu, resource.ProviderConfigUsageFinalizer)
+		if err := r.client.Update(ctx, pcu); resource.IgnoreNotFound(err) != nil {
+			log.Debug(errReleasePCU, "error", err)
+			r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errReleasePCU)))
+
+			recheck = true
+			continue
+		}
+
+		users--
 	}
 
 	log = log.WithValues("usages", users)
+
+	res := reconcile.Result{Requeue: false}
+	if recheck {
+		res = reconcile.Result{RequeueAfter: shortWait}
+	}
 
 	if meta.WasDeleted(pc) {
 		if users > 0 {
@@ -218,11 +283,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			log.Debug(msg)
 			r.record.Event(pc, event.Warning(reasonAccount, errors.New(msg)))
 
-			// We're watching our usages, so we'll be requeued when they go.
+			// Requeue if a terminating usage is waiting for its owner to finish.
 			pc.SetUsers(users)
 			pc.SetConditions(Terminating().WithMessage(msg))
 
-			return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pc), errUpdateStatus)
+			return res, errors.Wrap(r.client.Status().Update(ctx, pc), errUpdateStatus)
 		}
 
 		meta.RemoveFinalizer(pc, finalizer)
@@ -243,8 +308,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{RequeueAfter: shortWait}, nil
 	}
 
-	// There's no need to requeue explicitly - we're watching all PCs.
+	// Requeue only while waiting for a managed resource to finish deleting.
 	pc.SetUsers(users)
 
-	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pc), errUpdateStatus)
+	return res, errors.Wrap(r.client.Status().Update(ctx, pc), errUpdateStatus)
+}
+
+// ownerFinishedTeardown returns true if the supplied owner is being deleted and
+// has no finalizers other than Kubernetes deletion propagation finalizers.
+func ownerFinishedTeardown(owner metav1.Object) bool {
+	return meta.WasDeleted(owner) && len(meta.FinalizersExcludingPropagation(owner)) == 0
 }

--- a/pkg/reconciler/providerconfig/reconciler.go
+++ b/pkg/reconciler/providerconfig/reconciler.go
@@ -205,68 +205,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	recheck := false
 
 	for _, pcu := range l.GetItems() {
-		ref := metav1.GetControllerOf(pcu)
-		if ref == nil {
-			// Usages should always have a controller reference. If this one has
-			// none it's probably been stripped off (e.g. by a Velero restore).
-			// We can safely delete it - it's either stale, or will be recreated
-			// next time the relevant managed resource connects.
-			if err := r.client.Delete(ctx, pcu); resource.IgnoreNotFound(err) != nil {
-				log.Debug(errDeletePCU, "error", err)
-				r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errDeletePCU)))
-
+		if metav1.GetControllerOf(pcu) == nil {
+			if err := r.deleteOrphanedUsage(ctx, log, pc, pcu); err != nil {
 				return reconcile.Result{RequeueAfter: shortWait}, nil
 			}
 
 			users--
+
 			continue
 		}
 
-		if !meta.WasDeleted(pcu) || !meta.FinalizerExists(pcu, resource.ProviderConfigUsageFinalizer) {
-			continue
-		}
-
-		// Read the owner from the API server, not the cache. This reconciler
-		// runs inside providers that configure their own manager cache; an
-		// informer restricted by selector or namespace, or one that isn't
-		// synced, reports a live owner as not found. Releasing the usage on a
-		// false not-found lets the ProviderConfig and its credentials go while
-		// the owner is still deleting its external resource.
-		owner := &unstructured.Unstructured{}
-		owner.SetAPIVersion(ref.APIVersion)
-		owner.SetKind(ref.Kind)
-
-		err := r.apiReader.Get(ctx, client.ObjectKey{Namespace: pcu.GetNamespace(), Name: ref.Name}, owner)
-		if err != nil && !apierrors.IsNotFound(err) {
-			// We can't tell whether the owner still needs its ProviderConfig -
-			// its kind may no longer be served, for example. Keep blocking
-			// deletion and surface why, rather than risking orphaned external
-			// resources.
-			log.Debug(errGetPCUOwner, "error", err)
-			r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errGetPCUOwner)))
-
+		released, wait := r.releaseUsage(ctx, log, pc, pcu)
+		if wait {
 			recheck = true
-			continue
 		}
 
-		if err == nil && owner.GetUID() == ref.UID && !ownerFinishedTeardown(owner) {
-			// Recheck the usage after its owner has had time to finish deleting.
-			recheck = true
-			continue
+		if released {
+			users--
 		}
-
-		// The owner is gone, was recreated, or has finished tearing down its
-		// external resource. Nothing will release this usage but us.
-		meta.RemoveFinalizer(pcu, resource.ProviderConfigUsageFinalizer)
-		if err := r.client.Update(ctx, pcu); resource.IgnoreNotFound(err) != nil {
-			log.Debug(errReleasePCU, "error", err)
-			r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errReleasePCU)))
-
-			recheck = true
-			continue
-		}
-
-		users--
 	}
 
 	log = log.WithValues("usages", users)
@@ -314,8 +270,90 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return res, errors.Wrap(r.client.Status().Update(ctx, pc), errUpdateStatus)
 }
 
+// deleteOrphanedUsage removes a ProviderConfigUsage that has no controller
+// reference. Usages should always have one; if this one has none it's probably
+// been stripped off (e.g. by a Velero restore). It's either stale, or will be
+// recreated next time the relevant managed resource connects.
+func (r *Reconciler) deleteOrphanedUsage(ctx context.Context, log logging.Logger, pc resource.ProviderConfig, pcu resource.ProviderConfigUsage) error {
+	// Release our finalizer first. Without an owner reference we can't tell
+	// which managed resource would remove it, so deleting the usage while
+	// it's still finalized would leave it terminating forever - and in turn
+	// block its namespace from being deleted.
+	if meta.FinalizerExists(pcu, resource.ProviderConfigUsageFinalizer) {
+		meta.RemoveFinalizer(pcu, resource.ProviderConfigUsageFinalizer)
+
+		if err := r.client.Update(ctx, pcu); resource.IgnoreNotFound(err) != nil {
+			log.Debug(errReleasePCU, "error", err)
+			r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errReleasePCU)))
+
+			return errors.Wrap(err, errReleasePCU)
+		}
+	}
+
+	if err := r.client.Delete(ctx, pcu); resource.IgnoreNotFound(err) != nil {
+		log.Debug(errDeletePCU, "error", err)
+		r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errDeletePCU)))
+
+		return errors.Wrap(err, errDeletePCU)
+	}
+
+	return nil
+}
+
+// releaseUsage releases a terminating ProviderConfigUsage whose owner is gone,
+// was replaced, or has finished tearing down its external resource - nothing
+// else will. It reports whether the usage no longer counts as a user of the
+// ProviderConfig, and whether the ProviderConfig should be rechecked later
+// because the usage is still waiting for its owner.
+func (r *Reconciler) releaseUsage(ctx context.Context, log logging.Logger, pc resource.ProviderConfig, pcu resource.ProviderConfigUsage) (bool, bool) {
+	if !meta.WasDeleted(pcu) || !meta.FinalizerExists(pcu, resource.ProviderConfigUsageFinalizer) {
+		return false, false
+	}
+
+	ref := metav1.GetControllerOf(pcu)
+
+	// Read the owner from the API server, not the cache. This reconciler
+	// runs inside providers that configure their own manager cache; an
+	// informer restricted by selector or namespace, or one that isn't
+	// synced, reports a live owner as not found. Releasing the usage on a
+	// false not-found lets the ProviderConfig and its credentials go while
+	// the owner is still deleting its external resource.
+	owner := &unstructured.Unstructured{}
+	owner.SetAPIVersion(ref.APIVersion)
+	owner.SetKind(ref.Kind)
+
+	err := r.apiReader.Get(ctx, client.ObjectKey{Namespace: pcu.GetNamespace(), Name: ref.Name}, owner)
+	if err != nil && !apierrors.IsNotFound(err) {
+		// We can't tell whether the owner still needs its ProviderConfig -
+		// its kind may no longer be served, for example. Keep blocking
+		// deletion and surface why, rather than risking orphaned external
+		// resources.
+		log.Debug(errGetPCUOwner, "error", err)
+		r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errGetPCUOwner)))
+
+		return false, true
+	}
+
+	if err == nil && owner.GetUID() == ref.UID && !ownerFinishedTeardown(owner) {
+		// Recheck the usage after its owner has had time to finish deleting.
+		return false, true
+	}
+
+	// The owner is gone, was recreated, or has finished tearing down its
+	// external resource. Nothing will release this usage but us.
+	meta.RemoveFinalizer(pcu, resource.ProviderConfigUsageFinalizer)
+	if err := r.client.Update(ctx, pcu); resource.IgnoreNotFound(err) != nil {
+		log.Debug(errReleasePCU, "error", err)
+		r.record.Event(pc, event.Warning(reasonAccount, errors.Wrap(err, errReleasePCU)))
+
+		return false, true
+	}
+
+	return true, false
+}
+
 // ownerFinishedTeardown returns true if the supplied owner is being deleted and
 // has no finalizers other than Kubernetes deletion propagation finalizers.
 func ownerFinishedTeardown(owner metav1.Object) bool {
-	return meta.WasDeleted(owner) && len(meta.FinalizersExcludingPropagation(owner)) == 0
+	return meta.WasDeleted(owner) && len(meta.NonGCFinalizers(owner)) == 0
 }

--- a/pkg/reconciler/providerconfig/reconciler_test.go
+++ b/pkg/reconciler/providerconfig/reconciler_test.go
@@ -494,6 +494,69 @@ func TestReapOrphanedProviderConfigUsage(t *testing.T) {
 	}
 }
 
+// TestReapProviderConfigUsageWithoutController ensures a usage that lost its
+// controller reference has its finalizer released before it's deleted. Nothing
+// else can release it, so deleting it while finalized would leave it
+// terminating forever.
+func TestReapProviderConfigUsageWithoutController(t *testing.T) {
+	released := false
+	deleted := false
+
+	pcu := &fake.ProviderConfigUsage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pcu",
+			Finalizers: []string{resource.ProviderConfigUsageFinalizer},
+		},
+	}
+
+	c := &test.MockClient{
+		MockGet: test.NewMockGetFn(nil),
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			// Test-only; always our list type.
+			obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{pcu}
+			return nil
+		}),
+		MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+			if u, ok := obj.(*fake.ProviderConfigUsage); ok && len(u.GetFinalizers()) == 0 {
+				released = true
+			}
+			return nil
+		}),
+		MockDelete: test.NewMockDeleteFn(nil, func(_ client.Object) error {
+			if !released {
+				t.Error("Reconcile(...): the ProviderConfigUsage was deleted before its finalizer was released")
+			}
+
+			deleted = true
+
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+	}
+
+	m := &fake.Manager{
+		Client: c,
+		Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+	}
+	r := NewReconciler(m, resource.ProviderConfigKinds{
+		Config:    fake.GVK(&fake.ProviderConfig{}),
+		Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+		UsageList: fake.GVK(&ProviderConfigUsageList{}),
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}}); err != nil {
+		t.Fatalf("Reconcile(...): unexpected error: %v", err)
+	}
+
+	if !released {
+		t.Error("Reconcile(...): expected the ProviderConfigUsage finalizer to be released, but it was not")
+	}
+
+	if !deleted {
+		t.Error("Reconcile(...): expected the ProviderConfigUsage to be deleted, but it was not")
+	}
+}
+
 // TestReapProviderConfigUsageWhoseOwnerFinishedTeardown ensures a usage is
 // released after its deleting owner removes its controller finalizers.
 func TestReapProviderConfigUsageWhoseOwnerFinishedTeardown(t *testing.T) {

--- a/pkg/reconciler/providerconfig/reconciler_test.go
+++ b/pkg/reconciler/providerconfig/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -425,5 +427,430 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// TestReapOrphanedProviderConfigUsage ensures a usage is released after its
+// owner is gone.
+func TestReapOrphanedProviderConfigUsage(t *testing.T) {
+	now := metav1.Now()
+	uid := types.UID("owner-uid")
+	ctrl := true
+	reaped := false
+
+	pcu := &fake.ProviderConfigUsage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pcu",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{resource.ProviderConfigUsageFinalizer},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "example.org/v1",
+				Kind:       "Thing",
+				Name:       "thing",
+				UID:        uid,
+				Controller: &ctrl,
+			}},
+		},
+	}
+
+	c := &test.MockClient{
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			// Return NotFound only for the usage owner.
+			if _, ok := obj.(*unstructured.Unstructured); ok {
+				return kerrors.NewNotFound(schema.GroupResource{Group: "example.org", Resource: "things"}, "thing")
+			}
+			return nil
+		}),
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			// Test-only; always our list type.
+			obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{pcu}
+			return nil
+		}),
+		MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+			// Record an update that removes the usage finalizer.
+			if u, ok := obj.(*fake.ProviderConfigUsage); ok && len(u.GetFinalizers()) == 0 {
+				reaped = true
+			}
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+	}
+
+	m := &fake.Manager{
+		Client: c,
+		Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+	}
+	r := NewReconciler(m, resource.ProviderConfigKinds{
+		Config:    fake.GVK(&fake.ProviderConfig{}),
+		Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+		UsageList: fake.GVK(&ProviderConfigUsageList{}),
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}}); err != nil {
+		t.Fatalf("Reconcile(...): unexpected error: %v", err)
+	}
+	if !reaped {
+		t.Error("Reconcile(...): expected the orphaned ProviderConfigUsage finalizer to be released, but it was not")
+	}
+}
+
+// TestReapProviderConfigUsageWhoseOwnerFinishedTeardown ensures a usage is
+// released after its deleting owner removes its controller finalizers.
+func TestReapProviderConfigUsageWhoseOwnerFinishedTeardown(t *testing.T) {
+	now := metav1.Now()
+	uid := types.UID("owner-uid")
+	ctrl := true
+
+	cases := map[string]struct {
+		reason          string
+		ownerDeleting   bool
+		ownerFinalizers []string
+		wantReaped      bool
+		wantRequeue     bool
+	}{
+		"OwnerFinishedTeardown": {
+			reason:          "A deleting owner holding only Kubernetes' propagation finalizer has completed teardown, so the usage must be released.",
+			ownerDeleting:   true,
+			ownerFinalizers: []string{"foregroundDeletion"},
+			wantReaped:      true,
+			wantRequeue:     false,
+		},
+		"OwnerHoldsNoFinalizersAtAll": {
+			reason:          "A deleting owner with no finalizers left has nothing outstanding, so the usage must be released.",
+			ownerDeleting:   true,
+			ownerFinalizers: nil,
+			wantReaped:      true,
+			wantRequeue:     false,
+		},
+		"OwnerStillHoldsItsOwnFinalizer": {
+			reason:          "A deleting owner that still holds its own finalizer has not finished tearing down. The usage must be left alone, and because we watch usages and ProviderConfigs - not managed resources - nothing will notify us when that owner finishes, so we must ask to be re-queued.",
+			ownerDeleting:   true,
+			ownerFinalizers: []string{"finalizer.managedresource.crossplane.io", "foregroundDeletion"},
+			wantReaped:      false,
+			wantRequeue:     true,
+		},
+		"OwnerIsNotDeleting": {
+			reason:          "A live owner still needs its ProviderConfig, so the usage must be left alone - and re-checked, since nothing will tell us when it starts deleting.",
+			ownerDeleting:   false,
+			ownerFinalizers: nil,
+			wantReaped:      false,
+			wantRequeue:     true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			reaped := false
+			pcu := &fake.ProviderConfigUsage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pcu",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{resource.ProviderConfigUsageFinalizer},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "example.org/v1",
+						Kind:       "Thing",
+						Name:       "thing",
+						UID:        uid,
+						Controller: &ctrl,
+					}},
+				},
+			}
+
+			c := &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					// Return the current usage owner.
+					u, ok := obj.(*unstructured.Unstructured)
+					if !ok {
+						return nil
+					}
+					u.SetName("thing")
+					u.SetUID(uid)
+					u.SetFinalizers(tc.ownerFinalizers)
+					if tc.ownerDeleting {
+						u.SetDeletionTimestamp(&now)
+					}
+					return nil
+				}),
+				MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+					// Test-only; always our list type.
+					obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{pcu}
+					return nil
+				}),
+				MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+					if u, ok := obj.(*fake.ProviderConfigUsage); ok && len(u.GetFinalizers()) == 0 {
+						reaped = true
+					}
+					return nil
+				}),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			}
+
+			m := &fake.Manager{
+				Client: c,
+				Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+			}
+			r := NewReconciler(m, resource.ProviderConfigKinds{
+				Config:    fake.GVK(&fake.ProviderConfig{}),
+				Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+				UsageList: fake.GVK(&ProviderConfigUsageList{}),
+			})
+
+			got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}})
+			if err != nil {
+				t.Fatalf("%s\nReconcile(...): unexpected error: %v", tc.reason, err)
+			}
+			if diff := cmp.Diff(tc.wantReaped, reaped); diff != "" {
+				t.Errorf("%s\nReconcile(...): -want usage released, +got:\n%s", tc.reason, diff)
+			}
+			// The reconciler must requeue because it does not watch the owner.
+			if diff := cmp.Diff(tc.wantRequeue, got.RequeueAfter > 0); diff != "" {
+				t.Errorf("%s\nReconcile(...): -want a re-queue, +got (result %+v):\n%s", tc.reason, got, diff)
+			}
+		})
+	}
+}
+
+// A recorder that captures the events it is asked to record.
+type recorder struct{ events []event.Event }
+
+func (r *recorder) Event(_ runtime.Object, e event.Event) { r.events = append(r.events, e) }
+
+func (r *recorder) WithAnnotations(_ ...string) event.Recorder { return r }
+
+// terminatingUsage returns a usage that is being deleted, and that is waiting
+// for its owner to release it.
+func terminatingUsage(name, owner string, uid types.UID, deleted *metav1.Time) *fake.ProviderConfigUsage {
+	ctrl := true
+
+	return &fake.ProviderConfigUsage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			DeletionTimestamp: deleted,
+			Finalizers:        []string{resource.ProviderConfigUsageFinalizer},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "example.org/v1",
+				Kind:       "Thing",
+				Name:       owner,
+				UID:        uid,
+				Controller: &ctrl,
+			}},
+		},
+	}
+}
+
+// TestReapUsageWhileProviderConfigLives ensures a terminating usage does not
+// remain stuck when its owner is gone, even if its ProviderConfig is not being
+// deleted.
+func TestReapUsageWhileProviderConfigLives(t *testing.T) {
+	now := metav1.Now()
+	pcu := terminatingUsage("pcu", "thing", types.UID("owner-uid"), &now)
+
+	var users int64
+	released := false
+
+	c := &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			if _, ok := obj.(*unstructured.Unstructured); ok {
+				return kerrors.NewNotFound(schema.GroupResource{Group: "example.org", Resource: "things"}, key.Name)
+			}
+			return nil
+		},
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			// Test-only; always our list type.
+			obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{pcu}
+			return nil
+		}),
+		MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+			if u, ok := obj.(*fake.ProviderConfigUsage); ok && len(u.GetFinalizers()) == 0 {
+				released = true
+			}
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(obj client.Object) error {
+			if pc, ok := obj.(*fake.ProviderConfig); ok {
+				users = pc.GetUsers()
+			}
+			return nil
+		}),
+	}
+
+	m := &fake.Manager{
+		Client: c,
+		Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+	}
+	r := NewReconciler(m, resource.ProviderConfigKinds{
+		Config:    fake.GVK(&fake.ProviderConfig{}),
+		Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+		UsageList: fake.GVK(&ProviderConfigUsageList{}),
+	})
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}})
+	if err != nil {
+		t.Fatalf("Reconcile(...): unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(reconcile.Result{Requeue: false}, got); diff != "" {
+		t.Errorf("Reconcile(...): -want, +got:\n%s", diff)
+	}
+
+	if !released {
+		t.Error("Reconcile(...): did not release the terminating usage")
+	}
+
+	if diff := cmp.Diff(int64(0), users); diff != "" {
+		t.Errorf("Reconcile(...): -want users, +got users:\n%s", diff)
+	}
+}
+
+// TestBlockDeletionWhenUsageOwnerIsUnreadable ensures we keep blocking
+// ProviderConfig deletion - loudly - when we can't tell whether a usage's owner
+// still needs it. Releasing the usage would let the ProviderConfig and its
+// credentials go while the owner may still be deleting its external resource.
+func TestBlockDeletionWhenUsageOwnerIsUnreadable(t *testing.T) {
+	errBoom := errors.New("boom")
+	now := metav1.Now()
+	pcu := terminatingUsage("pcu", "thing", types.UID("owner-uid"), &now)
+
+	var users int64
+
+	c := &test.MockClient{
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			if pc, ok := obj.(*fake.ProviderConfig); ok {
+				pc.SetDeletionTimestamp(&now)
+				pc.SetFinalizers([]string{finalizer})
+				return nil
+			}
+			// The owner's kind may no longer be served, for example.
+			if _, ok := obj.(*unstructured.Unstructured); ok {
+				return errBoom
+			}
+			return nil
+		}),
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			// Test-only; always our list type.
+			obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{pcu}
+			return nil
+		}),
+		MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+			// Neither the usage nor the ProviderConfig may be released.
+			t.Errorf("Reconcile(...): unexpected update of %T %s", obj, obj.GetName())
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(obj client.Object) error {
+			if pc, ok := obj.(*fake.ProviderConfig); ok {
+				users = pc.GetUsers()
+			}
+			return nil
+		}),
+	}
+
+	m := &fake.Manager{
+		Client: c,
+		Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+	}
+	rec := &recorder{}
+	r := NewReconciler(m, resource.ProviderConfigKinds{
+		Config:    fake.GVK(&fake.ProviderConfig{}),
+		Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+		UsageList: fake.GVK(&ProviderConfigUsageList{}),
+	}, WithRecorder(rec))
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}})
+	if err != nil {
+		t.Fatalf("Reconcile(...): unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(reconcile.Result{RequeueAfter: shortWait}, got); diff != "" {
+		t.Errorf("Reconcile(...): -want, +got:\n%s", diff)
+	}
+
+	// The usage must still be counted, and our status must say so - a silent
+	// requeue loop would leave nothing to debug.
+	if diff := cmp.Diff(int64(1), users); diff != "" {
+		t.Errorf("Reconcile(...): -want users, +got users:\n%s", diff)
+	}
+
+	want := []event.Event{
+		event.Warning(reasonAccount, errors.Wrap(errBoom, errGetPCUOwner)),
+		event.Warning(reasonAccount, errors.New("Blocking deletion while usages still exist")),
+	}
+	if diff := cmp.Diff(want, rec.events); diff != "" {
+		t.Errorf("Reconcile(...): -want events, +got events:\n%s", diff)
+	}
+}
+
+// TestAccountForUsagesWhenOneOwnerIsUnreadable ensures one unreadable owner
+// doesn't stop us accounting for - and releasing - the rest of the usages.
+func TestAccountForUsagesWhenOneOwnerIsUnreadable(t *testing.T) {
+	errBoom := errors.New("boom")
+	now := metav1.Now()
+
+	unreadable := terminatingUsage("pcu-unreadable", "unreadable", types.UID("unreadable-uid"), &now)
+	orphaned := terminatingUsage("pcu-orphaned", "orphaned", types.UID("orphaned-uid"), &now)
+
+	var users int64
+
+	released := []string{}
+
+	c := &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			if pc, ok := obj.(*fake.ProviderConfig); ok {
+				pc.SetDeletionTimestamp(&now)
+				pc.SetFinalizers([]string{finalizer})
+				return nil
+			}
+			if _, ok := obj.(*unstructured.Unstructured); !ok {
+				return nil
+			}
+			if key.Name == "unreadable" {
+				return errBoom
+			}
+			return kerrors.NewNotFound(schema.GroupResource{Group: "example.org", Resource: "things"}, key.Name)
+		},
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			// Test-only; always our list type.
+			obj.(*ProviderConfigUsageList).Items = []resource.ProviderConfigUsage{unreadable, orphaned}
+			return nil
+		}),
+		MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+			if u, ok := obj.(*fake.ProviderConfigUsage); ok && len(u.GetFinalizers()) == 0 {
+				released = append(released, u.GetName())
+			}
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(obj client.Object) error {
+			if pc, ok := obj.(*fake.ProviderConfig); ok {
+				users = pc.GetUsers()
+			}
+			return nil
+		}),
+	}
+
+	m := &fake.Manager{
+		Client: c,
+		Scheme: fake.SchemeWith(&fake.ProviderConfig{}, &fake.ProviderConfigUsage{}, &ProviderConfigUsageList{}),
+	}
+	r := NewReconciler(m, resource.ProviderConfigKinds{
+		Config:    fake.GVK(&fake.ProviderConfig{}),
+		Usage:     fake.GVK(&fake.ProviderConfigUsage{}),
+		UsageList: fake.GVK(&ProviderConfigUsageList{}),
+	})
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "pc"}})
+	if err != nil {
+		t.Fatalf("Reconcile(...): unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(reconcile.Result{RequeueAfter: shortWait}, got); diff != "" {
+		t.Errorf("Reconcile(...): -want, +got:\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]string{"pcu-orphaned"}, released); diff != "" {
+		t.Errorf("Reconcile(...): -want released usages, +got:\n%s", diff)
+	}
+
+	// Only the usage we couldn't account for still blocks deletion.
+	if diff := cmp.Diff(int64(1), users); diff != "" {
+		t.Errorf("Reconcile(...): -want users, +got users:\n%s", diff)
 	}
 }

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -550,6 +550,9 @@ func (m *Manager) GetCache() cache.Cache { return m.Cache }
 // GetClient returns the client.
 func (m *Manager) GetClient() client.Client { return m.Client }
 
+// GetAPIReader returns the client, acting as a (non-caching) API reader.
+func (m *Manager) GetAPIReader() client.Reader { return m.Client }
+
 // GetScheme returns the scheme.
 func (m *Manager) GetScheme() *runtime.Scheme { return m.Scheme }
 

--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -201,8 +201,9 @@ func (fns ProviderConfigUsageCleanerFns) Untrack(ctx context.Context, mg Managed
 }
 
 // NewNopProviderConfigUsageCleaner returns a ProviderConfigUsageCleaner that
-// does nothing. It is intended for managed resources that do not use a
-// ProviderConfigUsage.
+// does nothing. It is the default for managed resources whose scheme registers
+// no usable ProviderConfigUsage kind, and turns ProviderConfig deletion
+// protection off when supplied to a managed reconciler explicitly.
 func NewNopProviderConfigUsageCleaner() ProviderConfigUsageCleaner {
 	return ProviderConfigUsageCleanerFns{
 		ProtectFn: func(context.Context, Managed) error { return nil },
@@ -303,6 +304,13 @@ func (u *ProviderConfigUsageTracker) Protect(ctx context.Context, mg Managed) er
 		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
 	}
 
+	// The API server refuses new finalizers on an object that is being
+	// deleted. The usage will be recreated, and protected, on the next
+	// reconcile once it's gone.
+	if meta.WasDeleted(pcu) {
+		return nil
+	}
+
 	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).AddFinalizer(ctx, pcu), errAddPCUFinalizer)
 }
 
@@ -391,6 +399,13 @@ func (u *LegacyProviderConfigUsageTracker) Protect(ctx context.Context, mg Manag
 
 	if err := u.client.Get(ctx, client.ObjectKeyFromObject(pcu), pcu); err != nil {
 		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
+	}
+
+	// The API server refuses new finalizers on an object that is being
+	// deleted. The usage will be recreated, and protected, on the next
+	// reconcile once it's gone.
+	if meta.WasDeleted(pcu) {
+		return nil
 	}
 
 	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).AddFinalizer(ctx, pcu), errAddPCUFinalizer)

--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -41,7 +41,15 @@ const (
 	errMissingPCRef          = "managed resource does not reference a ProviderConfig"
 	errMissingPCRefKind      = "managed resource ProviderConfig reference has no Kind"
 	errApplyPCU              = "cannot apply ProviderConfigUsage"
+	errGetPCU                = "cannot get ProviderConfigUsage"
+	errRemovePCUFinalizer    = "cannot remove ProviderConfigUsage finalizer"
+	errFmtPCUNotModern       = "cannot release ProviderConfigUsage: %T is not a namespaced managed resource, so this tracker cannot resolve its usage"
+	errFmtPCUNotLegacy       = "cannot release ProviderConfigUsage: %T is not a cluster-scoped managed resource, so this tracker cannot resolve its usage"
 )
+
+// ProviderConfigUsageFinalizer keeps a ProviderConfigUsage alive until the
+// managed resource that owns it has finished deleting its external resource.
+const ProviderConfigUsageFinalizer = "finalizer.providerconfigusage.crossplane.io"
 
 type missingRefError struct{ error }
 
@@ -154,23 +162,46 @@ func (fn ModernTrackerFn) Track(ctx context.Context, mg ModernManaged) error {
 	return fn(ctx, mg)
 }
 
+// A ProviderConfigUsageCleaner releases the ProviderConfigUsage of a managed
+// resource after it no longer needs its ProviderConfig.
+type ProviderConfigUsageCleaner interface {
+	Untrack(ctx context.Context, mg Managed) error
+}
+
+// A ProviderConfigUsageCleanerFn releases a ProviderConfigUsage.
+type ProviderConfigUsageCleanerFn func(ctx context.Context, mg Managed) error
+
+// Untrack the supplied managed resource.
+func (fn ProviderConfigUsageCleanerFn) Untrack(ctx context.Context, mg Managed) error {
+	return fn(ctx, mg)
+}
+
+// NewNopProviderConfigUsageCleaner returns a ProviderConfigUsageCleaner that
+// does nothing. It is intended for managed resources that do not use a
+// ProviderConfigUsage.
+func NewNopProviderConfigUsageCleaner() ProviderConfigUsageCleaner {
+	return ProviderConfigUsageCleanerFn(func(context.Context, Managed) error { return nil })
+}
+
 // A ProviderConfigUsageTracker tracks usages of a ProviderConfig by creating or
 // updating the appropriate ProviderConfigUsage.
 type ProviderConfigUsageTracker struct {
-	c  Applicator
-	of ProviderConfigUsage
+	client client.Client
+	c      Applicator
+	of     ProviderConfigUsage
 }
 
 // NewProviderConfigUsageTracker creates a ProviderConfigUsageTracker.
 func NewProviderConfigUsageTracker(c client.Client, of TypedProviderConfigUsage) *ProviderConfigUsageTracker {
-	return &ProviderConfigUsageTracker{c: NewAPIUpdatingApplicator(c), of: of}
+	return &ProviderConfigUsageTracker{client: c, c: NewAPIUpdatingApplicator(c), of: of}
 }
 
 // Track that the supplied Managed resource is using the ProviderConfig it
 // references by creating or updating a ProviderConfigUsage. Track should be
 // called _before_ attempting to use the ProviderConfig. This ensures the
 // managed resource's usage is updated if the managed resource is updated to
-// reference a misconfigured ProviderConfig.
+// reference a misconfigured ProviderConfig. Callers must use this tracker as
+// the managed reconciler's ProviderConfigUsageCleaner.
 func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg ModernManaged) error {
 	//nolint:forcetypeassert // Will always be a PCU.
 	pcu := u.of.DeepCopyObject().(TypedProviderConfigUsage)
@@ -195,36 +226,58 @@ func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg ModernManaged
 		Kind:       gvk.Kind,
 		Name:       mg.GetName(),
 	})
+	meta.AddFinalizer(pcu, ProviderConfigUsageFinalizer)
 
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),
 		AllowUpdateIf(func(current, _ runtime.Object) bool {
 			//nolint:forcetypeassert // Will always be a PCU.
-			return current.(TypedProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference()
+			return current.(TypedProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference() ||
+				!meta.FinalizerExists(current.(TypedProviderConfigUsage), ProviderConfigUsageFinalizer)
 		}),
 	)
 
 	return errors.Wrap(Ignore(IsNotAllowed, err), errApplyPCU)
 }
 
+// Untrack releases the ProviderConfigUsage for the supplied managed resource.
+// It returns an error if the managed resource is not namespaced.
+func (u *ProviderConfigUsageTracker) Untrack(ctx context.Context, mg Managed) error {
+	if _, ok := mg.(ModernManaged); !ok {
+		return errors.Errorf(errFmtPCUNotModern, mg)
+	}
+
+	//nolint:forcetypeassert // Will always be a PCU.
+	pcu := u.of.DeepCopyObject().(TypedProviderConfigUsage)
+	pcu.SetName(string(mg.GetUID()))
+	pcu.SetNamespace(mg.GetNamespace())
+
+	if err := u.client.Get(ctx, client.ObjectKeyFromObject(pcu), pcu); err != nil {
+		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
+	}
+	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).RemoveFinalizer(ctx, pcu), errRemovePCUFinalizer)
+}
+
 // A LegacyProviderConfigUsageTracker tracks usages of a by creating or
 // updating the appropriate LegacyProviderConfigUsage.
 type LegacyProviderConfigUsageTracker struct {
-	c  Applicator
-	of LegacyProviderConfigUsage
+	client client.Client
+	c      Applicator
+	of     LegacyProviderConfigUsage
 }
 
 // NewLegacyProviderConfigUsageTracker tracks usages of a by creating or
 // updating the appropriate LegacyProviderConfigUsage.
 func NewLegacyProviderConfigUsageTracker(c client.Client, of LegacyProviderConfigUsage) *LegacyProviderConfigUsageTracker {
-	return &LegacyProviderConfigUsageTracker{c: NewAPIUpdatingApplicator(c), of: of}
+	return &LegacyProviderConfigUsageTracker{client: c, c: NewAPIUpdatingApplicator(c), of: of}
 }
 
 // Track that the supplied LegacyManaged resource is using the ProviderConfig it
 // references by creating or updating a ProviderConfigUsage. Track should be
 // called _before_ attempting to use the ProviderConfig. This ensures the
 // managed resource's usage is updated if the managed resource is updated to
-// reference a misconfigured ProviderConfig.
+// reference a misconfigured ProviderConfig. Callers must use this tracker as
+// the managed reconciler's ProviderConfigUsageCleaner.
 func (u *LegacyProviderConfigUsageTracker) Track(ctx context.Context, mg LegacyManaged) error {
 	//nolint:forcetypeassert // Will always be a legacy PCU.
 	pcu := u.of.DeepCopyObject().(LegacyProviderConfigUsage)
@@ -245,14 +298,33 @@ func (u *LegacyProviderConfigUsageTracker) Track(ctx context.Context, mg LegacyM
 		Kind:       gvk.Kind,
 		Name:       mg.GetName(),
 	})
+	meta.AddFinalizer(pcu, ProviderConfigUsageFinalizer)
 
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),
 		AllowUpdateIf(func(current, _ runtime.Object) bool {
 			//nolint:forcetypeassert // Will always be a PCU.
-			return current.(LegacyProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference()
+			return current.(LegacyProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference() ||
+				!meta.FinalizerExists(current.(LegacyProviderConfigUsage), ProviderConfigUsageFinalizer)
 		}),
 	)
 
 	return errors.Wrap(Ignore(IsNotAllowed, err), errApplyPCU)
+}
+
+// Untrack releases the ProviderConfigUsage for the supplied managed resource.
+// It returns an error if the managed resource is not cluster scoped.
+func (u *LegacyProviderConfigUsageTracker) Untrack(ctx context.Context, mg Managed) error {
+	if _, ok := mg.(LegacyManaged); !ok {
+		return errors.Errorf(errFmtPCUNotLegacy, mg)
+	}
+
+	//nolint:forcetypeassert // Will always be a legacy PCU.
+	pcu := u.of.DeepCopyObject().(LegacyProviderConfigUsage)
+	pcu.SetName(string(mg.GetUID()))
+
+	if err := u.client.Get(ctx, client.ObjectKeyFromObject(pcu), pcu); err != nil {
+		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
+	}
+	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).RemoveFinalizer(ctx, pcu), errRemovePCUFinalizer)
 }

--- a/pkg/resource/providerconfig.go
+++ b/pkg/resource/providerconfig.go
@@ -42,9 +42,11 @@ const (
 	errMissingPCRefKind      = "managed resource ProviderConfig reference has no Kind"
 	errApplyPCU              = "cannot apply ProviderConfigUsage"
 	errGetPCU                = "cannot get ProviderConfigUsage"
+	errAddPCUFinalizer       = "cannot add ProviderConfigUsage finalizer"
 	errRemovePCUFinalizer    = "cannot remove ProviderConfigUsage finalizer"
-	errFmtPCUNotModern       = "cannot release ProviderConfigUsage: %T is not a namespaced managed resource, so this tracker cannot resolve its usage"
-	errFmtPCUNotLegacy       = "cannot release ProviderConfigUsage: %T is not a cluster-scoped managed resource, so this tracker cannot resolve its usage"
+	// Shared by Protect and Untrack, so the wording names neither.
+	errFmtPCUNotModern = "cannot resolve ProviderConfigUsage: %T is not a namespaced managed resource"
+	errFmtPCUNotLegacy = "cannot resolve ProviderConfigUsage: %T is not a cluster-scoped managed resource"
 )
 
 // ProviderConfigUsageFinalizer keeps a ProviderConfigUsage alive until the
@@ -162,25 +164,70 @@ func (fn ModernTrackerFn) Track(ctx context.Context, mg ModernManaged) error {
 	return fn(ctx, mg)
 }
 
-// A ProviderConfigUsageCleaner releases the ProviderConfigUsage of a managed
-// resource after it no longer needs its ProviderConfig.
+// A ProviderConfigUsageCleaner protects a managed resource's
+// ProviderConfigUsage while the resource still needs its ProviderConfig, and
+// releases it once it doesn't.
+//
+// Both halves belong to the managed reconciler, so the finalizer is written and
+// removed by the same component. A tracker that only creates usages - at a
+// provider's connect site, which may build a fresh one per connection - never
+// needs to know about the finalizer, and cannot get out of step with whatever
+// removes it.
 type ProviderConfigUsageCleaner interface {
+	// Protect the managed resource's ProviderConfigUsage, so the garbage
+	// collector can't take it while the resource still needs its
+	// ProviderConfig.
+	Protect(ctx context.Context, mg Managed) error
+
+	// Untrack releases the managed resource's ProviderConfigUsage.
 	Untrack(ctx context.Context, mg Managed) error
 }
 
-// A ProviderConfigUsageCleanerFn releases a ProviderConfigUsage.
-type ProviderConfigUsageCleanerFn func(ctx context.Context, mg Managed) error
+// ProviderConfigUsageCleanerFns protects and releases ProviderConfigUsages
+// using the supplied functions.
+type ProviderConfigUsageCleanerFns struct {
+	ProtectFn func(ctx context.Context, mg Managed) error
+	UntrackFn func(ctx context.Context, mg Managed) error
+}
+
+// Protect the supplied managed resource's ProviderConfigUsage.
+func (fns ProviderConfigUsageCleanerFns) Protect(ctx context.Context, mg Managed) error {
+	return fns.ProtectFn(ctx, mg)
+}
 
 // Untrack the supplied managed resource.
-func (fn ProviderConfigUsageCleanerFn) Untrack(ctx context.Context, mg Managed) error {
-	return fn(ctx, mg)
+func (fns ProviderConfigUsageCleanerFns) Untrack(ctx context.Context, mg Managed) error {
+	return fns.UntrackFn(ctx, mg)
 }
 
 // NewNopProviderConfigUsageCleaner returns a ProviderConfigUsageCleaner that
 // does nothing. It is intended for managed resources that do not use a
 // ProviderConfigUsage.
 func NewNopProviderConfigUsageCleaner() ProviderConfigUsageCleaner {
-	return ProviderConfigUsageCleanerFn(func(context.Context, Managed) error { return nil })
+	return ProviderConfigUsageCleanerFns{
+		ProtectFn: func(context.Context, Managed) error { return nil },
+		UntrackFn: func(context.Context, Managed) error { return nil },
+	}
+}
+
+// preserveFinalizers copies the current object's finalizers onto the desired
+// one. Apply updates with the desired object, so without this an update - a
+// changed ProviderConfig reference is the only one Track makes - would strip
+// the finalizer the reconciler put there.
+func preserveFinalizers(_ context.Context, current, desired runtime.Object) error {
+	c, ok := current.(metav1.Object)
+	if !ok {
+		return nil
+	}
+
+	d, ok := desired.(metav1.Object)
+	if !ok {
+		return nil
+	}
+
+	d.SetFinalizers(c.GetFinalizers())
+
+	return nil
 }
 
 // A ProviderConfigUsageTracker tracks usages of a ProviderConfig by creating or
@@ -200,8 +247,9 @@ func NewProviderConfigUsageTracker(c client.Client, of TypedProviderConfigUsage)
 // references by creating or updating a ProviderConfigUsage. Track should be
 // called _before_ attempting to use the ProviderConfig. This ensures the
 // managed resource's usage is updated if the managed resource is updated to
-// reference a misconfigured ProviderConfig. Callers must use this tracker as
-// the managed reconciler's ProviderConfigUsageCleaner.
+// reference a misconfigured ProviderConfig. Track doesn't manage the
+// ProviderConfigUsageFinalizer; the managed reconciler does, through Protect
+// and Untrack.
 func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg ModernManaged) error {
 	//nolint:forcetypeassert // Will always be a PCU.
 	pcu := u.of.DeepCopyObject().(TypedProviderConfigUsage)
@@ -226,18 +274,36 @@ func (u *ProviderConfigUsageTracker) Track(ctx context.Context, mg ModernManaged
 		Kind:       gvk.Kind,
 		Name:       mg.GetName(),
 	})
-	meta.AddFinalizer(pcu, ProviderConfigUsageFinalizer)
-
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),
+		preserveFinalizers,
 		AllowUpdateIf(func(current, _ runtime.Object) bool {
 			//nolint:forcetypeassert // Will always be a PCU.
-			return current.(TypedProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference() ||
-				!meta.FinalizerExists(current.(TypedProviderConfigUsage), ProviderConfigUsageFinalizer)
+			return current.(TypedProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference()
 		}),
 	)
 
 	return errors.Wrap(Ignore(IsNotAllowed, err), errApplyPCU)
+}
+
+// Protect the supplied managed resource's ProviderConfigUsage, so the garbage
+// collector can't take it while the resource still needs its ProviderConfig.
+// It returns an error if the managed resource is not namespaced.
+func (u *ProviderConfigUsageTracker) Protect(ctx context.Context, mg Managed) error {
+	if _, ok := mg.(ModernManaged); !ok {
+		return errors.Errorf(errFmtPCUNotModern, mg)
+	}
+
+	//nolint:forcetypeassert // Will always be a PCU.
+	pcu := u.of.DeepCopyObject().(TypedProviderConfigUsage)
+	pcu.SetName(string(mg.GetUID()))
+	pcu.SetNamespace(mg.GetNamespace())
+
+	if err := u.client.Get(ctx, client.ObjectKeyFromObject(pcu), pcu); err != nil {
+		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
+	}
+
+	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).AddFinalizer(ctx, pcu), errAddPCUFinalizer)
 }
 
 // Untrack releases the ProviderConfigUsage for the supplied managed resource.
@@ -276,8 +342,9 @@ func NewLegacyProviderConfigUsageTracker(c client.Client, of LegacyProviderConfi
 // references by creating or updating a ProviderConfigUsage. Track should be
 // called _before_ attempting to use the ProviderConfig. This ensures the
 // managed resource's usage is updated if the managed resource is updated to
-// reference a misconfigured ProviderConfig. Callers must use this tracker as
-// the managed reconciler's ProviderConfigUsageCleaner.
+// reference a misconfigured ProviderConfig. Track doesn't manage the
+// ProviderConfigUsageFinalizer; the managed reconciler does, through Protect
+// and Untrack.
 func (u *LegacyProviderConfigUsageTracker) Track(ctx context.Context, mg LegacyManaged) error {
 	//nolint:forcetypeassert // Will always be a legacy PCU.
 	pcu := u.of.DeepCopyObject().(LegacyProviderConfigUsage)
@@ -298,18 +365,35 @@ func (u *LegacyProviderConfigUsageTracker) Track(ctx context.Context, mg LegacyM
 		Kind:       gvk.Kind,
 		Name:       mg.GetName(),
 	})
-	meta.AddFinalizer(pcu, ProviderConfigUsageFinalizer)
-
 	err := u.c.Apply(ctx, pcu,
 		MustBeControllableBy(mg.GetUID()),
+		preserveFinalizers,
 		AllowUpdateIf(func(current, _ runtime.Object) bool {
 			//nolint:forcetypeassert // Will always be a PCU.
-			return current.(LegacyProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference() ||
-				!meta.FinalizerExists(current.(LegacyProviderConfigUsage), ProviderConfigUsageFinalizer)
+			return current.(LegacyProviderConfigUsage).GetProviderConfigReference() != pcu.GetProviderConfigReference()
 		}),
 	)
 
 	return errors.Wrap(Ignore(IsNotAllowed, err), errApplyPCU)
+}
+
+// Protect the supplied managed resource's ProviderConfigUsage, so the garbage
+// collector can't take it while the resource still needs its ProviderConfig.
+// It returns an error if the managed resource is not cluster scoped.
+func (u *LegacyProviderConfigUsageTracker) Protect(ctx context.Context, mg Managed) error {
+	if _, ok := mg.(LegacyManaged); !ok {
+		return errors.Errorf(errFmtPCUNotLegacy, mg)
+	}
+
+	//nolint:forcetypeassert // Will always be a legacy PCU.
+	pcu := u.of.DeepCopyObject().(LegacyProviderConfigUsage)
+	pcu.SetName(string(mg.GetUID()))
+
+	if err := u.client.Get(ctx, client.ObjectKeyFromObject(pcu), pcu); err != nil {
+		return errors.Wrap(IgnoreNotFound(err), errGetPCU)
+	}
+
+	return errors.Wrap(NewAPIFinalizer(u.client, ProviderConfigUsageFinalizer).AddFinalizer(ctx, pcu), errAddPCUFinalizer)
 }
 
 // Untrack releases the ProviderConfigUsage for the supplied managed resource.

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 )
@@ -283,6 +285,7 @@ func TestTrackLegacy(t *testing.T) {
 								Ref: xpv2.Reference{Name: name},
 							},
 						}
+						current.SetFinalizers([]string{ProviderConfigUsageFinalizer})
 						if err := fn(ctx, current, nil); err != nil {
 							return err
 						}
@@ -304,7 +307,10 @@ func TestTrackLegacy(t *testing.T) {
 		"ApplyError": {
 			reason: "Errors applying the ProviderConfigUsage should be returned",
 			fields: fields{
-				c: ApplyFn(func(_ context.Context, _ client.Object, _ ...ApplyOption) error {
+				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
+					if !meta.FinalizerExists(o.(LegacyProviderConfigUsage), ProviderConfigUsageFinalizer) {
+						t.Error("ProviderConfigUsage finalizer was not added")
+					}
 					return errBoom
 				}),
 				of: &fake.LegacyProviderConfigUsage{},
@@ -378,6 +384,7 @@ func TestTrackModern(t *testing.T) {
 								Ref: xpv2.ProviderConfigReference{Name: name, Kind: "ProviderConfig"},
 							},
 						}
+						current.SetFinalizers([]string{ProviderConfigUsageFinalizer})
 						if err := fn(ctx, current, nil); err != nil {
 							return err
 						}
@@ -399,7 +406,10 @@ func TestTrackModern(t *testing.T) {
 		"ApplyError": {
 			reason: "Errors applying the ProviderConfigUsage should be returned",
 			fields: fields{
-				c: ApplyFn(func(_ context.Context, _ client.Object, _ ...ApplyOption) error {
+				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
+					if !meta.FinalizerExists(o.(TypedProviderConfigUsage), ProviderConfigUsageFinalizer) {
+						t.Error("ProviderConfigUsage finalizer was not added")
+					}
 					return errBoom
 				}),
 				of: &fake.ProviderConfigUsage{},
@@ -422,6 +432,104 @@ func TestTrackModern(t *testing.T) {
 			got := ut.Track(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nut.Track(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestUntrack(t *testing.T) {
+	uid := types.UID("some-uid")
+	namespace := "some-namespace"
+
+	for name, tc := range map[string]struct {
+		reason  string
+		cleaner func(client.Client) ProviderConfigUsageCleaner
+		mg      func() Managed
+		wantNS  string
+	}{
+		"Legacy": {
+			reason: "The cluster-scoped tracker must look its usage up by the managed resource UID without a namespace.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewLegacyProviderConfigUsageTracker(c, &fake.LegacyProviderConfigUsage{})
+			},
+			// The namespace of a cluster-scoped managed resource is ignored.
+			mg: func() Managed { return &fake.LegacyManaged{} },
+		},
+		"Modern": {
+			reason: "The namespaced tracker must look its usage up by the managed resource UID in its namespace.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewProviderConfigUsageTracker(c, &fake.ProviderConfigUsage{})
+			},
+			mg:     func() Managed { return &fake.ModernManaged{} },
+			wantNS: namespace,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := test.NewMockClient()
+			c.MockGet = func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+				if diff := cmp.Diff(client.ObjectKey{Name: string(uid), Namespace: tc.wantNS}, key); diff != "" {
+					t.Errorf("%s\nUntrack lookup: -want, +got:\n%s", tc.reason, diff)
+				}
+				obj.SetFinalizers([]string{ProviderConfigUsageFinalizer})
+				return nil
+			}
+			c.MockUpdate = test.NewMockUpdateFn(nil, func(obj client.Object) error {
+				if meta.FinalizerExists(obj.(ProviderConfigUsage), ProviderConfigUsageFinalizer) {
+					t.Errorf("%s\nProviderConfigUsage finalizer was not removed", tc.reason)
+				}
+				return nil
+			})
+
+			mg := tc.mg()
+			mg.SetUID(uid)
+			mg.SetNamespace(namespace)
+			if err := tc.cleaner(c).Untrack(context.Background(), mg); err != nil {
+				t.Fatalf("%s\nUntrack returned an unexpected error: %v", tc.reason, err)
+			}
+		})
+	}
+}
+
+// TestUntrackRejectsMismatchedScope ensures a tracker does not silently look for
+// a usage in the wrong scope.
+func TestUntrackRejectsMismatchedScope(t *testing.T) {
+	uid := types.UID("some-uid")
+
+	for name, tc := range map[string]struct {
+		reason  string
+		cleaner func(client.Client) ProviderConfigUsageCleaner
+		mg      func() Managed
+	}{
+		"ModernTrackerGivenLegacyManaged": {
+			reason: "The namespaced tracker cannot resolve a cluster-scoped managed resource's usage, so it must report an error.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewProviderConfigUsageTracker(c, &fake.ProviderConfigUsage{})
+			},
+			mg: func() Managed { return &fake.LegacyManaged{} },
+		},
+		"LegacyTrackerGivenModernManaged": {
+			reason: "The cluster-scoped tracker cannot resolve a namespaced managed resource's usage, so it must report an error.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewLegacyProviderConfigUsageTracker(c, &fake.LegacyProviderConfigUsage{})
+			},
+			mg: func() Managed { return &fake.ModernManaged{} },
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := test.NewMockClient()
+			c.MockGet = func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+				t.Errorf("%s\nUntrack looked a ProviderConfigUsage up despite the scope mismatch", tc.reason)
+				return nil
+			}
+			c.MockUpdate = test.NewMockUpdateFn(nil, func(_ client.Object) error {
+				t.Errorf("%s\nUntrack updated a ProviderConfigUsage despite the scope mismatch", tc.reason)
+				return nil
+			})
+
+			mg := tc.mg()
+			mg.SetUID(uid)
+			if err := tc.cleaner(c).Untrack(context.Background(), mg); err == nil {
+				t.Errorf("%s\nUntrack(...): want an error, got nil", tc.reason)
 			}
 		})
 	}

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -480,10 +481,12 @@ func TestProtect(t *testing.T) {
 	namespace := "some-namespace"
 
 	for name, tc := range map[string]struct {
-		reason  string
-		cleaner func(client.Client) ProviderConfigUsageCleaner
-		mg      func() Managed
-		wantNS  string
+		reason     string
+		cleaner    func(client.Client) ProviderConfigUsageCleaner
+		mg         func() Managed
+		wantNS     string
+		deleting   bool
+		wantUpdate bool
 	}{
 		"Legacy": {
 			reason: "The cluster-scoped tracker must protect the usage named for the managed resource UID.",
@@ -491,24 +494,47 @@ func TestProtect(t *testing.T) {
 				return NewLegacyProviderConfigUsageTracker(c, &fake.LegacyProviderConfigUsage{})
 			},
 			// The namespace of a cluster-scoped managed resource is ignored.
-			mg: func() Managed { return &fake.LegacyManaged{} },
+			mg:         func() Managed { return &fake.LegacyManaged{} },
+			wantUpdate: true,
 		},
 		"Modern": {
 			reason: "The namespaced tracker must protect the usage named for the managed resource UID in its namespace.",
 			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
 				return NewProviderConfigUsageTracker(c, &fake.ProviderConfigUsage{})
 			},
-			mg:     func() Managed { return &fake.ModernManaged{} },
-			wantNS: namespace,
+			mg:         func() Managed { return &fake.ModernManaged{} },
+			wantNS:     namespace,
+			wantUpdate: true,
+		},
+		"LegacyUsageBeingDeleted": {
+			reason: "The API server refuses finalizers on a terminating object, so a cluster-scoped usage that is being deleted must be left alone without error.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewLegacyProviderConfigUsageTracker(c, &fake.LegacyProviderConfigUsage{})
+			},
+			mg:       func() Managed { return &fake.LegacyManaged{} },
+			deleting: true,
+		},
+		"ModernUsageBeingDeleted": {
+			reason: "The API server refuses finalizers on a terminating object, so a namespaced usage that is being deleted must be left alone without error.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewProviderConfigUsageTracker(c, &fake.ProviderConfigUsage{})
+			},
+			mg:       func() Managed { return &fake.ModernManaged{} },
+			wantNS:   namespace,
+			deleting: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			updated := false
 
 			c := test.NewMockClient()
-			c.MockGet = func(_ context.Context, key client.ObjectKey, _ client.Object) error {
+			c.MockGet = func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 				if diff := cmp.Diff(client.ObjectKey{Name: string(uid), Namespace: tc.wantNS}, key); diff != "" {
 					t.Errorf("%s\nProtect lookup: -want, +got:\n%s", tc.reason, diff)
+				}
+				if tc.deleting {
+					now := metav1.Now()
+					obj.SetDeletionTimestamp(&now)
 				}
 				return nil
 			}
@@ -527,8 +553,8 @@ func TestProtect(t *testing.T) {
 				t.Fatalf("%s\nProtect returned an unexpected error: %v", tc.reason, err)
 			}
 
-			if !updated {
-				t.Errorf("%s\nProtect did not write the usage finalizer", tc.reason)
+			if diff := cmp.Diff(tc.wantUpdate, updated); diff != "" {
+				t.Errorf("%s\nProtect wrote the usage: -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/resource/providerconfig_test.go
+++ b/pkg/resource/providerconfig_test.go
@@ -307,10 +307,7 @@ func TestTrackLegacy(t *testing.T) {
 		"ApplyError": {
 			reason: "Errors applying the ProviderConfigUsage should be returned",
 			fields: fields{
-				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
-					if !meta.FinalizerExists(o.(LegacyProviderConfigUsage), ProviderConfigUsageFinalizer) {
-						t.Error("ProviderConfigUsage finalizer was not added")
-					}
+				c: ApplyFn(func(_ context.Context, _ client.Object, _ ...ApplyOption) error {
 					return errBoom
 				}),
 				of: &fake.LegacyProviderConfigUsage{},
@@ -323,6 +320,26 @@ func TestTrackLegacy(t *testing.T) {
 				},
 			},
 			want: errors.Wrap(errBoom, errApplyPCU),
+		},
+		"NeverAddsFinalizer": {
+			reason: "Track must not write the usage finalizer. The managed reconciler owns it, so a tracker built at a provider's connect site can't get out of step with whatever removes it.",
+			fields: fields{
+				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
+					if meta.FinalizerExists(o.(LegacyProviderConfigUsage), ProviderConfigUsageFinalizer) {
+						t.Error("ProviderConfigUsage finalizer was added by Track")
+					}
+					return nil
+				}),
+				of: &fake.LegacyProviderConfigUsage{},
+			},
+			args: args{
+				mg: &fake.LegacyManaged{
+					LegacyProviderConfigReferencer: fake.LegacyProviderConfigReferencer{
+						Ref: &xpv2.Reference{Name: name},
+					},
+				},
+			},
+			want: nil,
 		},
 	}
 
@@ -406,10 +423,7 @@ func TestTrackModern(t *testing.T) {
 		"ApplyError": {
 			reason: "Errors applying the ProviderConfigUsage should be returned",
 			fields: fields{
-				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
-					if !meta.FinalizerExists(o.(TypedProviderConfigUsage), ProviderConfigUsageFinalizer) {
-						t.Error("ProviderConfigUsage finalizer was not added")
-					}
+				c: ApplyFn(func(_ context.Context, _ client.Object, _ ...ApplyOption) error {
 					return errBoom
 				}),
 				of: &fake.ProviderConfigUsage{},
@@ -423,6 +437,26 @@ func TestTrackModern(t *testing.T) {
 			},
 			want: errors.Wrap(errBoom, errApplyPCU),
 		},
+		"NeverAddsFinalizer": {
+			reason: "Track must not write the usage finalizer. The managed reconciler owns it, so a tracker built at a provider's connect site can't get out of step with whatever removes it.",
+			fields: fields{
+				c: ApplyFn(func(_ context.Context, o client.Object, _ ...ApplyOption) error {
+					if meta.FinalizerExists(o.(TypedProviderConfigUsage), ProviderConfigUsageFinalizer) {
+						t.Error("ProviderConfigUsage finalizer was added by Track")
+					}
+					return nil
+				}),
+				of: &fake.ProviderConfigUsage{},
+			},
+			args: args{
+				mg: &fake.ModernManaged{
+					TypedProviderConfigReferencer: fake.TypedProviderConfigReferencer{
+						Ref: &xpv2.ProviderConfigReference{Name: name, Kind: "ProviderConfig"},
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for name, tc := range cases {
@@ -432,6 +466,69 @@ func TestTrackModern(t *testing.T) {
 			got := ut.Track(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nut.Track(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// TestProtect ensures a cleaner adds the usage finalizer to the usage belonging
+// to a managed resource. The cleaner here is built independently of any tracker
+// that called Track, which is the point: the managed reconciler owns the
+// finalizer, so a provider is free to build a fresh tracker per connection.
+func TestProtect(t *testing.T) {
+	uid := types.UID("some-uid")
+	namespace := "some-namespace"
+
+	for name, tc := range map[string]struct {
+		reason  string
+		cleaner func(client.Client) ProviderConfigUsageCleaner
+		mg      func() Managed
+		wantNS  string
+	}{
+		"Legacy": {
+			reason: "The cluster-scoped tracker must protect the usage named for the managed resource UID.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewLegacyProviderConfigUsageTracker(c, &fake.LegacyProviderConfigUsage{})
+			},
+			// The namespace of a cluster-scoped managed resource is ignored.
+			mg: func() Managed { return &fake.LegacyManaged{} },
+		},
+		"Modern": {
+			reason: "The namespaced tracker must protect the usage named for the managed resource UID in its namespace.",
+			cleaner: func(c client.Client) ProviderConfigUsageCleaner {
+				return NewProviderConfigUsageTracker(c, &fake.ProviderConfigUsage{})
+			},
+			mg:     func() Managed { return &fake.ModernManaged{} },
+			wantNS: namespace,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			updated := false
+
+			c := test.NewMockClient()
+			c.MockGet = func(_ context.Context, key client.ObjectKey, _ client.Object) error {
+				if diff := cmp.Diff(client.ObjectKey{Name: string(uid), Namespace: tc.wantNS}, key); diff != "" {
+					t.Errorf("%s\nProtect lookup: -want, +got:\n%s", tc.reason, diff)
+				}
+				return nil
+			}
+			c.MockUpdate = test.NewMockUpdateFn(nil, func(obj client.Object) error {
+				updated = true
+				if !meta.FinalizerExists(obj.(ProviderConfigUsage), ProviderConfigUsageFinalizer) {
+					t.Errorf("%s\nProviderConfigUsage finalizer was not added", tc.reason)
+				}
+				return nil
+			})
+
+			mg := tc.mg()
+			mg.SetUID(uid)
+			mg.SetNamespace(namespace)
+			if err := tc.cleaner(c).Protect(context.Background(), mg); err != nil {
+				t.Fatalf("%s\nProtect returned an unexpected error: %v", tc.reason, err)
+			}
+
+			if !updated {
+				t.Errorf("%s\nProtect did not write the usage finalizer", tc.reason)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

This PR prevents a `ProviderConfig` from being deleted while a managed resource
that uses it is still terminating.

It:

- Adds `finalizer.providerconfigusage.crossplane.io` to a `ProviderConfigUsage`
  and makes the managed reconciler the owner of both ends of that finalizer:
  `Protect` adds it right after a successful `Connect`, `Untrack` removes it
  after the managed resource has removed its own finalizer, on both the Delete
  and the Orphan/no-Delete paths. `Track` never touches the finalizer and
  preserves existing finalizers when it updates the usage.
- Exposes this through a new `ProviderConfigUsageCleaner` interface
  (`Protect`/`Untrack`), implemented by both existing trackers, and turns it
  on by default. The managed reconciler derives its cleaner from the managed
  resource's scope and the single `ProviderConfigUsage` kind of that scope
  registered with the manager's scheme, which is the kind the provider's
  connector records usages with. `managed.WithProviderConfigUsageCleaner`
  overrides the default, for schemes that register no or several usage kinds
  of a scope, and passing `NewNopProviderConfigUsageCleaner()` turns
  protection off. `NewReconciler`'s signature is unchanged.
- Skips adding the usage finalizer when the usage is already being deleted,
  since the API server rejects new finalizers on a terminating object. The
  usage is recreated and protected on the next reconcile once it is gone.
- Teaches the `ProviderConfig` reconciler to release a terminating, finalized
  usage whose owner is gone, was replaced, or has itself finished teardown
  (deleting, with no finalizers other than the garbage collector's), reading the
  owner through an uncached API reader. It also strips the finalizer before
  deleting a usage that has no owner reference.
- Changes the delayed-delete gate from #855 to count only non-GC finalizers
  (`meta.NonGCFinalizers`), so `foregroundDeletion` and `orphan` no longer
  hold back external deletion. Without this the usage finalizer deadlocks
  foreground deletion.
- Emits warning events when protecting or releasing a usage fails.

## Why is this needed?

During foreground deletion, a `ProviderConfigUsage` can be garbage-collected
before its managed resource finishes deleting its external resource. The
`ProviderConfig` controller then observes no remaining usages and removes its
`in-use.crossplane.io` finalizer. The managed resource's next reconciliation
fails because its `ProviderConfig` has already disappeared, leaving the resource
stuck in deletion.

The gate change is needed independently: any controller that adds its own
finalizer to a `ProviderConfigUsage` deadlocks foreground deletion on the
current gate.

## Provider integration

None required. A provider gets ProviderConfig deletion protection by upgrading
crossplane-runtime: the reconciler finds the provider's usage kind in the
manager's scheme, so no code change or option is needed, including for upjet
family providers that register both a cluster-scoped and a namespaced usage
kind. `managed.WithProviderConfigUsageCleaner(tracker)` is available to
override the choice, where `tracker` is a `ProviderConfigUsageTracker` or
`LegacyProviderConfigUsageTracker` built with the same client and usage type
the connector uses, and `WithProviderConfigUsageCleaner(NewNopProviderConfigUsageCleaner())`
turns protection off.

## Testing

Tested with locally built `provider-kubernetes` and `provider-aws-iam` (with
`provider-aws-config`) on kind: foreground and background cascades of
cluster-scoped and namespaced managed resources with the `ProviderConfig`
deleted concurrently, composed claims with both `compositeDeletePolicy` values,
a paused managed resource, migration of usages created without the finalizer,
and namespace deletion. Both providers were also built from their upstream
trees with only the runtime replaced, to confirm the default applies without
any provider change.

Design: crossplane/crossplane#7594
Fixes: https://github.com/crossplane/crossplane/issues/4661

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
