### PR TITLE
Skip Update and LateInitialize for non-existent external resources

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1476,14 +1476,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
 	}
 
-	if !observation.ResourceExists {
-		// There is no need to late initialize or update a resource that doesn't exist yet.
-		reconcileAfter := r.pollIntervalHook(managed, r.effectivePollInterval(managed))
-		log.Debug("Resource does not exist so skip late initialize and update", "requeue-after", time.Now().Add(reconcileAfter))
-		status.MarkConditions(xpv2.ReconcileSuccess())
-
-		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
-	}
 	if observation.ResourceLateInitialized && policy.ShouldLateInitialize() {
 		// Note that this update may reset any pending updates to the status of
 		// the managed resource from when it was observed above. This is because
@@ -1518,6 +1510,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		// because all the cases above could contribute (for different reasons)
 		// that the external object would not have been updated.
 		r.metricRecorder.recordUnchanged(managed.GetName())
+
+		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+	}
+
+	if !observation.ResourceExists {
+		// There is no need to update a resource that doesn't exist yet.
+		reconcileAfter := r.pollIntervalHook(managed, r.effectivePollInterval(managed))
+		log.Debug("Resource does not exist so skip update", "requeue-after", time.Now().Add(reconcileAfter))
+		status.MarkConditions(xpv2.ReconcileSuccess())
 
 		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
 	}

--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -1476,6 +1476,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		return reconcile.Result{Requeue: true}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
 	}
 
+	if !observation.ResourceExists {
+		// There is no need to late initialize or update a resource that doesn't exist yet.
+		reconcileAfter := r.pollIntervalHook(managed, r.effectivePollInterval(managed))
+		log.Debug("Resource does not exist so skip late initialize and update", "requeue-after", time.Now().Add(reconcileAfter))
+		status.MarkConditions(xpv2.ReconcileSuccess())
+
+		return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(updateStatus(), errUpdateManagedStatus)
+	}
 	if observation.ResourceLateInitialized && policy.ShouldLateInitialize() {
 		// Note that this update may reset any pending updates to the status of
 		// the managed resource from when it was observed above. This is because

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -1819,7 +1819,7 @@ func TestReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ObserveUpdateResourceDoesNotExist": {
-			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update or LateInitialze external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
+			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{

--- a/pkg/reconciler/managed/reconciler_legacy_test.go
+++ b/pkg/reconciler/managed/reconciler_legacy_test.go
@@ -1818,6 +1818,59 @@ func TestReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
+		"ObserveUpdateResourceDoesNotExist": {
+			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update or LateInitialze external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asLegacyManaged(obj, 42)
+							mg.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate})
+
+							return nil
+						}),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newLegacyManaged(42)
+							want.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate})
+							want.SetConditions(xpv2.ReconcileSuccess().WithObservedGeneration(42))
+
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "Resource does not exist should be reported as a conditioned status when only Observe and Update actions are allowed."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
+					Scheme: fake.SchemeWith(&fake.LegacyManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.LegacyManaged{})),
+				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
+								// Update should not be called in this scenario
+								return ExternalUpdate{}, errBoom
+							},
+							DisconnectFn: func(_ context.Context) error {
+								return nil
+							},
+						}
+
+						return c, nil
+					})),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: 10 * time.Minute}},
+		},
 		"ManagementPolicyAllCreateSuccessful": {
 			reason: "Successful managed resource creation using management policy all should trigger a requeue after a short wait.",
 			args: args{

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -1825,7 +1825,7 @@ func TestModernReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
 		"ObserveUpdateResourceDoesNotExist": {
-			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update or LateInitialze external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
+			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
 			args: args{
 				m: &fake.Manager{
 					Client: &test.MockClient{

--- a/pkg/reconciler/managed/reconciler_modern_test.go
+++ b/pkg/reconciler/managed/reconciler_modern_test.go
@@ -1824,6 +1824,59 @@ func TestModernReconciler(t *testing.T) {
 			},
 			want: want{result: reconcile.Result{RequeueAfter: defaultPollInterval}},
 		},
+		"ObserveUpdateResourceDoesNotExist": {
+			reason: "With only Observe and Update management actions, observing a resource that does not exist should not call the Update or LateInitialze external functions and should be reported as a conditioned status and requeued after the poll interval, not via the error rate limiter.",
+			args: args{
+				m: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							mg := asModernManaged(obj, 42)
+							mg.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate})
+
+							return nil
+						}),
+						MockStatusUpdate: test.MockSubResourceUpdateFn(func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							want := newModernManaged(42)
+							want.SetManagementPolicies(xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate})
+							want.SetConditions(xpv2.ReconcileSuccess().WithObservedGeneration(42))
+
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								reason := "Resource does not exist should be reported as a conditioned status when only Observe and Update actions are allowed."
+								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
+							}
+
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
+					Scheme: fake.SchemeWith(&fake.ModernManaged{}),
+				},
+				mg: resource.ManagedKind(fake.GVK(&fake.ModernManaged{})),
+				o: []ReconcilerOption{
+					WithPollInterval(10 * time.Minute),
+					WithInitializers(),
+					WithManagementPolicies(),
+					WithExternalConnector(ExternalConnectorFn(func(_ context.Context, _ resource.Managed) (ExternalClient, error) {
+						c := &ExternalClientFns{
+							ObserveFn: func(_ context.Context, _ resource.Managed) (ExternalObservation, error) {
+								return ExternalObservation{ResourceExists: false}, nil
+							},
+							UpdateFn: func(_ context.Context, _ resource.Managed) (ExternalUpdate, error) {
+								// Update should not be called in this scenario
+								return ExternalUpdate{}, errBoom
+							},
+							DisconnectFn: func(_ context.Context) error {
+								return nil
+							},
+						}
+
+						return c, nil
+					})),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil }}),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: 10 * time.Minute}},
+		},
 		"ManagementPolicyAllCreateSuccessful": {
 			reason: "Successful managed resource creation using management policy all should trigger a requeue after a short wait.",
 			args: args{


### PR DESCRIPTION
### Description of your changes

Check for non-existent external resources before calling LateInitialize or Update in the managed reconciler.

Fixes #1129  

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
