### PR TITLE
chore: remove release-2.1 from Renovate baseBranches

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -20,7 +20,6 @@
   baseBranches: [
     'main',
     'release-1.20',
-    'release-2.1',
     'release-2.2',
     'release-2.3',
     'release-2.4',


### PR DESCRIPTION
### Description of your changes

From https://github.com/crossplane/release/issues/95:

> Update the baseBranches list in .github/renovate-base.json5 on main, removing the now old unsupported release.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
