### PR TITLE
fix(ci): clean /homeless-shelter before Renovate's Nix commands

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -34,7 +34,8 @@ build-users-group =
 # One build at a time, so no build starts before we can clean up /homeless-shelter.
 max-jobs = 1
 
-# Removes /homeless-shelter after each build (see the hook script above).
+# Removes /homeless-shelter after each successful build. The crossplane-nix launcher covers any
+# failed builds this misses.
 post-build-hook = /usr/local/bin/nix-clean-homeless-shelter
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
@@ -48,6 +49,8 @@ EOF
 # and the config it reads.
 cat > /usr/local/bin/crossplane-nix << 'EOF'
 #!/bin/bash
+# ensure any leftover /homeless-shelter from a failed build is cleaned up before we start
+/usr/local/bin/nix-clean-homeless-shelter
 exec env NIX_CONF_DIR=/etc/nix /usr/bin/nix "$@"
 EOF
 chmod +x /usr/local/bin/crossplane-nix


### PR DESCRIPTION
### Description of your changes

I noticed in https://github.com/crossplane/crossplane-runtime/pull/1101#issuecomment-5173684794 that Renovate is still sometimes hitting the nix /homeless-shelter purity check error. Overall, our cleanup has been working well for builds that succeed, but if a build hits its own unrelated error then we are not able to clean up with just the post-build hook.

Nix runs the post-build hook only after a build succeeds, so a failed build leaves /homeless-shelter behind and every Nix command after it fails the purity check instead of doing its work.

This commit has the crossplane-nix launcher clean the directory on the way in as well. We keep the post-build hook because it cleans up between builds within a single Nix invocation, which the launcher that only runs once before the Nix invocation can't do.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
